### PR TITLE
Fix: strip diacritics in step 3 CSV filter

### DIFF
--- a/scripts/filter_csv.py
+++ b/scripts/filter_csv.py
@@ -13,6 +13,7 @@ Usage:
 import csv
 import logging
 import sys
+import unicodedata
 from pathlib import Path
 
 logging.basicConfig(
@@ -34,8 +35,13 @@ RELEASE_ID_FILES = [
 
 
 def normalize_artist(name: str) -> str:
-    """Normalize artist name for matching."""
-    return name.lower().strip()
+    """Normalize artist name for matching.
+
+    Strips diacritics so that Discogs "Björk" matches library "Bjork".
+    """
+    nfkd = unicodedata.normalize("NFKD", name)
+    stripped = "".join(c for c in nfkd if not unicodedata.combining(c))
+    return stripped.lower().strip()
 
 
 def load_library_artists(path: Path) -> set[str]:

--- a/tests/unit/test_filter_csv.py
+++ b/tests/unit/test_filter_csv.py
@@ -40,8 +40,26 @@ class TestNormalizeArtist:
             ("RADIOHEAD", "radiohead"),
             ("  Mixed Case  ", "mixed case"),
             ("", ""),
+            ("Björk", "bjork"),
+            ("Sigur Rós", "sigur ros"),
+            ("Motörhead", "motorhead"),
+            ("Hüsker Dü", "husker du"),
+            ("Café Tacvba", "cafe tacvba"),
+            ("Zoé", "zoe"),
         ],
-        ids=["lowercase", "strip-spaces", "all-caps", "mixed-case-strip", "empty"],
+        ids=[
+            "lowercase",
+            "strip-spaces",
+            "all-caps",
+            "mixed-case-strip",
+            "empty",
+            "bjork",
+            "sigur-ros",
+            "motorhead",
+            "husker-du",
+            "cafe-tacvba",
+            "zoe",
+        ],
     )
     def test_normalize(self, raw: str, expected: str) -> None:
         assert normalize_artist(raw) == expected


### PR DESCRIPTION
## Summary
- The library stores ASCII artist names ("Bjork") but Discogs uses diacritics ("Björk")
- Step 3's `normalize_artist()` only did `.lower().strip()`, so `"björk" != "bjork"` and all releases for those artists were silently excluded from the cache
- Now uses `unicodedata.normalize('NFKD')` to strip diacritics before comparing, matching the approach already used in step 8's `verify_cache.py`

## Test plan
- [x] Existing `TestNormalizeArtist` cases still pass
- [x] New parametrized cases for Bjork, Sigur Ros, Motorhead, Husker Du, Cafe Tacvba, Zoe
- [x] Full `test_filter_csv.py` suite passes (28 tests)
- [ ] Next pipeline run should pick up previously-missed diacritics artists