### PR TITLE
Remove UNIQUE constraints that cause btree overflow

### DIFF
--- a/schema/create_database.sql
+++ b/schema/create_database.sql
@@ -30,8 +30,7 @@ CREATE TABLE IF NOT EXISTS release (
 CREATE TABLE IF NOT EXISTS release_artist (
     release_id      integer NOT NULL REFERENCES release(id) ON DELETE CASCADE,
     artist_name     text NOT NULL,
-    extra           integer DEFAULT 0, -- 0 = main artist, 1 = extra credit
-    UNIQUE (release_id, artist_name)
+    extra           integer DEFAULT 0  -- 0 = main artist, 1 = extra credit
 );
 
 -- Tracks on releases
@@ -47,8 +46,7 @@ CREATE TABLE IF NOT EXISTS release_track (
 CREATE TABLE IF NOT EXISTS release_track_artist (
     release_id      integer NOT NULL REFERENCES release(id) ON DELETE CASCADE,
     track_sequence  integer NOT NULL,
-    artist_name     text NOT NULL,
-    UNIQUE (release_id, track_sequence, artist_name)
+    artist_name     text NOT NULL
 );
 
 -- ============================================


### PR DESCRIPTION
## Summary
- Remove `UNIQUE (release_id, artist_name)` from `release_artist` and `UNIQUE (release_id, track_sequence, artist_name)` from `release_track_artist` in `create_database.sql`
- These constraints cause btree index overflow when `artist_name` exceeds ~900 bytes (PostgreSQL's 2,704-byte page limit)
- The constraints are redundant: `import_csv.py` deduplicates rows via `unique_key` before COPY, and `dedup_releases.py` drops them during copy-swap anyway

## Test plan
- [x] Unit tests pass (190/190)
- [ ] Integration tests pass (`pytest -m postgres`) -- added `test_no_unique_constraints_on_child_tables` to verify constraints are absent
- [ ] Re-run ETL import with previously-failing data (long artist names)