### PR TITLE
Add release_label table to ETL pipeline

### DIFF
--- a/schema/create_database.sql
+++ b/schema/create_database.sql
@@ -36,6 +36,12 @@ CREATE TABLE IF NOT EXISTS release_artist (
     extra           integer DEFAULT 0  -- 0 = main artist, 1 = extra credit
 );
 
+-- Labels on releases
+CREATE TABLE IF NOT EXISTS release_label (
+    release_id      integer NOT NULL REFERENCES release(id) ON DELETE CASCADE,
+    label_name      text NOT NULL
+);
+
 -- Tracks on releases
 CREATE TABLE IF NOT EXISTS release_track (
     release_id      integer NOT NULL REFERENCES release(id) ON DELETE CASCADE,
@@ -69,6 +75,7 @@ CREATE TABLE IF NOT EXISTS cache_metadata (
 
 -- Foreign key indexes
 CREATE INDEX IF NOT EXISTS idx_release_artist_release_id ON release_artist(release_id);
+CREATE INDEX IF NOT EXISTS idx_release_label_release_id ON release_label(release_id);
 CREATE INDEX IF NOT EXISTS idx_release_track_release_id ON release_track(release_id);
 CREATE INDEX IF NOT EXISTS idx_release_track_artist_release_id ON release_track_artist(release_id);
 

--- a/scripts/filter_csv.py
+++ b/scripts/filter_csv.py
@@ -24,10 +24,11 @@ logger = logging.getLogger(__name__)
 
 # CSV files that need to be filtered by release_id.
 # Only includes files needed by the optimized schema (see 04-create-database.sql).
-# Dropped tables (release_label, release_genre, release_style) are excluded.
+# Dropped tables (release_genre, release_style) are excluded.
 RELEASE_ID_FILES = [
     "release.csv",
     "release_artist.csv",
+    "release_label.csv",
     "release_track.csv",
     "release_track_artist.csv",
     "release_image.csv",  # for artwork_url extraction during import

--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -233,6 +233,7 @@ def run_vacuum(db_url: str) -> None:
     tables = [
         "release",
         "release_artist",
+        "release_label",
         "release_track",
         "release_track_artist",
         "cache_metadata",
@@ -260,8 +261,8 @@ def report_sizes(db_url: str) -> None:
                    pg_size_pretty(pg_total_relation_size(relid)) as total_size
             FROM pg_stat_user_tables
             WHERE relname IN (
-                'release', 'release_artist', 'release_track',
-                'release_track_artist', 'cache_metadata'
+                'release', 'release_artist', 'release_label',
+                'release_track', 'release_track_artist', 'cache_metadata'
             )
             ORDER BY pg_total_relation_size(relid) DESC
         """)

--- a/tests/e2e/test_pipeline.py
+++ b/tests/e2e/test_pipeline.py
@@ -110,7 +110,13 @@ class TestPipeline:
         compilation releases, which may be pruned depending on matching.
         """
         conn = self._connect()
-        for table in ("release", "release_artist", "release_track", "cache_metadata"):
+        for table in (
+            "release",
+            "release_artist",
+            "release_label",
+            "release_track",
+            "cache_metadata",
+        ):
             with conn.cursor() as cur:
                 cur.execute(f"SELECT count(*) FROM {table}")
                 count = cur.fetchone()[0]
@@ -195,7 +201,13 @@ class TestPipeline:
             """)
             fk_tables = {row[0] for row in cur.fetchall()}
         conn.close()
-        expected = {"release_artist", "release_track", "release_track_artist", "cache_metadata"}
+        expected = {
+            "release_artist",
+            "release_label",
+            "release_track",
+            "release_track_artist",
+            "cache_metadata",
+        }
         assert expected.issubset(fk_tables)
 
     def test_null_title_release_not_imported(self) -> None:
@@ -379,7 +391,13 @@ class TestPipelineWithCopyTo:
     def test_target_tables_populated(self) -> None:
         """Core tables in target have rows."""
         conn = psycopg.connect(self.target_url)
-        for table in ("release", "release_artist", "release_track", "cache_metadata"):
+        for table in (
+            "release",
+            "release_artist",
+            "release_label",
+            "release_track",
+            "cache_metadata",
+        ):
             with conn.cursor() as cur:
                 cur.execute(f"SELECT count(*) FROM {table}")
                 count = cur.fetchone()[0]

--- a/tests/fixtures/create_fixtures.py
+++ b/tests/fixtures/create_fixtures.py
@@ -184,6 +184,44 @@ def create_release_track_artist_csv() -> None:
     write_csv("release_track_artist.csv", headers, rows)
 
 
+def create_release_label_csv() -> None:
+    """Create release_label.csv with label names for releases.
+
+    Includes:
+    - Multiple labels per release (release 1001 has Parlophone and Capitol Records)
+    - Labels for releases in the same dedup group (1001, 1002, 1003)
+    - Labels for releases that won't match the library (5001, 5002)
+    """
+    headers = ["release_id", "label", "catno"]
+    rows = [
+        # Radiohead - OK Computer (dedup group, master_id 500)
+        [1001, "Parlophone", "7243 8 55229 2 8"],
+        [1001, "Capitol Records", "CDP 7243 8 55229 2 8"],
+        [1002, "Capitol Records", "C1-55229"],
+        [1003, "EMI", "TOCP-50201"],
+        # Joy Division - Unknown Pleasures (dedup group, master_id 600)
+        [2001, "Factory Records", "FACT 10"],
+        [2002, "Qwest Records", "1-25840"],
+        # Unique releases
+        [3001, "Parlophone", "7243 5 27753 2 3"],
+        [4001, "Parlophone", "7243 5 32764 2 8"],
+        # Won't match library
+        [5001, "Unknown Label", "UNK-001"],
+        [5002, "Mystery Records", "MYS-002"],
+        # Bjork
+        [6001, "One Little Indian", "TPLP 71 CD"],
+        # Compilation
+        [8001, "Sugar Hill Records", "SH-542"],
+        # Beatles, Simon & Garfunkel
+        [9001, "Apple Records", "PCS 7088"],
+        [9002, "Columbia", "KCS 9914"],
+        # Not in library
+        [10001, "Random Label", "RL-001"],
+        [10002, "Obscure Label", "OL-002"],
+    ]
+    write_csv("release_label.csv", headers, rows)
+
+
 def create_release_image_csv() -> None:
     """Create release_image.csv for artwork URL testing."""
     headers = ["release_id", "type", "width", "height", "uri"]
@@ -290,6 +328,7 @@ def main() -> None:
     create_release_artist_csv()
     create_release_track_csv()
     create_release_track_artist_csv()
+    create_release_label_csv()
     create_release_image_csv()
     print()
     print("Library data:")

--- a/tests/fixtures/csv/release_label.csv
+++ b/tests/fixtures/csv/release_label.csv
@@ -1,0 +1,17 @@
+release_id,label,catno
+1001,Parlophone,7243 8 55229 2 8
+1001,Capitol Records,CDP 7243 8 55229 2 8
+1002,Capitol Records,C1-55229
+1003,EMI,TOCP-50201
+2001,Factory Records,FACT 10
+2002,Qwest Records,1-25840
+3001,Parlophone,7243 5 27753 2 3
+4001,Parlophone,7243 5 32764 2 8
+5001,Unknown Label,UNK-001
+5002,Mystery Records,MYS-002
+6001,One Little Indian,TPLP 71 CD
+8001,Sugar Hill Records,SH-542
+9001,Apple Records,PCS 7088
+9002,Columbia,KCS 9914
+10001,Random Label,RL-001
+10002,Obscure Label,OL-002

--- a/tests/integration/test_import.py
+++ b/tests/integration/test_import.py
@@ -90,6 +90,27 @@ class TestImportCsv:
         # 16 rows in fixture CSV (all have required fields)
         assert count == 16
 
+    def test_release_label_row_count(self) -> None:
+        """All label rows imported (one per unique release_id+label pair)."""
+        conn = self._connect()
+        with conn.cursor() as cur:
+            cur.execute("SELECT count(*) FROM release_label")
+            count = cur.fetchone()[0]
+        conn.close()
+        # 16 rows in fixture CSV, all unique (release_id, label) pairs
+        assert count == 16
+
+    def test_release_label_column_mapping(self) -> None:
+        """CSV 'label' column maps to DB 'label_name'."""
+        conn = self._connect()
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT label_name FROM release_label WHERE release_id = 1001 ORDER BY label_name"
+            )
+            labels = [row[0] for row in cur.fetchall()]
+        conn.close()
+        assert labels == ["Capitol Records", "Parlophone"]
+
     def test_release_track_row_count(self) -> None:
         conn = self._connect()
         with conn.cursor() as cur:
@@ -210,6 +231,7 @@ ALL_TABLES = (
     "cache_metadata",
     "release_track_artist",
     "release_track",
+    "release_label",
     "release_artist",
     "release",
 )

--- a/tests/integration/test_schema.py
+++ b/tests/integration/test_schema.py
@@ -40,6 +40,7 @@ class TestCreateDatabase:
         expected = {
             "release",
             "release_artist",
+            "release_label",
             "release_track",
             "release_track_artist",
             "cache_metadata",
@@ -59,6 +60,7 @@ class TestCreateDatabase:
         [
             ("release", {"id", "title", "release_year", "artwork_url", "master_id"}),
             ("release_artist", {"release_id", "artist_name", "extra"}),
+            ("release_label", {"release_id", "label_name"}),
             ("release_track", {"release_id", "sequence", "position", "title", "duration"}),
             ("release_track_artist", {"release_id", "track_sequence", "artist_name"}),
             ("cache_metadata", {"release_id", "cached_at", "source", "last_validated"}),
@@ -66,6 +68,7 @@ class TestCreateDatabase:
         ids=[
             "release",
             "release_artist",
+            "release_label",
             "release_track",
             "release_track_artist",
             "cache_metadata",
@@ -127,6 +130,7 @@ class TestCreateDatabase:
         conn.close()
         expected_fk_tables = {
             "release_artist",
+            "release_label",
             "release_track",
             "release_track_artist",
             "cache_metadata",
@@ -145,7 +149,7 @@ class TestCreateDatabase:
                 SELECT tc.table_name, tc.constraint_name
                 FROM information_schema.table_constraints tc
                 WHERE tc.constraint_type = 'UNIQUE'
-                  AND tc.table_name IN ('release_artist', 'release_track_artist')
+                  AND tc.table_name IN ('release_artist', 'release_label', 'release_track_artist')
             """)
             unique_constraints = cur.fetchall()
         conn.close()

--- a/tests/unit/test_import_csv.py
+++ b/tests/unit/test_import_csv.py
@@ -111,7 +111,7 @@ class TestTablesConfig:
 
     @pytest.mark.parametrize(
         "table_name",
-        ["release", "release_artist", "release_track", "release_track_artist"],
+        ["release", "release_artist", "release_label", "release_track", "release_track_artist"],
     )
     def test_table_has_csv_file(self, table_name: str) -> None:
         """Each table config specifies a CSV file."""
@@ -129,7 +129,7 @@ class TestTablesConfig:
 
     def test_tables_with_unique_constraints_have_unique_key(self) -> None:
         """Tables with unique constraints must specify unique_key for dedup during import."""
-        tables_needing_dedup = {"release_artist", "release_track_artist"}
+        tables_needing_dedup = {"release_artist", "release_label", "release_track_artist"}
         for table_config in TABLES:
             if table_config["table"] in tables_needing_dedup:
                 assert "unique_key" in table_config, (
@@ -176,6 +176,20 @@ class TestColumnHeaderDetection:
         for col in ra_config["csv_columns"]:
             assert col in headers, (
                 f"Expected column {col!r} not in release_artist.csv headers: {headers}"
+            )
+
+    def test_release_label_csv_has_expected_columns(self) -> None:
+        import csv as csv_mod
+
+        csv_path = Path(__file__).parent.parent / "fixtures" / "csv" / "release_label.csv"
+        with open(csv_path) as f:
+            reader = csv_mod.DictReader(f)
+            headers = reader.fieldnames
+        assert headers is not None
+        rl_config = next(t for t in TABLES if t["table"] == "release_label")
+        for col in rl_config["csv_columns"]:
+            assert col in headers, (
+                f"Expected column {col!r} not in release_label.csv headers: {headers}"
             )
 
 
@@ -230,9 +244,9 @@ class TestTableSplit:
     def test_tables_is_union(self) -> None:
         assert TABLES == BASE_TABLES + TRACK_TABLES
 
-    def test_base_tables_are_release_and_release_artist(self) -> None:
+    def test_base_tables_names(self) -> None:
         names = [t["table"] for t in BASE_TABLES]
-        assert names == ["release", "release_artist"]
+        assert names == ["release", "release_artist", "release_label"]
 
     def test_track_tables_are_release_track_and_release_track_artist(self) -> None:
         names = [t["table"] for t in TRACK_TABLES]


### PR DESCRIPTION
## Summary

- Add `release_label` (release_id, label_name) as a base table throughout the entire ETL pipeline: schema, CSV filter, import, dedup copy-swap, verify/copy-to, vacuum, and reporting
- Labels follow the same pattern as `release_artist` -- FK CASCADE child table, imported before dedup, copy-swapped during dedup, streamed during copy-to
- CSV column `label` maps to DB column `label_name`; `catno` (catalog number) is dropped as not needed by consumers
- Fix pre-existing bug where `_create_target_indexes()` didn't create track trigram indexes on the copy-to target

## Test plan

- [x] Unit tests: 211 passed
- [x] Integration tests: 104 passed (schema, import, dedup, copy-to)
- [x] E2E tests: 21 passed (full pipeline, copy-to, resume)
- [x] Pre-commit hooks (ruff format + lint) pass