### PR TITLE
perf: filter csv.reader, parallel VACUUM, master_id index, normalize cache

### DIFF
--- a/schema/create_database.sql
+++ b/schema/create_database.sql
@@ -81,6 +81,10 @@ CREATE INDEX IF NOT EXISTS idx_release_label_release_id ON release_label(release
 CREATE INDEX IF NOT EXISTS idx_release_track_release_id ON release_track(release_id);
 CREATE INDEX IF NOT EXISTS idx_release_track_artist_release_id ON release_track_artist(release_id);
 
+-- Partial index on master_id for dedup performance.
+-- Transient: dropped automatically by dedup copy-swap (which excludes master_id).
+CREATE INDEX IF NOT EXISTS idx_release_master_id ON release(master_id) WHERE master_id IS NOT NULL;
+
 -- Cache metadata indexes
 CREATE INDEX IF NOT EXISTS idx_cache_metadata_cached_at ON cache_metadata(cached_at);
 CREATE INDEX IF NOT EXISTS idx_cache_metadata_source ON cache_metadata(source);

--- a/scripts/filter_csv.py
+++ b/scripts/filter_csv.py
@@ -69,6 +69,8 @@ def find_matching_release_ids(release_artist_path: Path, library_artists: set[st
     total_rows = 0
     matched_rows = 0
 
+    normalize_cache: dict[str, str] = {}
+
     with open(release_artist_path, encoding="utf-8", errors="replace") as f:
         reader = csv.reader(f)
         header = next(reader)
@@ -77,9 +79,13 @@ def find_matching_release_ids(release_artist_path: Path, library_artists: set[st
         for row in reader:
             total_rows += 1
             try:
-                artist_name = normalize_artist(row[artist_name_idx])
+                raw_name = row[artist_name_idx]
             except IndexError:
                 continue
+            artist_name = normalize_cache.get(raw_name)
+            if artist_name is None:
+                artist_name = normalize_artist(raw_name)
+                normalize_cache[raw_name] = artist_name
             if artist_name in library_artists:
                 release_id = int(row[release_id_idx])
                 matching_ids.add(release_id)
@@ -107,28 +113,37 @@ def get_release_id_column(filename: str) -> str:
 def filter_csv_file(
     input_path: Path, output_path: Path, matching_ids: set[int], id_column: str
 ) -> tuple[int, int]:
-    """Filter a CSV file to only include rows with matching release IDs."""
+    """Filter a CSV file to only include rows with matching release IDs.
+
+    Uses csv.reader with positional indexing instead of csv.DictReader
+    to avoid dict creation overhead on large files.
+    """
     input_count = 0
     output_count = 0
 
     with open(input_path, encoding="utf-8", errors="replace") as infile:
-        reader = csv.DictReader(infile)
-        fieldnames = reader.fieldnames
-        assert fieldnames is not None, f"No header row found in {input_path}"
+        reader = csv.reader(infile)
+        header = next(reader)
+        try:
+            id_idx = header.index(id_column)
+        except ValueError:
+            raise ValueError(
+                f"Column '{id_column}' not found in {input_path}. Available columns: {header}"
+            ) from None
 
         with open(output_path, "w", encoding="utf-8", newline="") as outfile:
-            writer = csv.DictWriter(outfile, fieldnames=fieldnames)
-            writer.writeheader()
+            writer = csv.writer(outfile)
+            writer.writerow(header)
 
             for row in reader:
                 input_count += 1
                 try:
-                    release_id = int(row[id_column])
+                    release_id = int(row[id_idx])
                     if release_id in matching_ids:
                         writer.writerow(row)
                         output_count += 1
-                except (ValueError, KeyError):
-                    # Skip rows with invalid release IDs
+                except (ValueError, IndexError):
+                    # Skip rows with invalid release IDs or short rows
                     pass
 
                 if input_count % 1000000 == 0:

--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -331,8 +331,12 @@ def run_step(description: str, cmd: list[str], **kwargs) -> None:
 
 
 def run_vacuum(db_url: str) -> None:
-    """Run VACUUM FULL on all pipeline tables."""
-    logger.info("Running VACUUM FULL ...")
+    """Run VACUUM FULL on all pipeline tables in parallel.
+
+    VACUUM FULL on independent tables does not conflict, so we use
+    run_sql_statements_parallel (which opens a separate autocommit
+    connection per statement) to vacuum all tables concurrently.
+    """
     tables = [
         "release",
         "release_artist",
@@ -341,16 +345,8 @@ def run_vacuum(db_url: str) -> None:
         "release_track_artist",
         "cache_metadata",
     ]
-    conn = psycopg.connect(db_url, autocommit=True)
-    for table in tables:
-        logger.info("  VACUUM FULL %s ...", table)
-        try:
-            with conn.cursor() as cur:
-                cur.execute(f"VACUUM FULL {table}")
-        except psycopg.Error as exc:
-            logger.warning("  VACUUM FULL %s failed: %s", table, exc)
-    conn.close()
-    logger.info("  VACUUM complete.")
+    statements = [f"VACUUM FULL {table}" for table in tables]
+    run_sql_statements_parallel(db_url, statements, description="VACUUM FULL")
 
 
 def report_sizes(db_url: str) -> None:

--- a/tests/unit/test_filter_csv.py
+++ b/tests/unit/test_filter_csv.py
@@ -133,6 +133,33 @@ class TestFindMatchingReleaseIds:
         # "Some Producer" is an extra artist on release 1001
         assert 1001 in ids
 
+    def test_normalize_cache_avoids_redundant_calls(self, tmp_path: Path) -> None:
+        """Duplicate artist names should only be normalized once (via cache)."""
+        csv_path = tmp_path / "release_artist.csv"
+        # Write a CSV with the same artist name repeated many times
+        with open(csv_path, "w", newline="") as f:
+            writer = csv.writer(f)
+            writer.writerow(["release_id", "artist_id", "artist_name", "extra", "anv", "position"])
+            for i in range(1, 101):
+                writer.writerow([i, 1, "Juana Molina", 0, "", 1])
+
+        from unittest.mock import patch
+
+        call_count = 0
+        original_normalize = normalize_artist
+
+        def counting_normalize(name):
+            nonlocal call_count
+            call_count += 1
+            return original_normalize(name)
+
+        with patch.object(_fc, "normalize_artist", side_effect=counting_normalize):
+            find_matching_release_ids(csv_path, {"juana molina"})
+
+        # With caching, normalize should be called once for the unique name,
+        # not 100 times for every row.
+        assert call_count == 1
+
 
 # ---------------------------------------------------------------------------
 # get_release_id_column
@@ -210,3 +237,12 @@ class TestFilterCsvFile:
 
         _, output_count = filter_csv_file(input_path, output_path, matching_ids, "release_id")
         assert output_count == 5  # Release 1001 has 5 tracks
+
+    def test_missing_id_column_raises_clear_error(self, tmp_path: Path) -> None:
+        """When id_column is not in the CSV header, a ValueError is raised
+        with a message listing the available columns."""
+        input_path = FIXTURES_DIR / "csv" / "release.csv"
+        output_path = tmp_path / "out.csv"
+
+        with pytest.raises(ValueError, match="Column 'nonexistent'.*not found"):
+            filter_csv_file(input_path, output_path, {1001}, "nonexistent")

--- a/tests/unit/test_run_pipeline.py
+++ b/tests/unit/test_run_pipeline.py
@@ -271,6 +271,27 @@ class TestRunSqlStatementsParallel:
         assert any("test indexes" in r.message for r in caplog.records)
 
 
+class TestRunVacuum:
+    """run_vacuum() delegates to run_sql_statements_parallel for parallel execution."""
+
+    def test_vacuum_uses_parallel_execution(self) -> None:
+        """run_vacuum should call run_sql_statements_parallel with VACUUM FULL statements."""
+        from unittest.mock import patch
+
+        with patch.object(run_pipeline, "run_sql_statements_parallel") as mock_parallel:
+            run_pipeline.run_vacuum("postgresql:///test")
+
+        mock_parallel.assert_called_once()
+        args, kwargs = mock_parallel.call_args
+        db_url, statements = args[0], args[1]
+        assert db_url == "postgresql:///test"
+        assert len(statements) == 6
+        assert all(s.startswith("VACUUM FULL ") for s in statements)
+        assert "VACUUM FULL release" in statements
+        assert "VACUUM FULL cache_metadata" in statements
+        assert kwargs.get("description") or args[2] if len(args) > 2 else True
+
+
 class TestXmlModeEnrichment:
     """In --xml mode, library_artists.txt is generated from library.db when not provided."""
 


### PR DESCRIPTION
## Summary

- Replace `DictReader`/`DictWriter` with `csv.reader`/`csv.writer` in `filter_csv_file()` for 100M+ row files
- Parallel VACUUM FULL via existing `run_sql_statements_parallel()` — wall-clock time drops to max(single) instead of sum
- Partial index on `release.master_id` for dedup partition scan performance
- Cache `normalize_artist()` results in `find_matching_release_ids()` to avoid redundant NFKD decomposition

## Test plan

- [x] `pytest` — 262 unit tests pass
- [x] `ruff format --check` — clean
- [x] `ruff check` — clean
- [x] Regression test for missing id_column in filter_csv_file
- [x] Test for parallel VACUUM using run_sql_statements_parallel
- [x] Test verifying normalize_artist cache deduplication

Closes #13
Cross-references: WXYC/discogs-xml-converter#11, WXYC/discogs-xml-converter#12