### PR TITLE
perf: import_csv csv.reader and COPY for dedup label loading

### DIFF
--- a/scripts/dedup_releases.py
+++ b/scripts/dedup_releases.py
@@ -83,22 +83,19 @@ def load_library_labels(conn, csv_path: Path) -> int:
             )
         """)
 
-    rows = []
+    count = 0
     with open(csv_path, newline="", encoding="utf-8") as f:
         reader = csv.DictReader(f)
-        for row in reader:
-            rows.append((row["artist_name"], row["release_title"], row["label_name"]))
-
-    if rows:
         with conn.cursor() as cur:
-            cur.executemany(
-                "INSERT INTO wxyc_label_pref (artist_name, release_title, label_name) "
-                "VALUES (%s, %s, %s)",
-                rows,
-            )
+            with cur.copy(
+                "COPY wxyc_label_pref (artist_name, release_title, label_name) FROM STDIN"
+            ) as copy:
+                for row in reader:
+                    copy.write_row((row["artist_name"], row["release_title"], row["label_name"]))
+                    count += 1
 
-    logger.info("Loaded %d label preferences", len(rows))
-    return len(rows)
+    logger.info("Loaded %d label preferences", count)
+    return count
 
 
 def load_label_hierarchy(conn, csv_path: Path) -> int:
@@ -128,29 +125,27 @@ def load_label_hierarchy(conn, csv_path: Path) -> int:
             )
         """)
 
-    rows = []
+    count = 0
     with open(csv_path, newline="", encoding="utf-8") as f:
         reader = csv.DictReader(f)
-        for row in reader:
-            rows.append(
-                (
-                    int(row["label_id"]),
-                    row["label_name"],
-                    int(row["parent_label_id"]),
-                    row["parent_label_name"],
-                )
-            )
-
-    if rows:
         with conn.cursor() as cur:
-            cur.executemany(
-                "INSERT INTO label_hierarchy (label_id, label_name, parent_label_id, "
-                "parent_label_name) VALUES (%s, %s, %s, %s)",
-                rows,
-            )
+            with cur.copy(
+                "COPY label_hierarchy (label_id, label_name, parent_label_id, "
+                "parent_label_name) FROM STDIN"
+            ) as copy:
+                for row in reader:
+                    copy.write_row(
+                        (
+                            int(row["label_id"]),
+                            row["label_name"],
+                            int(row["parent_label_id"]),
+                            row["parent_label_name"],
+                        )
+                    )
+                    count += 1
 
-    logger.info("Loaded %d label hierarchy entries", len(rows))
-    return len(rows)
+    logger.info("Loaded %d label hierarchy entries", count)
+    return count
 
 
 def _label_hierarchy_table_exists(conn) -> bool:

--- a/scripts/import_csv.py
+++ b/scripts/import_csv.py
@@ -159,28 +159,31 @@ def import_csv(
         unique_key_indices = [csv_columns.index(col) for col in unique_key]
 
     with open(csv_path, encoding="utf-8", errors="replace") as f:
-        reader = csv.DictReader(f)
-        header = reader.fieldnames
+        reader = csv.reader(f)
+        header = next(reader, None)
         if not header:
             logger.warning(f"  No header found in {csv_path.name}, skipping")
             return 0
 
         # Verify required CSV columns exist in header
-        missing = [c for c in csv_columns if c not in header]
+        missing = sorted(set(csv_columns) - set(header))
         if missing:
             logger.error(f"  Missing columns in {csv_path.name}: {missing}")
             return 0
+
+        # Build column index mapping for positional access
+        col_idx = {col: header.index(col) for col in csv_columns}
 
         # Find indices of required columns for null checking
         required_set = set(required_columns)
         seen: set[tuple[str | None, ...]] = set()
 
-        # Determine release_id column name for filtering
-        release_id_col: str | None = None
+        # Determine release_id column index for filtering
+        release_id_idx: int | None = None
         if release_id_filter is not None:
             for col_name in ("release_id", "id"):
-                if col_name in csv_columns:
-                    release_id_col = col_name
+                if col_name in col_idx:
+                    release_id_idx = col_idx[col_name]
                     break
 
         with conn.cursor() as cur:
@@ -191,10 +194,10 @@ def import_csv(
                 dupes = 0
                 for row in reader:
                     # Filter by release_id if specified
-                    if release_id_filter is not None and release_id_col is not None:
+                    if release_id_filter is not None and release_id_idx is not None:
                         try:
-                            rid = int(row.get(release_id_col, ""))
-                        except (ValueError, TypeError):
+                            rid = int(row[release_id_idx])
+                        except (ValueError, IndexError):
                             filtered += 1
                             continue
                         if rid not in release_id_filter:
@@ -205,7 +208,7 @@ def import_csv(
                     values: list[str | None] = []
                     skip = False
                     for csv_col in csv_columns:
-                        val = row.get(csv_col, "")
+                        val = row[col_idx[csv_col]]
                         if val == "":
                             val = None
 

--- a/tests/unit/test_import_csv.py
+++ b/tests/unit/test_import_csv.py
@@ -16,6 +16,7 @@ _spec.loader.exec_module(_ic)
 
 extract_year = _ic.extract_year
 count_tracks_from_csv = _ic.count_tracks_from_csv
+import_csv = _ic.import_csv
 TABLES = _ic.TABLES
 BASE_TABLES = _ic.BASE_TABLES
 TRACK_TABLES = _ic.TRACK_TABLES
@@ -326,3 +327,57 @@ class TestTableSplit:
         base_names = {t["table"] for t in BASE_TABLES}
         track_names = {t["table"] for t in TRACK_TABLES}
         assert base_names.isdisjoint(track_names)
+
+
+# ---------------------------------------------------------------------------
+# import_csv missing columns
+# ---------------------------------------------------------------------------
+
+
+class TestImportCsvMissingColumns:
+    """import_csv reports clear errors when CSV header is missing expected columns."""
+
+    def test_missing_columns_returns_zero_and_logs_error(self, tmp_path, caplog) -> None:
+        """When the CSV header lacks required columns, import_csv returns 0 and logs them."""
+        csv_path = tmp_path / "release.csv"
+        # Write a CSV missing the 'title' and 'master_id' columns
+        csv_path.write_text("id,country,released\n1001,US,2024\n")
+
+        from unittest.mock import MagicMock
+
+        conn = MagicMock()
+        count = import_csv(
+            conn,
+            csv_path,
+            table="release",
+            csv_columns=["id", "title", "country", "released", "master_id"],
+            db_columns=["id", "title", "country", "release_year", "master_id"],
+            required_columns=["id", "title"],
+            transforms={},
+        )
+
+        assert count == 0
+        assert "Missing columns" in caplog.text
+        assert "master_id" in caplog.text
+        assert "title" in caplog.text
+
+    def test_no_header_returns_zero(self, tmp_path, caplog) -> None:
+        """An empty CSV file returns 0 with a warning."""
+        csv_path = tmp_path / "empty.csv"
+        csv_path.write_text("")
+
+        from unittest.mock import MagicMock
+
+        conn = MagicMock()
+        count = import_csv(
+            conn,
+            csv_path,
+            table="release",
+            csv_columns=["id", "title"],
+            db_columns=["id", "title"],
+            required_columns=["id"],
+            transforms={},
+        )
+
+        assert count == 0
+        assert "No header" in caplog.text


### PR DESCRIPTION
## Summary

- Replace `DictReader` with `csv.reader` in `import_csv()` for positional row access on 100M+ row files
- Replace `executemany()` with `cur.copy()` COPY protocol in `load_library_labels()` and `load_label_hierarchy()`

## Test plan

- [x] `pytest` — 261 unit tests pass
- [x] `ruff format --check` — clean
- [x] `ruff check` — clean
- [x] Regression test for missing columns in CSV header
- [x] Regression test for empty CSV file

Closes #14
Cross-references: WXYC/discogs-xml-converter#11, WXYC/discogs-xml-converter#12