### PR TITLE
fix: drop and recreate tables in schema to prevent stale data conflicts

### DIFF
--- a/schema/create_database.sql
+++ b/schema/create_database.sql
@@ -17,11 +17,19 @@ CREATE EXTENSION IF NOT EXISTS pg_trgm;
 CREATE EXTENSION IF NOT EXISTS unaccent;
 
 -- ============================================
--- Core tables
+-- Core tables (drop + recreate for clean ETL)
 -- ============================================
 
+-- Drop in FK order: children first, then parent
+DROP TABLE IF EXISTS cache_metadata CASCADE;
+DROP TABLE IF EXISTS release_track_artist CASCADE;
+DROP TABLE IF EXISTS release_track CASCADE;
+DROP TABLE IF EXISTS release_label CASCADE;
+DROP TABLE IF EXISTS release_artist CASCADE;
+DROP TABLE IF EXISTS release CASCADE;
+
 -- Releases
-CREATE TABLE IF NOT EXISTS release (
+CREATE TABLE release (
     id              integer PRIMARY KEY,
     title           text NOT NULL,
     release_year    smallint,
@@ -31,7 +39,7 @@ CREATE TABLE IF NOT EXISTS release (
 );
 
 -- Artists on releases
-CREATE TABLE IF NOT EXISTS release_artist (
+CREATE TABLE release_artist (
     release_id      integer NOT NULL REFERENCES release(id) ON DELETE CASCADE,
     artist_id       integer,             -- Discogs artist ID (nullable for API-fetched releases)
     artist_name     text NOT NULL,
@@ -39,13 +47,13 @@ CREATE TABLE IF NOT EXISTS release_artist (
 );
 
 -- Labels on releases
-CREATE TABLE IF NOT EXISTS release_label (
+CREATE TABLE release_label (
     release_id      integer NOT NULL REFERENCES release(id) ON DELETE CASCADE,
     label_name      text NOT NULL
 );
 
 -- Tracks on releases
-CREATE TABLE IF NOT EXISTS release_track (
+CREATE TABLE release_track (
     release_id      integer NOT NULL REFERENCES release(id) ON DELETE CASCADE,
     sequence        integer NOT NULL,
     position        text,              -- "A1", "B2", etc.
@@ -54,7 +62,7 @@ CREATE TABLE IF NOT EXISTS release_track (
 );
 
 -- Artists on specific tracks (for compilations)
-CREATE TABLE IF NOT EXISTS release_track_artist (
+CREATE TABLE release_track_artist (
     release_id      integer NOT NULL REFERENCES release(id) ON DELETE CASCADE,
     track_sequence  integer NOT NULL,
     artist_name     text NOT NULL
@@ -64,7 +72,7 @@ CREATE TABLE IF NOT EXISTS release_track_artist (
 -- Cache metadata (for tracking data freshness)
 -- ============================================
 
-CREATE TABLE IF NOT EXISTS cache_metadata (
+CREATE TABLE cache_metadata (
     release_id      integer PRIMARY KEY REFERENCES release(id) ON DELETE CASCADE,
     cached_at       timestamptz NOT NULL DEFAULT now(),
     source          text NOT NULL,  -- 'bulk_import' or 'api_fetch'


### PR DESCRIPTION
Closes #36

## Summary

- Change `create_database.sql` from `CREATE TABLE IF NOT EXISTS` to `DROP TABLE IF EXISTS ... CASCADE` + `CREATE TABLE`
- Ensures a clean state on every fresh pipeline run, preventing `UniqueViolation` on `release_pkey` during re-imports
- `--resume` mode skips schema creation entirely, so in-progress work is unaffected
- Add regression test `test_schema_clears_stale_data_on_rerun` that inserts data, re-runs schema, and verifies tables are empty
- Update CI to run all tests with `--cov-fail-under=80` coverage enforcement

## Test plan

- [x] Schema is idempotent: running twice produces no errors
- [x] Regression test verifies stale data is cleared on schema re-run
- [x] All 594 tests pass (unit + integration + E2E)
- [x] Coverage at 84%, threshold of 80% enforced in CI