### PR TITLE
test: add schema regression test + CI coverage enforcement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,12 +49,16 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-      - run: pip install -e ".[dev]"
+      - run: pip install -e ".[dev]" pytest-cov
       - name: Enable pg_trgm extension
         run: |
           PGPASSWORD=discogs psql -h localhost -p 5433 -U discogs -d postgres \
             -c "CREATE EXTENSION IF NOT EXISTS pg_trgm;"
-      - name: Run integration and E2E tests
+      - name: Run all tests with coverage
         env:
           DATABASE_URL_TEST: postgresql://discogs:discogs@localhost:5433/postgres
-        run: pytest -m 'postgres or e2e' -v
+        run: >-
+          pytest -m 'not mysql' -v
+          --cov=scripts --cov=lib
+          --cov-report=term-missing
+          --cov-fail-under=80

--- a/tests/integration/test_schema.py
+++ b/tests/integration/test_schema.py
@@ -156,10 +156,37 @@ class TestCreateDatabase:
         assert unique_constraints == [], f"Unexpected UNIQUE constraints: {unique_constraints}"
 
     def test_schema_is_idempotent(self) -> None:
-        """Running the schema twice doesn't error (IF NOT EXISTS)."""
+        """Running the schema twice doesn't error."""
         conn = psycopg.connect(self.db_url, autocommit=True)
         with conn.cursor() as cur:
             cur.execute(SCHEMA_DIR.joinpath("create_database.sql").read_text())
+        conn.close()
+
+    def test_schema_clears_stale_data_on_rerun(self) -> None:
+        """Re-running the schema drops old data so import doesn't hit UniqueViolation."""
+        conn = psycopg.connect(self.db_url, autocommit=True)
+
+        # Insert data as if a previous pipeline run completed
+        with conn.cursor() as cur:
+            cur.execute("INSERT INTO release (id, title) VALUES (1, 'DOGA')")
+            cur.execute(
+                "INSERT INTO release_artist (release_id, artist_name, extra) "
+                "VALUES (1, 'Juana Molina', 0)"
+            )
+            cur.execute("SELECT count(*) FROM release")
+            assert cur.fetchone()[0] == 1
+
+        # Re-run schema (simulates a fresh pipeline run)
+        with conn.cursor() as cur:
+            cur.execute(SCHEMA_DIR.joinpath("create_database.sql").read_text())
+
+        # Tables should be empty — no stale data to conflict with new imports
+        with conn.cursor() as cur:
+            cur.execute("SELECT count(*) FROM release")
+            assert cur.fetchone()[0] == 0
+            cur.execute("SELECT count(*) FROM release_artist")
+            assert cur.fetchone()[0] == 0
+
         conn.close()
 
 


### PR DESCRIPTION
Closes #38

## Summary

- Add `test_schema_clears_stale_data_on_rerun` regression test: inserts data, re-runs schema, verifies tables are empty. Would have caught the `UniqueViolation` bug from #36.
- Update CI `test-postgres` job to run all non-MySQL tests with `--cov-fail-under=80`, enforcing a minimum coverage threshold.

## Test plan

- [x] Regression test passes locally against Docker Compose PostgreSQL
- [x] All 594 tests pass
- [x] Coverage at 84%, threshold of 80% enforced