### PR TITLE
Add daily cron workflow to sync library.db

### DIFF
--- a/.github/workflows/sync-library.yml
+++ b/.github/workflows/sync-library.yml
@@ -1,0 +1,44 @@
+name: Sync Library
+
+on:
+  schedule:
+    # Daily at noon UTC (7 AM EST / 8 AM EDT)
+    - cron: "0 12 * * *"
+  workflow_dispatch:
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - run: pip install -e .
+
+      - uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+
+      - name: Add Kattare host key
+        run: |
+          mkdir -p ~/.ssh
+          ssh-keyscan -H "$LIBRARY_SSH_HOST" >> ~/.ssh/known_hosts
+        env:
+          LIBRARY_SSH_HOST: ${{ secrets.LIBRARY_SSH_HOST }}
+
+      - name: Run library sync
+        run: scripts/sync-library.sh --notify
+        env:
+          LIBRARY_SSH_HOST: ${{ secrets.LIBRARY_SSH_HOST }}
+          LIBRARY_SSH_USER: ${{ secrets.LIBRARY_SSH_USER }}
+          LIBRARY_DB_HOST: ${{ secrets.LIBRARY_DB_HOST }}
+          LIBRARY_DB_USER: ${{ secrets.LIBRARY_DB_USER }}
+          LIBRARY_DB_PASSWORD: ${{ secrets.LIBRARY_DB_PASSWORD }}
+          LIBRARY_DB_NAME: ${{ secrets.LIBRARY_DB_NAME }}
+          ADMIN_TOKEN: ${{ secrets.ADMIN_TOKEN }}
+          STAGING_URL: ${{ secrets.STAGING_URL }}
+          PRODUCTION_URL: ${{ secrets.PRODUCTION_URL }}
+          SLACK_MONITORING_WEBHOOK: ${{ secrets.SLACK_MONITORING_WEBHOOK }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,6 +133,34 @@ Test fixtures are in `tests/fixtures/` (CSV files, library.db, library_artists.t
 
 This pipeline runs monthly (or when Discogs publishes new data dumps). It has a completely different lifecycle from the request-handling services that consume its output.
 
+## Automation
+
+### Library Sync (`sync-library.yml`)
+
+A GitHub Actions cron workflow runs `scripts/sync-library.sh` daily at noon UTC (7 AM EST / 8 AM EDT) to export the WXYC library catalog from MySQL on Kattare to SQLite and upload it to library-metadata-lookup staging and production environments.
+
+The workflow can also be triggered manually: `gh workflow run sync-library.yml`
+
+The `--notify` flag is always passed, so Slack notifications are sent on failure when `SLACK_MONITORING_WEBHOOK` is configured.
+
+**Required GitHub secrets:**
+
+| Secret | Description |
+|--------|-------------|
+| `SSH_PRIVATE_KEY` | Private key authorized on Kattare |
+| `LIBRARY_SSH_HOST` | Kattare SSH hostname |
+| `LIBRARY_SSH_USER` | SSH username |
+| `LIBRARY_DB_HOST` | MySQL host (as seen from SSH host) |
+| `LIBRARY_DB_USER` | MySQL username |
+| `LIBRARY_DB_PASSWORD` | MySQL password |
+| `LIBRARY_DB_NAME` | MySQL database name |
+| `ADMIN_TOKEN` | Bearer token for library-metadata-lookup admin endpoints |
+| `STAGING_URL` | Staging base URL for library-metadata-lookup |
+| `PRODUCTION_URL` | Production base URL for library-metadata-lookup |
+| `SLACK_MONITORING_WEBHOOK` | Slack webhook for error notifications (optional) |
+
+After a successful run, verify the library-metadata-lookup health endpoint returns healthy with the expected row count.
+
 ## Development Practices
 
 ### TDD (Required)

--- a/scripts/sync-library.sh
+++ b/scripts/sync-library.sh
@@ -1,11 +1,21 @@
 #!/bin/bash
 set -eo pipefail
 
-LOG_FILE="$HOME/Library/Logs/library-metadata-lookup-etl.log"
+if [[ -d "$HOME/Library/Logs" ]]; then
+    LOG_FILE="$HOME/Library/Logs/library-metadata-lookup-etl.log"
+else
+    LOG_FILE="$(mktemp)"
+fi
 REPO_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 SLACK_WEBHOOK_URL="${SLACK_MONITORING_WEBHOOK:-}"
 NOTIFY_ENABLED=false
 EXIT_CODE=0
+
+# Python interpreter: allow override via PYTHON_BIN, prefer .venv, fall back to python3
+PYTHON="${PYTHON_BIN:-.venv/bin/python}"
+if ! command -v "$PYTHON" &>/dev/null; then
+    PYTHON="python3"
+fi
 
 # Parse arguments
 while [[ $# -gt 0 ]]; do
@@ -55,7 +65,7 @@ upload_library_db() {
         2>> "$LOG_FILE")
 
     if [[ "$HTTP_CODE" -eq 200 ]]; then
-        ROW_COUNT=$(python3 -c "import json,sys; print(json.load(sys.stdin).get('row_count','?'))" < "$UPLOAD_OUTPUT" 2>/dev/null || echo "?")
+        ROW_COUNT=$($PYTHON -c "import json,sys; print(json.load(sys.stdin).get('row_count','?'))" < "$UPLOAD_OUTPUT" 2>/dev/null || echo "?")
         log "Uploaded to $label successfully ($ROW_COUNT rows)"
         rm -f "$UPLOAD_OUTPUT"
         return 0
@@ -89,7 +99,7 @@ DB_PATH=$(mktemp -d)/library.db
 export LIBRARY_DB_OUTPUT_PATH="$DB_PATH"
 
 ETL_OUTPUT=$(mktemp)
-if ! .venv/bin/python scripts/export_to_sqlite.py 2>&1 | tee "$ETL_OUTPUT"; then
+if ! $PYTHON scripts/export_to_sqlite.py 2>&1 | tee "$ETL_OUTPUT"; then
     ERROR_DETAILS=$(grep -v '^[[:space:]]' "$ETL_OUTPUT" | grep -v '^$' | tail -1 | sed 's/"/\\"/g')
     cat "$ETL_OUTPUT" >> "$LOG_FILE"
     rm -f "$ETL_OUTPUT" "$DB_PATH"


### PR DESCRIPTION
## Summary

- Add GitHub Actions cron workflow (`sync-library.yml`) to run the library sync daily at noon UTC (7 AM EST), with `workflow_dispatch` for manual runs
- Make `sync-library.sh` CI-compatible: detect Python interpreter, handle log path on non-macOS
- Document the automation in CLAUDE.md including required secrets

Closes #52

## Test plan

- [ ] Configure required secrets in GitHub repo settings
- [ ] Trigger manually via `gh workflow run sync-library.yml`
- [ ] Verify Actions run log shows successful export + upload
- [ ] Verify library-metadata-lookup staging health endpoint returns healthy
- [ ] Verify sync-library.sh still works locally with `.venv/bin/python`