### PR TITLE
Fix: install pymysql extra for library sync workflow

### DIFF
--- a/.github/workflows/sync-library.yml
+++ b/.github/workflows/sync-library.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           python-version: "3.12"
 
-      - run: pip install -e .
+      - run: pip install -e ".[mysql]"
 
       - uses: webfactory/ssh-agent@v0.9.0
         with:


### PR DESCRIPTION
## Summary

- Install `.[mysql]` instead of `.` in the sync-library workflow so that `pymysql` is available for `export_to_sqlite.py`

Follow-up to #52.