### PR TITLE
Export label data in library.db

### DIFF
--- a/lib/catalog_source.py
+++ b/lib/catalog_source.py
@@ -25,7 +25,7 @@ class CatalogSource(Protocol):
 
     def fetch_library_rows(self) -> list[dict[str, Any]]:
         """Return library rows. Keys: id, title, artist, call_letters,
-        artist_call_number, release_call_number, genre, format, alternate_artist_name."""
+        artist_call_number, release_call_number, genre, format, alternate_artist_name, label."""
         ...
 
     def fetch_alternate_names(self) -> set[str]:
@@ -89,17 +89,26 @@ class TubafrenzySource:
             "genre",
             "format",
             "alternate_artist_name",
+            "label",
         ]
         with self._conn.cursor() as cur:
             cur.execute("""
                 SELECT
                     r.ID, r.TITLE, lc.PRESENTATION_NAME, lc.CALL_LETTERS,
                     lc.CALL_NUMBERS, r.CALL_NUMBERS, g.REFERENCE_NAME,
-                    f.REFERENCE_NAME, r.ALTERNATE_ARTIST_NAME
+                    f.REFERENCE_NAME, r.ALTERNATE_ARTIST_NAME,
+                    label_sub.label_name
                 FROM LIBRARY_RELEASE r
                 JOIN LIBRARY_CODE lc ON r.LIBRARY_CODE_ID = lc.ID
                 JOIN FORMAT f ON r.FORMAT_ID = f.ID
                 JOIN GENRE g ON lc.GENRE_ID = g.ID
+                LEFT JOIN (
+                    SELECT rr.LIBRARY_RELEASE_ID, c.NAME as label_name,
+                           ROW_NUMBER() OVER (PARTITION BY rr.LIBRARY_RELEASE_ID ORDER BY rr.ROTATION_ADD_DATE DESC) as rn
+                    FROM ROTATION_RELEASE rr
+                    JOIN COMPANY c ON rr.COMPANY_ID = c.ID
+                    WHERE rr.LIBRARY_RELEASE_ID IS NOT NULL AND rr.LIBRARY_RELEASE_ID > 0
+                ) label_sub ON label_sub.LIBRARY_RELEASE_ID = r.ID AND label_sub.rn = 1
             """)
             rows = cur.fetchall()
         return [dict(zip(columns, row, strict=True)) for row in rows]
@@ -175,7 +184,8 @@ class BackendServiceSource:
                     gac.artist_genre_code AS artist_call_number,
                     l.code_number AS release_call_number,
                     g.genre_name AS genre, f.format_name AS format,
-                    l.alternate_artist_name
+                    l.alternate_artist_name,
+                    NULL AS label
                 FROM wxyc_schema.library l
                 JOIN wxyc_schema.artists a ON l.artist_id = a.id
                 JOIN wxyc_schema.format f ON l.format_id = f.id

--- a/scripts/export_to_sqlite.py
+++ b/scripts/export_to_sqlite.py
@@ -39,9 +39,8 @@ MYSQL_PASSWORD = os.environ.get("LIBRARY_DB_PASSWORD", "")
 MYSQL_DATABASE = os.environ.get("LIBRARY_DB_NAME", "wxyc_library")
 
 # Output path (override with LIBRARY_DB_OUTPUT_PATH env var)
-OUTPUT_PATH = Path(os.environ.get("LIBRARY_DB_OUTPUT_PATH", "")) or (
-    Path(__file__).parent.parent / "library.db"
-)
+_output_env = os.environ.get("LIBRARY_DB_OUTPUT_PATH", "")
+OUTPUT_PATH = Path(_output_env) if _output_env else (Path(__file__).parent.parent / "library.db")
 
 # SQL query to extract library data
 LIBRARY_QUERY = """
@@ -54,11 +53,19 @@ SELECT
     r.CALL_NUMBERS as release_call_number,
     g.REFERENCE_NAME as genre,
     f.REFERENCE_NAME as format,
-    r.ALTERNATE_ARTIST_NAME as alternate_artist_name
+    r.ALTERNATE_ARTIST_NAME as alternate_artist_name,
+    label_sub.label_name as label
 FROM LIBRARY_RELEASE r
 JOIN LIBRARY_CODE lc ON r.LIBRARY_CODE_ID = lc.ID
 JOIN FORMAT f ON r.FORMAT_ID = f.ID
 JOIN GENRE g ON lc.GENRE_ID = g.ID
+LEFT JOIN (
+    SELECT rr.LIBRARY_RELEASE_ID, c.NAME as label_name,
+           ROW_NUMBER() OVER (PARTITION BY rr.LIBRARY_RELEASE_ID ORDER BY rr.ROTATION_ADD_DATE DESC) as rn
+    FROM ROTATION_RELEASE rr
+    JOIN COMPANY c ON rr.COMPANY_ID = c.ID
+    WHERE rr.LIBRARY_RELEASE_ID IS NOT NULL AND rr.LIBRARY_RELEASE_ID > 0
+) label_sub ON label_sub.LIBRARY_RELEASE_ID = r.ID AND label_sub.rn = 1
 """
 
 
@@ -132,6 +139,7 @@ def fetch_from_remote() -> list[dict]:
         "genre",
         "format",
         "alternate_artist_name",
+        "label",
     ]
 
     for line in output.strip().split("\n"):
@@ -247,7 +255,8 @@ def _do_export(rows: list[dict]):
             release_call_number INTEGER,
             genre TEXT,
             format TEXT,
-            alternate_artist_name TEXT
+            alternate_artist_name TEXT,
+            label TEXT
         )
     """)
 
@@ -268,8 +277,8 @@ def _do_export(rows: list[dict]):
     for row in rows:
         sqlite_cur.execute(
             """
-            INSERT INTO library (id, title, artist, call_letters, artist_call_number, release_call_number, genre, format, alternate_artist_name)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            INSERT INTO library (id, title, artist, call_letters, artist_call_number, release_call_number, genre, format, alternate_artist_name, label)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 row["id"],
@@ -281,6 +290,7 @@ def _do_export(rows: list[dict]):
                 row["genre"],
                 row["format"],
                 row.get("alternate_artist_name"),
+                row.get("label"),
             ),
         )
 

--- a/tests/integration/test_catalog_source.py
+++ b/tests/integration/test_catalog_source.py
@@ -177,6 +177,7 @@ class TestFetchLibraryRows:
             "genre",
             "format",
             "alternate_artist_name",
+            "label",
         }
         assert set(rows[0].keys()) == expected_keys
 

--- a/tests/unit/test_catalog_source.py
+++ b/tests/unit/test_catalog_source.py
@@ -76,9 +76,9 @@ class TestTubafrenzySourceFetchLibraryRows:
 
     @patch("lib.catalog_source.connect_mysql")
     def test_returns_list_of_dicts(self, mock_connect) -> None:
-        cursor = _make_mock_cursor([
-            (1, "DOGA", "Juana Molina", "JM", 42, 1, "Rock", "LP", None, "Sonamos")
-        ])
+        cursor = _make_mock_cursor(
+            [(1, "DOGA", "Juana Molina", "JM", 42, 1, "Rock", "LP", None, "Sonamos")]
+        )
         mock_connect.return_value.cursor.return_value = cursor
 
         source = TubafrenzySource("mysql://user:pass@host/db")
@@ -99,9 +99,9 @@ class TestTubafrenzySourceFetchLibraryRows:
     @patch("lib.catalog_source.connect_mysql")
     def test_returns_null_label(self, mock_connect) -> None:
         """Rows without a matching rotation release should have label=None."""
-        cursor = _make_mock_cursor([
-            (1, "DOGA", "Juana Molina", "JM", 42, 1, "Rock", "LP", None, None)
-        ])
+        cursor = _make_mock_cursor(
+            [(1, "DOGA", "Juana Molina", "JM", 42, 1, "Rock", "LP", None, None)]
+        )
         mock_connect.return_value.cursor.return_value = cursor
 
         source = TubafrenzySource("mysql://user:pass@host/db")

--- a/tests/unit/test_catalog_source.py
+++ b/tests/unit/test_catalog_source.py
@@ -76,7 +76,9 @@ class TestTubafrenzySourceFetchLibraryRows:
 
     @patch("lib.catalog_source.connect_mysql")
     def test_returns_list_of_dicts(self, mock_connect) -> None:
-        cursor = _make_mock_cursor([(1, "DOGA", "Juana Molina", "JM", 42, 1, "Rock", "LP", None)])
+        cursor = _make_mock_cursor([
+            (1, "DOGA", "Juana Molina", "JM", 42, 1, "Rock", "LP", None, "Sonamos")
+        ])
         mock_connect.return_value.cursor.return_value = cursor
 
         source = TubafrenzySource("mysql://user:pass@host/db")
@@ -92,6 +94,21 @@ class TestTubafrenzySourceFetchLibraryRows:
         assert rows[0]["genre"] == "Rock"
         assert rows[0]["format"] == "LP"
         assert rows[0]["alternate_artist_name"] is None
+        assert rows[0]["label"] == "Sonamos"
+
+    @patch("lib.catalog_source.connect_mysql")
+    def test_returns_null_label(self, mock_connect) -> None:
+        """Rows without a matching rotation release should have label=None."""
+        cursor = _make_mock_cursor([
+            (1, "DOGA", "Juana Molina", "JM", 42, 1, "Rock", "LP", None, None)
+        ])
+        mock_connect.return_value.cursor.return_value = cursor
+
+        source = TubafrenzySource("mysql://user:pass@host/db")
+        rows = source.fetch_library_rows()
+
+        assert len(rows) == 1
+        assert rows[0]["label"] is None
 
     @patch("lib.catalog_source.connect_mysql")
     def test_uses_dict_cursor(self, mock_connect) -> None:
@@ -256,9 +273,10 @@ class TestBackendServiceSourceFetchLibraryRows:
             ("genre",),
             ("format",),
             ("alternate_artist_name",),
+            ("label",),
         ]
         cursor.fetchall.return_value = [
-            (1, "DOGA", "Juana Molina", "JM", 42, 1, "Rock", "LP", None)
+            (1, "DOGA", "Juana Molina", "JM", 42, 1, "Rock", "LP", None, None)
         ]
 
         source = BackendServiceSource("postgresql://user:pass@host/db")
@@ -268,6 +286,7 @@ class TestBackendServiceSourceFetchLibraryRows:
         assert rows[0]["id"] == 1
         assert rows[0]["title"] == "DOGA"
         assert rows[0]["artist"] == "Juana Molina"
+        assert rows[0]["label"] is None
 
     @patch("lib.catalog_source.psycopg")
     def test_sql_references_wxyc_schema(self, mock_psycopg) -> None:


### PR DESCRIPTION
## Summary

- Join `ROTATION_RELEASE` -> `COMPANY` to include curated label names in the library SQLite export
- Uses a LEFT JOIN subquery that picks the most recent rotation release's company name per library release
- `BackendServiceSource` returns NULL for label (not available yet)
- 17,182 / 64,669 releases (26.5%) will have label data

Closes #55

## Test plan

- [ ] Existing unit tests pass
- [ ] Run export against staging and verify label column
- [ ] Spot-check label values (Cat Power / Moon Pix -> MATADOR)