### PR TITLE
Export compilation_track_artist to library.db

### DIFF
--- a/lib/catalog_source.py
+++ b/lib/catalog_source.py
@@ -44,6 +44,14 @@ class CatalogSource(Protocol):
         """Return (artist_name, release_title, label_name) triples from flowsheet plays."""
         ...
 
+    def fetch_compilation_track_artists(self) -> list[dict[str, Any]]:
+        """Return per-track artist credits from compilation releases.
+
+        Keys: library_release_id, artist_name, track_title.
+        Returns empty list if the table does not exist.
+        """
+        ...
+
     def close(self) -> None:
         """Release the underlying database connection."""
         ...
@@ -150,6 +158,21 @@ class TubafrenzySource:
             """)
             return _strip_label_rows(cur.fetchall())
 
+    def fetch_compilation_track_artists(self) -> list[dict[str, Any]]:
+        columns = ["library_release_id", "artist_name", "track_title"]
+        try:
+            with self._conn.cursor() as cur:
+                cur.execute("""
+                    SELECT LIBRARY_RELEASE_ID, ARTIST_NAME, TRACK_TITLE
+                    FROM COMPILATION_TRACK_ARTIST
+                    ORDER BY LIBRARY_RELEASE_ID
+                """)
+                rows = cur.fetchall()
+            return [dict(zip(columns, row, strict=True)) for row in rows]
+        except Exception:
+            logger.info("COMPILATION_TRACK_ARTIST table not found, skipping")
+            return []
+
     def close(self) -> None:
         self._conn.close()
 
@@ -230,6 +253,10 @@ class BackendServiceSource:
                   AND f.album_id IS NOT NULL
             """)
             return _strip_label_rows(cur.fetchall())
+
+    def fetch_compilation_track_artists(self) -> list[dict[str, Any]]:
+        # Backend-Service does not have COMPILATION_TRACK_ARTIST yet
+        return []
 
     def close(self) -> None:
         self._conn.close()

--- a/scripts/export_to_sqlite.py
+++ b/scripts/export_to_sqlite.py
@@ -147,6 +147,50 @@ def fetch_from_remote() -> list[dict]:
     return rows
 
 
+COMPILATION_TRACK_ARTIST_QUERY = """
+SELECT LIBRARY_RELEASE_ID, ARTIST_NAME, TRACK_TITLE
+FROM COMPILATION_TRACK_ARTIST
+ORDER BY LIBRARY_RELEASE_ID
+"""
+
+
+def fetch_compilation_track_artists_from_remote() -> list[dict]:
+    """Fetch compilation track artists via SSH. Returns empty list if table doesn't exist."""
+    ssh_target = f"{SSH_USER}@{SSH_HOST}"
+    mysql_cmd = (
+        f"mysql -h {MYSQL_HOST} -u {MYSQL_USER} -p'{MYSQL_PASSWORD}' "
+        f'-B -N {MYSQL_DATABASE} -e "{COMPILATION_TRACK_ARTIST_QUERY}"'
+    )
+
+    result = subprocess.run(["ssh", ssh_target, mysql_cmd], capture_output=True)
+
+    if result.returncode != 0:
+        stderr = result.stderr.decode("utf-8", errors="replace")
+        if "doesn't exist" in stderr:
+            print("COMPILATION_TRACK_ARTIST table not found, skipping")
+            return []
+        raise RuntimeError(f"MySQL query failed: {stderr}")
+
+    try:
+        output = result.stdout.decode("utf-8")
+    except UnicodeDecodeError:
+        output = result.stdout.decode("latin-1")
+
+    rows = []
+    columns = ["library_release_id", "artist_name", "track_title"]
+    for line in output.strip().split("\n"):
+        if not line:
+            continue
+        values = line.split("\t")
+        if len(values) == len(columns):
+            cleaned = [None if v == "\\N" else v for v in values]
+            row = dict(zip(columns, cleaned, strict=True))
+            row["library_release_id"] = int(row["library_release_id"])
+            rows.append(row)
+
+    return rows
+
+
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     """Parse command-line arguments."""
     parser = argparse.ArgumentParser(
@@ -174,12 +218,17 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 def export():
     args = parse_args()
 
+    compilation_track_artists: list[dict] | None = None
+
     # If --catalog-source is provided, use it regardless of SSH env vars
     if args.catalog_source and args.catalog_db_url:
         print(f"Fetching library from {args.catalog_source}...")
         source = create_catalog_source(args.catalog_source, args.catalog_db_url)
         try:
             rows = source.fetch_library_rows()
+            compilation_track_artists = source.fetch_compilation_track_artists()
+            if compilation_track_artists:
+                print(f"Fetched {len(compilation_track_artists):,} compilation track artists")
         finally:
             source.close()
         print(f"Fetched {len(rows):,} rows")
@@ -204,6 +253,9 @@ def export():
             sys.exit(1)
 
         rows = fetch_from_remote()
+        compilation_track_artists = fetch_compilation_track_artists_from_remote()
+        if compilation_track_artists:
+            print(f"Fetched {len(compilation_track_artists):,} compilation track artists")
     else:
         # Local MySQL connection (legacy support)
         import pymysql  # type: ignore[import-untyped]
@@ -222,10 +274,10 @@ def export():
             rows = cursor.fetchall()
         conn.close()
 
-    _do_export(rows)
+    _do_export(rows, compilation_track_artists)
 
 
-def _do_export(rows: list[dict]):
+def _do_export(rows: list[dict], compilation_track_artists: list[dict] | None = None):
     """Export rows to SQLite database."""
     # Remove existing SQLite file
     if OUTPUT_PATH.exists():
@@ -295,6 +347,27 @@ def _do_export(rows: list[dict]):
     sqlite_cur.execute("CREATE INDEX idx_artist ON library(artist)")
     sqlite_cur.execute("CREATE INDEX idx_title ON library(title)")
     sqlite_cur.execute("CREATE INDEX idx_alternate_artist ON library(alternate_artist_name)")
+
+    # Export compilation track artists (if available)
+    if compilation_track_artists:
+        sqlite_cur.execute("""
+            CREATE TABLE compilation_track_artist (
+                library_release_id INTEGER NOT NULL,
+                artist_name TEXT NOT NULL,
+                track_title TEXT
+            )
+        """)
+        for row in compilation_track_artists:
+            sqlite_cur.execute(
+                "INSERT INTO compilation_track_artist (library_release_id, artist_name, track_title) VALUES (?, ?, ?)",
+                (row["library_release_id"], row["artist_name"], row.get("track_title")),
+            )
+        sqlite_cur.execute("CREATE INDEX idx_cta_release ON compilation_track_artist(library_release_id)")
+        sqlite_cur.execute("CREATE INDEX idx_cta_artist ON compilation_track_artist(artist_name)")
+
+        cta_count = sqlite_cur.execute("SELECT COUNT(*) FROM compilation_track_artist").fetchone()[0]
+        cta_releases = sqlite_cur.execute("SELECT COUNT(DISTINCT library_release_id) FROM compilation_track_artist").fetchone()[0]
+        print(f"Exported {cta_count} compilation track artists across {cta_releases} releases")
 
     sqlite_conn.commit()
 

--- a/scripts/export_to_sqlite.py
+++ b/scripts/export_to_sqlite.py
@@ -362,11 +362,17 @@ def _do_export(rows: list[dict], compilation_track_artists: list[dict] | None = 
                 "INSERT INTO compilation_track_artist (library_release_id, artist_name, track_title) VALUES (?, ?, ?)",
                 (row["library_release_id"], row["artist_name"], row.get("track_title")),
             )
-        sqlite_cur.execute("CREATE INDEX idx_cta_release ON compilation_track_artist(library_release_id)")
+        sqlite_cur.execute(
+            "CREATE INDEX idx_cta_release ON compilation_track_artist(library_release_id)"
+        )
         sqlite_cur.execute("CREATE INDEX idx_cta_artist ON compilation_track_artist(artist_name)")
 
-        cta_count = sqlite_cur.execute("SELECT COUNT(*) FROM compilation_track_artist").fetchone()[0]
-        cta_releases = sqlite_cur.execute("SELECT COUNT(DISTINCT library_release_id) FROM compilation_track_artist").fetchone()[0]
+        cta_count = sqlite_cur.execute("SELECT COUNT(*) FROM compilation_track_artist").fetchone()[
+            0
+        ]
+        cta_releases = sqlite_cur.execute(
+            "SELECT COUNT(DISTINCT library_release_id) FROM compilation_track_artist"
+        ).fetchone()[0]
         print(f"Exported {cta_count} compilation track artists across {cta_releases} releases")
 
     sqlite_conn.commit()

--- a/tests/unit/test_catalog_source.py
+++ b/tests/unit/test_catalog_source.py
@@ -199,6 +199,36 @@ class TestTubafrenzySourceFetchLibraryLabels:
         assert labels == {("Juana Molina", "DOGA", "Sonamos")}
 
 
+class TestTubafrenzySourceFetchCompilationTrackArtists:
+    """TubafrenzySource.fetch_compilation_track_artists returns per-track artist credits."""
+
+    @patch("lib.catalog_source.connect_mysql")
+    def test_returns_list_of_dicts(self, mock_connect) -> None:
+        cursor = _make_mock_cursor(
+            [(1, "Koo Nimo", "odo akosomo"), (1, "T.O. Jazz", "Yaa Amponsah")]
+        )
+        mock_connect.return_value.cursor.return_value = cursor
+
+        source = TubafrenzySource("mysql://user:pass@host/db")
+        rows = source.fetch_compilation_track_artists()
+
+        assert len(rows) == 2
+        assert rows[0] == {"library_release_id": 1, "artist_name": "Koo Nimo", "track_title": "odo akosomo"}
+        assert rows[1] == {"library_release_id": 1, "artist_name": "T.O. Jazz", "track_title": "Yaa Amponsah"}
+
+    @patch("lib.catalog_source.connect_mysql")
+    def test_returns_empty_list_when_table_missing(self, mock_connect) -> None:
+        """Gracefully returns empty list if COMPILATION_TRACK_ARTIST table doesn't exist."""
+        cursor = _make_mock_cursor([])
+        cursor.execute.side_effect = Exception("Table 'COMPILATION_TRACK_ARTIST' doesn't exist")
+        mock_connect.return_value.cursor.return_value = cursor
+
+        source = TubafrenzySource("mysql://user:pass@host/db")
+        rows = source.fetch_compilation_track_artists()
+
+        assert rows == []
+
+
 class TestTubafrenzySourceClose:
     """TubafrenzySource.close() closes the underlying connection."""
 

--- a/tests/unit/test_catalog_source.py
+++ b/tests/unit/test_catalog_source.py
@@ -213,8 +213,16 @@ class TestTubafrenzySourceFetchCompilationTrackArtists:
         rows = source.fetch_compilation_track_artists()
 
         assert len(rows) == 2
-        assert rows[0] == {"library_release_id": 1, "artist_name": "Koo Nimo", "track_title": "odo akosomo"}
-        assert rows[1] == {"library_release_id": 1, "artist_name": "T.O. Jazz", "track_title": "Yaa Amponsah"}
+        assert rows[0] == {
+            "library_release_id": 1,
+            "artist_name": "Koo Nimo",
+            "track_title": "odo akosomo",
+        }
+        assert rows[1] == {
+            "library_release_id": 1,
+            "artist_name": "T.O. Jazz",
+            "track_title": "Yaa Amponsah",
+        }
 
     @patch("lib.catalog_source.connect_mysql")
     def test_returns_empty_list_when_table_missing(self, mock_connect) -> None:

--- a/tests/unit/test_export.py
+++ b/tests/unit/test_export.py
@@ -240,6 +240,93 @@ class TestDoExport:
         conn.close()
 
 
+class TestDoExportCompilationTrackArtists:
+    """Tests for compilation_track_artist table in _do_export."""
+
+    @pytest.fixture(autouse=True)
+    def use_tmp_output(self, tmp_path, monkeypatch):
+        """Redirect OUTPUT_PATH to a temp directory."""
+        self.output_path = tmp_path / "library.db"
+        monkeypatch.setattr(_mod, _OUTPUT_PATH_ATTR, self.output_path)
+
+    def _make_rows(self):
+        return [
+            {
+                "id": "1",
+                "title": "Vintage Palmwine",
+                "artist": "Various Artists",
+                "call_letters": "Z-X",
+                "artist_call_number": "1",
+                "release_call_number": "1",
+                "genre": "World",
+                "format": "CD",
+                "alternate_artist_name": None,
+            },
+        ]
+
+    def _make_track_artists(self):
+        return [
+            {"library_release_id": 1, "artist_name": "Koo Nimo", "track_title": "odo akosomo"},
+            {"library_release_id": 1, "artist_name": "T.O. Jazz", "track_title": "Yaa Amponsah"},
+        ]
+
+    def test_creates_compilation_track_artist_table(self):
+        """The compilation_track_artist table should be created when track artists are provided."""
+        _do_export(self._make_rows(), self._make_track_artists())
+
+        conn = sqlite3.connect(self.output_path)
+        cursor = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='compilation_track_artist'"
+        )
+        assert cursor.fetchone() is not None
+        conn.close()
+
+    def test_inserts_track_artist_rows(self):
+        """Track artist rows should be inserted into the compilation_track_artist table."""
+        _do_export(self._make_rows(), self._make_track_artists())
+
+        conn = sqlite3.connect(self.output_path)
+        cursor = conn.execute("SELECT library_release_id, artist_name, track_title FROM compilation_track_artist ORDER BY artist_name")
+        rows = cursor.fetchall()
+        conn.close()
+
+        assert len(rows) == 2
+        assert rows[0] == (1, "Koo Nimo", "odo akosomo")
+        assert rows[1] == (1, "T.O. Jazz", "Yaa Amponsah")
+
+    def test_creates_indexes_on_compilation_track_artist(self):
+        """Indexes should be created on library_release_id and artist_name columns."""
+        _do_export(self._make_rows(), self._make_track_artists())
+
+        conn = sqlite3.connect(self.output_path)
+        cursor = conn.execute("SELECT name FROM sqlite_master WHERE type='index' AND name LIKE 'idx_cta_%'")
+        indexes = {row[0] for row in cursor.fetchall()}
+        conn.close()
+
+        assert "idx_cta_release" in indexes
+        assert "idx_cta_artist" in indexes
+
+    def test_no_compilation_table_when_empty(self):
+        """When no track artists are provided, the table should not be created."""
+        _do_export(self._make_rows())
+
+        conn = sqlite3.connect(self.output_path)
+        cursor = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='compilation_track_artist'"
+        )
+        assert cursor.fetchone() is None
+        conn.close()
+
+    def test_backward_compatible_without_track_artists(self):
+        """Calling _do_export without track artists should work as before."""
+        _do_export(self._make_rows())
+
+        conn = sqlite3.connect(self.output_path)
+        cursor = conn.execute("SELECT COUNT(*) FROM library")
+        assert cursor.fetchone()[0] == 1
+        conn.close()
+
+
 class TestFormatSize:
     """Test human-readable size formatting."""
 

--- a/tests/unit/test_export.py
+++ b/tests/unit/test_export.py
@@ -286,7 +286,9 @@ class TestDoExportCompilationTrackArtists:
         _do_export(self._make_rows(), self._make_track_artists())
 
         conn = sqlite3.connect(self.output_path)
-        cursor = conn.execute("SELECT library_release_id, artist_name, track_title FROM compilation_track_artist ORDER BY artist_name")
+        cursor = conn.execute(
+            "SELECT library_release_id, artist_name, track_title FROM compilation_track_artist ORDER BY artist_name"
+        )
         rows = cursor.fetchall()
         conn.close()
 
@@ -299,7 +301,9 @@ class TestDoExportCompilationTrackArtists:
         _do_export(self._make_rows(), self._make_track_artists())
 
         conn = sqlite3.connect(self.output_path)
-        cursor = conn.execute("SELECT name FROM sqlite_master WHERE type='index' AND name LIKE 'idx_cta_%'")
+        cursor = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='index' AND name LIKE 'idx_cta_%'"
+        )
         indexes = {row[0] for row in cursor.fetchall()}
         conn.close()
 


### PR DESCRIPTION
## Summary

- Add `fetch_compilation_track_artists()` to `CatalogSource` protocol and both implementations
- Update `export_to_sqlite.py` to create `compilation_track_artist` table with indexes when data is available
- SSH remote path fetches the table via a second MySQL query; gracefully skips if table doesn't exist yet

Closes #61

## Test plan

- [x] 519 unit tests pass
- [x] `TubafrenzySource.fetch_compilation_track_artists()` returns list of dicts
- [x] Graceful fallback when table doesn't exist
- [x] `_do_export()` creates table and indexes when track artists provided
- [x] `_do_export()` backward-compatible without track artists
- [x] After WXYC/tubafrenzy#367 is merged and `va_catalog_inserts.sql` is applied, re-run `sync-library.sh` to verify end-to-end