### PR TITLE
Add connection resilience and timeout tests

### DIFF
--- a/tests/integration/test_connection_resilience.py
+++ b/tests/integration/test_connection_resilience.py
@@ -106,9 +106,7 @@ class TestCopyConnectionLoss:
         with open(large_csv, "w") as f:
             f.write(header)
             for i in range(500_000):
-                f.write(
-                    f"{i},Accepted,DOGA Pressing {i},AR,2024-05-10,,Correct,{8000 + i},LP\n"
-                )
+                f.write(f"{i},Accepted,DOGA Pressing {i},AR,2024-05-10,,Correct,{8000 + i},LP\n")
 
         import_conn = psycopg.connect(self.db_url)
         import_pid = import_conn.info.backend_pid
@@ -127,9 +125,7 @@ class TestCopyConnectionLoss:
                     )
                     row = cur.fetchone()
                     if row and row[0] and "COPY" in row[0].upper():
-                        cur.execute(
-                            "SELECT pg_terminate_backend(%s)", (import_pid,)
-                        )
+                        cur.execute("SELECT pg_terminate_backend(%s)", (import_pid,))
                         terminated.set()
                         admin_conn.close()
                         return

--- a/tests/integration/test_connection_resilience.py
+++ b/tests/integration/test_connection_resilience.py
@@ -1,0 +1,458 @@
+"""Integration tests for PG COPY connection loss and import resume resilience.
+
+Verifies that:
+- When a PostgreSQL connection is terminated mid-COPY, the transaction is
+  rolled back and no partial data is committed.
+- The pipeline state file does not mark a step complete when COPY fails.
+- Import can resume after a connection loss by re-running the import step.
+
+These tests use pg_terminate_backend() to simulate a network failure during
+a COPY operation, which is the closest approximation to a real network drop
+that we can achieve in an integration test.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import threading
+import time
+from pathlib import Path
+
+import psycopg
+import pytest
+
+from lib.pipeline_state import PipelineState
+
+SCHEMA_DIR = Path(__file__).parent.parent.parent / "schema"
+FIXTURES_DIR = Path(__file__).parent.parent / "fixtures"
+CSV_DIR = FIXTURES_DIR / "csv"
+
+# Load import_csv module from scripts directory (not a proper package).
+_IMPORT_PATH = Path(__file__).parent.parent.parent / "scripts" / "import_csv.py"
+_spec = importlib.util.spec_from_file_location("import_csv", _IMPORT_PATH)
+assert _spec is not None and _spec.loader is not None
+_ic = importlib.util.module_from_spec(_spec)
+sys.modules["import_csv"] = _ic
+_spec.loader.exec_module(_ic)
+
+import_csv_func = _ic.import_csv
+populate_cache_metadata = _ic.populate_cache_metadata
+BASE_TABLES = _ic.BASE_TABLES
+
+pytestmark = pytest.mark.postgres
+
+
+ALL_TABLES = (
+    "cache_metadata",
+    "release_track_artist",
+    "release_track",
+    "release_label",
+    "release_artist",
+    "release",
+)
+
+
+def _drop_all_tables(conn) -> None:
+    """Drop all pipeline tables with CASCADE to clear any state."""
+    with conn.cursor() as cur:
+        for table in ALL_TABLES:
+            cur.execute(f"DROP TABLE IF EXISTS {table} CASCADE")
+        cur.execute("DROP TABLE IF EXISTS release_track_count CASCADE")
+
+
+def _apply_schema(db_url: str) -> None:
+    """Apply the schema to the test database."""
+    conn = psycopg.connect(db_url, autocommit=True)
+    _drop_all_tables(conn)
+    with conn.cursor() as cur:
+        cur.execute(SCHEMA_DIR.joinpath("create_database.sql").read_text())
+    conn.close()
+
+
+class TestCopyConnectionLoss:
+    """Simulate connection termination during COPY and verify rollback.
+
+    Uses pg_terminate_backend() from a separate admin connection to kill the
+    import connection mid-COPY. This is the closest we can get to simulating
+    a network failure in an integration test.
+    """
+
+    @pytest.fixture(autouse=True, scope="class")
+    def _set_up_schema(self, db_url):
+        self.__class__._db_url = db_url
+        _apply_schema(db_url)
+
+    @pytest.fixture(autouse=True)
+    def _store_url(self):
+        self.db_url = self.__class__._db_url
+
+    def _connect(self):
+        return psycopg.connect(self.db_url)
+
+    def test_terminated_copy_rolls_back_transaction(self, tmp_path) -> None:
+        """When pg_terminate_backend kills a COPY connection, no rows are committed.
+
+        Uses a large CSV (500K rows) so COPY takes long enough for the
+        terminator thread to poll pg_stat_activity and kill the backend
+        while COPY is still in progress.
+        """
+        _apply_schema(self.db_url)
+
+        # Create a CSV large enough that COPY takes measurable time.
+        # 500K rows produces a ~40MB CSV that takes >100ms to COPY even locally.
+        large_csv = tmp_path / "large_release.csv"
+        header = "id,status,title,country,released,notes,data_quality,master_id,format\n"
+        with open(large_csv, "w") as f:
+            f.write(header)
+            for i in range(500_000):
+                f.write(
+                    f"{i},Accepted,DOGA Pressing {i},AR,2024-05-10,,Correct,{8000 + i},LP\n"
+                )
+
+        import_conn = psycopg.connect(self.db_url)
+        import_pid = import_conn.info.backend_pid
+
+        # Poll pg_stat_activity until we see the COPY command, then terminate
+        terminated = threading.Event()
+
+        def _terminate():
+            admin_conn = psycopg.connect(self.db_url, autocommit=True)
+            # Poll until the import connection is running a COPY command
+            for _ in range(200):  # up to 2 seconds
+                with admin_conn.cursor() as cur:
+                    cur.execute(
+                        "SELECT query FROM pg_stat_activity WHERE pid = %s",
+                        (import_pid,),
+                    )
+                    row = cur.fetchone()
+                    if row and row[0] and "COPY" in row[0].upper():
+                        cur.execute(
+                            "SELECT pg_terminate_backend(%s)", (import_pid,)
+                        )
+                        terminated.set()
+                        admin_conn.close()
+                        return
+                time.sleep(0.01)
+            # If we never saw COPY, terminate anyway so the test doesn't hang
+            with admin_conn.cursor() as cur:
+                cur.execute("SELECT pg_terminate_backend(%s)", (import_pid,))
+            admin_conn.close()
+            terminated.set()
+
+        terminator = threading.Thread(target=_terminate, daemon=True)
+        terminator.start()
+
+        release_config = next(t for t in BASE_TABLES if t["table"] == "release")
+        copy_raised = False
+        try:
+            import_csv_func(
+                import_conn,
+                large_csv,
+                release_config["table"],
+                release_config["csv_columns"],
+                release_config["db_columns"],
+                release_config["required"],
+                release_config["transforms"],
+            )
+        except psycopg.OperationalError:
+            copy_raised = True
+        finally:
+            try:
+                import_conn.close()
+            except Exception:
+                pass
+
+        terminated.wait(timeout=10)
+        assert terminated.is_set(), "Terminator thread did not fire"
+
+        if not copy_raised:
+            # COPY completed before termination (unlikely with 500K rows,
+            # but possible on very fast machines). The conn.commit() inside
+            # import_csv_func would have succeeded. Skip the rollback assertion
+            # since there was nothing to roll back.
+            pytest.skip("COPY completed before pg_terminate_backend fired")
+
+        # The import connection is dead — use a fresh one to verify state
+        verify_conn = self._connect()
+        with verify_conn.cursor() as cur:
+            cur.execute("SELECT count(*) FROM release")
+            count = cur.fetchone()[0]
+        verify_conn.close()
+
+        # Transaction was rolled back: no rows committed
+        assert count == 0, (
+            f"Expected 0 rows after terminated COPY, got {count}. "
+            "Transaction was not properly rolled back."
+        )
+
+    def test_state_file_not_marked_complete_on_copy_failure(self, tmp_path) -> None:
+        """Pipeline state file does not mark import_csv complete when COPY fails.
+
+        Simulates the pattern used by run_pipeline.py: create a PipelineState,
+        attempt import, and verify the state file reflects the failure.
+        """
+        _apply_schema(self.db_url)
+
+        state = PipelineState(db_url=self.db_url, csv_dir=str(CSV_DIR))
+        state_file = tmp_path / ".pipeline_state.json"
+        state.save(state_file)
+
+        # Create a CSV that will cause COPY to fail — use a non-nullable column
+        # with an empty value that passes the Python filter but violates the DB constraint.
+        # Actually, simpler: try to import into a table that doesn't exist.
+        bad_conn = psycopg.connect(self.db_url)
+        try:
+            # Drop the release table so COPY fails
+            admin = psycopg.connect(self.db_url, autocommit=True)
+            with admin.cursor() as cur:
+                cur.execute("DROP TABLE IF EXISTS release CASCADE")
+            admin.close()
+
+            release_config = next(t for t in BASE_TABLES if t["table"] == "release")
+            try:
+                import_csv_func(
+                    bad_conn,
+                    CSV_DIR / "release.csv",
+                    release_config["table"],
+                    release_config["csv_columns"],
+                    release_config["db_columns"],
+                    release_config["required"],
+                    release_config["transforms"],
+                )
+                # If import somehow succeeded, that's fine — the point is that
+                # mark_completed is NOT called on failure.
+            except Exception:
+                state.mark_failed("import_csv", "COPY failed: table not found")
+                state.save(state_file)
+        finally:
+            bad_conn.close()
+
+        # Reload state and verify import_csv is NOT completed
+        loaded = PipelineState.load(state_file)
+        assert not loaded.is_completed("import_csv"), (
+            "import_csv should not be marked completed after COPY failure"
+        )
+        assert loaded.step_status("import_csv") == "failed"
+
+
+class TestImportResumeAfterConnectionLoss:
+    """Verify that import can be resumed after a connection loss.
+
+    Simulates partial import (only release table), then completes the full
+    import on a second attempt.
+    """
+
+    @pytest.fixture(autouse=True, scope="class")
+    def _set_up_schema(self, db_url):
+        self.__class__._db_url = db_url
+        _apply_schema(db_url)
+
+    @pytest.fixture(autouse=True)
+    def _store_url(self):
+        self.db_url = self.__class__._db_url
+
+    def _connect(self):
+        return psycopg.connect(self.db_url)
+
+    def test_resume_after_partial_import(self) -> None:
+        """After a failed import, re-running imports the remaining tables correctly.
+
+        Simulates: first run imports release only (and "crashes"), second run
+        re-applies schema and imports everything.
+        """
+        _apply_schema(self.db_url)
+
+        # First run: import only the release table
+        conn = psycopg.connect(self.db_url)
+        release_config = next(t for t in BASE_TABLES if t["table"] == "release")
+        import_csv_func(
+            conn,
+            CSV_DIR / "release.csv",
+            release_config["table"],
+            release_config["csv_columns"],
+            release_config["db_columns"],
+            release_config["required"],
+            release_config["transforms"],
+        )
+        conn.close()
+
+        # Verify partial state: releases exist, but no artists
+        verify = self._connect()
+        with verify.cursor() as cur:
+            cur.execute("SELECT count(*) FROM release")
+            release_count = cur.fetchone()[0]
+            cur.execute("SELECT count(*) FROM release_artist")
+            artist_count = cur.fetchone()[0]
+        verify.close()
+        assert release_count > 0
+        assert artist_count == 0
+
+        # Second run: re-apply schema (like the pipeline would on a fresh resume)
+        # and import everything
+        _apply_schema(self.db_url)
+
+        conn = psycopg.connect(self.db_url)
+        for table_config in BASE_TABLES:
+            csv_path = CSV_DIR / table_config["csv_file"]
+            if csv_path.exists():
+                import_csv_func(
+                    conn,
+                    csv_path,
+                    table_config["table"],
+                    table_config["csv_columns"],
+                    table_config["db_columns"],
+                    table_config["required"],
+                    table_config["transforms"],
+                )
+        conn.close()
+
+        # Verify complete state
+        verify = self._connect()
+        with verify.cursor() as cur:
+            cur.execute("SELECT count(*) FROM release")
+            release_count = cur.fetchone()[0]
+            cur.execute("SELECT count(*) FROM release_artist")
+            artist_count = cur.fetchone()[0]
+        verify.close()
+        assert release_count == 15  # 16 rows minus 1 with empty title
+        assert artist_count == 16
+
+    def test_state_file_tracks_resume_correctly(self, tmp_path) -> None:
+        """State file correctly tracks step completion across resume.
+
+        First attempt: create_schema completes, import_csv fails.
+        Second attempt: load state, skip create_schema, import_csv completes.
+        """
+        _apply_schema(self.db_url)
+
+        state = PipelineState(db_url=self.db_url, csv_dir=str(CSV_DIR))
+        state_file = tmp_path / ".pipeline_state.json"
+
+        # First attempt: mark schema complete, fail import
+        state.mark_completed("create_schema")
+        state.mark_failed("import_csv", "Connection terminated during COPY")
+        state.save(state_file)
+
+        # Verify state persisted
+        loaded = PipelineState.load(state_file)
+        assert loaded.is_completed("create_schema")
+        assert not loaded.is_completed("import_csv")
+        assert loaded.step_status("import_csv") == "failed"
+
+        # Second attempt: import succeeds
+        conn = psycopg.connect(self.db_url)
+        total = 0
+        for table_config in BASE_TABLES:
+            csv_path = CSV_DIR / table_config["csv_file"]
+            if csv_path.exists():
+                total += import_csv_func(
+                    conn,
+                    csv_path,
+                    table_config["table"],
+                    table_config["csv_columns"],
+                    table_config["db_columns"],
+                    table_config["required"],
+                    table_config["transforms"],
+                )
+        conn.close()
+
+        # Mark step complete
+        loaded.mark_completed("import_csv")
+        loaded.save(state_file)
+
+        # Verify final state
+        final = PipelineState.load(state_file)
+        assert final.is_completed("create_schema")
+        assert final.is_completed("import_csv")
+        assert total > 0
+
+
+class TestPopulateCacheMetadataConnectionLoss:
+    """Verify populate_cache_metadata COPY is also resilient to connection loss."""
+
+    @pytest.fixture(autouse=True, scope="class")
+    def _set_up(self, db_url):
+        self.__class__._db_url = db_url
+        _apply_schema(db_url)
+        # Insert some releases for cache_metadata to reference
+        conn = psycopg.connect(db_url, autocommit=True)
+        with conn.cursor() as cur:
+            cur.execute("INSERT INTO release (id, title) VALUES (5001, 'DOGA')")
+            cur.execute("INSERT INTO release (id, title) VALUES (5002, 'Aluminum Tunes')")
+            cur.execute("INSERT INTO release (id, title) VALUES (5003, 'Moon Pix')")
+        conn.close()
+
+    @pytest.fixture(autouse=True)
+    def _store_url(self):
+        self.db_url = self.__class__._db_url
+
+    def _connect(self):
+        return psycopg.connect(self.db_url)
+
+    def test_failed_cache_metadata_leaves_table_empty(self) -> None:
+        """If a COPY transaction is terminated before commit, no rows are committed.
+
+        Rather than racing pg_terminate_backend against a fast COPY (only 3 rows),
+        this test verifies the transactional semantics directly: start a COPY
+        inside a transaction, write rows, then terminate the connection before
+        commit. Verifies that the implicit rollback leaves the table empty.
+        """
+        # Clear any existing cache_metadata
+        admin = psycopg.connect(self.db_url, autocommit=True)
+        with admin.cursor() as cur:
+            cur.execute("DELETE FROM cache_metadata")
+        admin.close()
+
+        conn = psycopg.connect(self.db_url)
+        pid = conn.info.backend_pid
+
+        # Write rows via COPY but do NOT commit — then kill the connection
+        with conn.cursor() as cur:
+            with cur.copy("COPY cache_metadata (release_id, source) FROM STDIN") as copy:
+                copy.write_row((5001, "bulk_import"))
+                copy.write_row((5002, "bulk_import"))
+                copy.write_row((5003, "bulk_import"))
+            # COPY block exited successfully, but transaction is NOT committed.
+            # Now terminate the backend from another connection.
+            admin = psycopg.connect(self.db_url, autocommit=True)
+            with admin.cursor() as acur:
+                acur.execute("SELECT pg_terminate_backend(%s)", (pid,))
+            admin.close()
+
+        # The connection is now dead. Any further use would raise OperationalError.
+        try:
+            conn.close()
+        except Exception:
+            pass
+
+        # Verify no partial data was committed (rollback on disconnect)
+        verify = self._connect()
+        with verify.cursor() as cur:
+            cur.execute("SELECT count(*) FROM cache_metadata")
+            count = cur.fetchone()[0]
+        verify.close()
+        assert count == 0, (
+            f"Expected 0 cache_metadata rows after terminated connection, got {count}"
+        )
+
+    def test_retry_after_failure_succeeds(self) -> None:
+        """After a failed populate_cache_metadata, a retry succeeds."""
+        # Clear any existing cache_metadata
+        admin = psycopg.connect(self.db_url, autocommit=True)
+        with admin.cursor() as cur:
+            cur.execute("DELETE FROM cache_metadata")
+        admin.close()
+
+        conn = psycopg.connect(self.db_url)
+        count = populate_cache_metadata(conn)
+        conn.close()
+
+        assert count == 3
+
+        verify = self._connect()
+        with verify.cursor() as cur:
+            cur.execute("SELECT count(*) FROM cache_metadata")
+            db_count = cur.fetchone()[0]
+        verify.close()
+        assert db_count == 3

--- a/tests/integration/test_dedup.py
+++ b/tests/integration/test_dedup.py
@@ -1042,3 +1042,205 @@ class TestFormatAwareDedup:
         # Release 5 (UK, NULL format) should be deleted — groups with release 4 (US, NULL format)
         assert 5 in deleted
         assert 4 not in deleted
+
+
+class TestDedupCopySwapAbortCleanup:
+    """Verify that abandoned temp tables from a failed copy-swap are cleaned up.
+
+    Simulates a scenario where a previous dedup run created new_* tables
+    (the copy phase) but crashed before completing the swap. On the next run,
+    copy_table() drops any pre-existing new_* table before recreating it.
+    """
+
+    @pytest.fixture(autouse=True, scope="class")
+    def _set_up(self, db_url):
+        self.__class__._db_url = db_url
+        conn = psycopg.connect(db_url, autocommit=True)
+        _drop_all_tables(conn)
+        with conn.cursor() as cur:
+            cur.execute(SCHEMA_DIR.joinpath("create_database.sql").read_text())
+            # Two releases with same master_id — triggers dedup
+            cur.execute(
+                "INSERT INTO release (id, title, master_id, country) "
+                "VALUES (1, 'DOGA', 100, 'AR')"
+            )
+            cur.execute(
+                "INSERT INTO release (id, title, master_id, country) "
+                "VALUES (2, 'DOGA', 100, 'US')"
+            )
+            cur.execute(
+                "INSERT INTO release_artist (release_id, artist_name) "
+                "VALUES (1, 'Juana Molina')"
+            )
+            cur.execute(
+                "INSERT INTO release_artist (release_id, artist_name) "
+                "VALUES (2, 'Juana Molina')"
+            )
+            cur.execute(
+                "INSERT INTO cache_metadata (release_id, source) "
+                "VALUES (1, 'bulk_import')"
+            )
+            cur.execute(
+                "INSERT INTO cache_metadata (release_id, source) "
+                "VALUES (2, 'bulk_import')"
+            )
+            # Track counts for ranking
+            cur.execute("""
+                CREATE UNLOGGED TABLE release_track_count (
+                    release_id integer PRIMARY KEY,
+                    track_count integer NOT NULL
+                )
+            """)
+            cur.execute("INSERT INTO release_track_count VALUES (1, 3), (2, 5)")
+            # Simulate a previous failed run: leave a dangling new_release table
+            cur.execute(
+                "CREATE TABLE new_release AS SELECT * FROM release WHERE false"
+            )
+            cur.execute(
+                "INSERT INTO new_release (id, title, master_id, country) "
+                "VALUES (999, 'Stale Ghost Row', 999, 'XX')"
+            )
+        conn.close()
+
+    @pytest.fixture(autouse=True)
+    def _store_url(self):
+        self.db_url = self.__class__._db_url
+
+    def _connect(self):
+        return psycopg.connect(self.db_url)
+
+    def test_dangling_new_table_exists_before_dedup(self) -> None:
+        """Precondition: new_release from a failed previous run exists."""
+        conn = self._connect()
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT EXISTS ("
+                "  SELECT 1 FROM information_schema.tables "
+                "  WHERE table_name = 'new_release'"
+                ")"
+            )
+            exists = cur.fetchone()[0]
+        conn.close()
+        assert exists, "new_release should exist as a leftover from a failed run"
+
+    def test_copy_table_replaces_dangling_table(self) -> None:
+        """copy_table() drops the stale new_release and creates a fresh one.
+
+        This verifies that copy_table's `DROP TABLE IF EXISTS new_table`
+        handles cleanup of abandoned temp tables from prior failed runs.
+        """
+        conn = psycopg.connect(self.db_url, autocommit=True)
+        ensure_dedup_ids(conn)
+
+        # copy_table drops the stale new_release and creates a fresh one
+        count = copy_table(
+            conn,
+            "release",
+            "new_release",
+            "id, title, release_year, country, artwork_url, released, format",
+            "id",
+        )
+
+        # The stale ghost row (id=999) should be gone — new_release is rebuilt
+        with conn.cursor() as cur:
+            cur.execute("SELECT count(*) FROM new_release WHERE id = 999")
+            ghost_count = cur.fetchone()[0]
+            cur.execute("SELECT count(*) FROM new_release")
+            total = cur.fetchone()[0]
+        conn.close()
+
+        assert ghost_count == 0, "Stale ghost row should not survive copy_table"
+        assert total == count
+        # Only the US release (id=2) survives dedup (US preference)
+        assert count == 1
+
+    def test_full_dedup_succeeds_despite_dangling_tables(self) -> None:
+        """A complete dedup cycle succeeds even with leftover new_* tables.
+
+        Re-runs the full dedup pipeline from scratch, verifying it handles
+        cleanup of any leftover artifacts from the prior test methods.
+        """
+        # Re-create a clean state with dedup-worthy data
+        conn = psycopg.connect(self.db_url, autocommit=True)
+        _drop_all_tables(conn)
+        # Also drop any leftover new_* tables from the prior test method
+        with conn.cursor() as cur:
+            for table in ALL_TABLES:
+                cur.execute(f"DROP TABLE IF EXISTS new_{table} CASCADE")
+        with conn.cursor() as cur:
+            cur.execute(SCHEMA_DIR.joinpath("create_database.sql").read_text())
+            cur.execute(SCHEMA_DIR.joinpath("create_functions.sql").read_text())
+            cur.execute(
+                "INSERT INTO release (id, title, master_id, country) "
+                "VALUES (1, 'Aluminum Tunes', 100, 'UK')"
+            )
+            cur.execute(
+                "INSERT INTO release (id, title, master_id, country) "
+                "VALUES (2, 'Aluminum Tunes', 100, 'US')"
+            )
+            cur.execute(
+                "INSERT INTO release_artist (release_id, artist_name) "
+                "VALUES (1, 'Stereolab')"
+            )
+            cur.execute(
+                "INSERT INTO release_artist (release_id, artist_name) "
+                "VALUES (2, 'Stereolab')"
+            )
+            cur.execute(
+                "INSERT INTO release_label (release_id, label_name) "
+                "VALUES (1, 'Duophonic')"
+            )
+            cur.execute(
+                "INSERT INTO release_label (release_id, label_name) "
+                "VALUES (2, 'Duophonic')"
+            )
+            cur.execute(
+                "INSERT INTO cache_metadata (release_id, source) "
+                "VALUES (1, 'bulk_import')"
+            )
+            cur.execute(
+                "INSERT INTO cache_metadata (release_id, source) "
+                "VALUES (2, 'bulk_import')"
+            )
+            cur.execute("""
+                CREATE UNLOGGED TABLE release_track_count (
+                    release_id integer PRIMARY KEY,
+                    track_count integer NOT NULL
+                )
+            """)
+            cur.execute("INSERT INTO release_track_count VALUES (1, 5), (2, 3)")
+            # Leave a dangling new_release from a "crashed" previous run
+            cur.execute(
+                "CREATE TABLE new_release (id integer, title text)"
+            )
+            cur.execute("INSERT INTO new_release VALUES (999, 'Ghost')")
+        conn.close()
+
+        # Run the full dedup pipeline
+        _run_dedup(self.db_url)
+
+        # Verify the final state
+        conn = psycopg.connect(self.db_url)
+        with conn.cursor() as cur:
+            # Only US release survives
+            cur.execute("SELECT id FROM release ORDER BY id")
+            ids = [row[0] for row in cur.fetchall()]
+            # No dangling new_* or *_old tables
+            cur.execute(
+                "SELECT table_name FROM information_schema.tables "
+                "WHERE table_name LIKE 'new_%' OR table_name LIKE '%_old'"
+            )
+            dangling = [row[0] for row in cur.fetchall()]
+            # dedup_delete_ids should be cleaned up
+            cur.execute(
+                "SELECT EXISTS ("
+                "  SELECT 1 FROM information_schema.tables "
+                "  WHERE table_name = 'dedup_delete_ids'"
+                ")"
+            )
+            dedup_exists = cur.fetchone()[0]
+        conn.close()
+
+        assert ids == [2], f"Only US release should survive dedup, got {ids}"
+        assert dangling == [], f"No dangling temp tables should remain: {dangling}"
+        assert not dedup_exists, "dedup_delete_ids should be cleaned up"

--- a/tests/integration/test_dedup.py
+++ b/tests/integration/test_dedup.py
@@ -1061,29 +1061,19 @@ class TestDedupCopySwapAbortCleanup:
             cur.execute(SCHEMA_DIR.joinpath("create_database.sql").read_text())
             # Two releases with same master_id — triggers dedup
             cur.execute(
-                "INSERT INTO release (id, title, master_id, country) "
-                "VALUES (1, 'DOGA', 100, 'AR')"
+                "INSERT INTO release (id, title, master_id, country) VALUES (1, 'DOGA', 100, 'AR')"
             )
             cur.execute(
-                "INSERT INTO release (id, title, master_id, country) "
-                "VALUES (2, 'DOGA', 100, 'US')"
+                "INSERT INTO release (id, title, master_id, country) VALUES (2, 'DOGA', 100, 'US')"
             )
             cur.execute(
-                "INSERT INTO release_artist (release_id, artist_name) "
-                "VALUES (1, 'Juana Molina')"
+                "INSERT INTO release_artist (release_id, artist_name) VALUES (1, 'Juana Molina')"
             )
             cur.execute(
-                "INSERT INTO release_artist (release_id, artist_name) "
-                "VALUES (2, 'Juana Molina')"
+                "INSERT INTO release_artist (release_id, artist_name) VALUES (2, 'Juana Molina')"
             )
-            cur.execute(
-                "INSERT INTO cache_metadata (release_id, source) "
-                "VALUES (1, 'bulk_import')"
-            )
-            cur.execute(
-                "INSERT INTO cache_metadata (release_id, source) "
-                "VALUES (2, 'bulk_import')"
-            )
+            cur.execute("INSERT INTO cache_metadata (release_id, source) VALUES (1, 'bulk_import')")
+            cur.execute("INSERT INTO cache_metadata (release_id, source) VALUES (2, 'bulk_import')")
             # Track counts for ranking
             cur.execute("""
                 CREATE UNLOGGED TABLE release_track_count (
@@ -1093,9 +1083,7 @@ class TestDedupCopySwapAbortCleanup:
             """)
             cur.execute("INSERT INTO release_track_count VALUES (1, 3), (2, 5)")
             # Simulate a previous failed run: leave a dangling new_release table
-            cur.execute(
-                "CREATE TABLE new_release AS SELECT * FROM release WHERE false"
-            )
+            cur.execute("CREATE TABLE new_release AS SELECT * FROM release WHERE false")
             cur.execute(
                 "INSERT INTO new_release (id, title, master_id, country) "
                 "VALUES (999, 'Stale Ghost Row', 999, 'XX')"
@@ -1179,29 +1167,19 @@ class TestDedupCopySwapAbortCleanup:
                 "VALUES (2, 'Aluminum Tunes', 100, 'US')"
             )
             cur.execute(
-                "INSERT INTO release_artist (release_id, artist_name) "
-                "VALUES (1, 'Stereolab')"
+                "INSERT INTO release_artist (release_id, artist_name) VALUES (1, 'Stereolab')"
             )
             cur.execute(
-                "INSERT INTO release_artist (release_id, artist_name) "
-                "VALUES (2, 'Stereolab')"
+                "INSERT INTO release_artist (release_id, artist_name) VALUES (2, 'Stereolab')"
             )
             cur.execute(
-                "INSERT INTO release_label (release_id, label_name) "
-                "VALUES (1, 'Duophonic')"
+                "INSERT INTO release_label (release_id, label_name) VALUES (1, 'Duophonic')"
             )
             cur.execute(
-                "INSERT INTO release_label (release_id, label_name) "
-                "VALUES (2, 'Duophonic')"
+                "INSERT INTO release_label (release_id, label_name) VALUES (2, 'Duophonic')"
             )
-            cur.execute(
-                "INSERT INTO cache_metadata (release_id, source) "
-                "VALUES (1, 'bulk_import')"
-            )
-            cur.execute(
-                "INSERT INTO cache_metadata (release_id, source) "
-                "VALUES (2, 'bulk_import')"
-            )
+            cur.execute("INSERT INTO cache_metadata (release_id, source) VALUES (1, 'bulk_import')")
+            cur.execute("INSERT INTO cache_metadata (release_id, source) VALUES (2, 'bulk_import')")
             cur.execute("""
                 CREATE UNLOGGED TABLE release_track_count (
                     release_id integer PRIMARY KEY,
@@ -1210,9 +1188,7 @@ class TestDedupCopySwapAbortCleanup:
             """)
             cur.execute("INSERT INTO release_track_count VALUES (1, 5), (2, 3)")
             # Leave a dangling new_release from a "crashed" previous run
-            cur.execute(
-                "CREATE TABLE new_release (id integer, title text)"
-            )
+            cur.execute("CREATE TABLE new_release (id integer, title text)")
             cur.execute("INSERT INTO new_release VALUES (999, 'Ghost')")
         conn.close()
 

--- a/tests/integration/test_verify_cache.py
+++ b/tests/integration/test_verify_cache.py
@@ -1,18 +1,25 @@
 """Integration tests for verify_cache multi-index matching against real library.db."""
 
 import importlib.util
+import multiprocessing
 import os
 import subprocess
 import sys
+import time
+from concurrent.futures import ProcessPoolExecutor
+from concurrent.futures import TimeoutError as FuturesTimeoutError
 from pathlib import Path
 
 import pytest
 
-# Load verify_cache module from scripts directory
+# Load verify_cache module from scripts directory.
+# Must register in sys.modules BEFORE exec_module so that @dataclass can resolve
+# the module's __dict__ (Python looks up cls.__module__ in sys.modules).
 _SCRIPT_PATH = Path(__file__).parent.parent.parent / "scripts" / "verify_cache.py"
 _spec = importlib.util.spec_from_file_location("verify_cache", _SCRIPT_PATH)
 assert _spec is not None and _spec.loader is not None
 _vc = importlib.util.module_from_spec(_spec)
+sys.modules["verify_cache"] = _vc
 _spec.loader.exec_module(_vc)
 
 LibraryIndex = _vc.LibraryIndex
@@ -21,6 +28,10 @@ Decision = _vc.Decision
 normalize_artist = _vc.normalize_artist
 normalize_title = _vc.normalize_title
 classify_compilation = _vc.classify_compilation
+classify_fuzzy_batch = _vc.classify_fuzzy_batch
+classify_all_releases = _vc.classify_all_releases
+_init_fuzzy_worker = _vc._init_fuzzy_worker
+_classify_fuzzy_chunk = _vc._classify_fuzzy_chunk
 
 # Allow overriding library.db path via LIBRARY_DB env var
 LIBRARY_DB = Path(os.environ.get("LIBRARY_DB", Path(__file__).parent.parent.parent / "library.db"))
@@ -157,3 +168,209 @@ class TestVerifyCacheE2E:
             text=True,
         )
         assert result.returncode != 0
+
+
+# ---------------------------------------------------------------------------
+# Top-level helper for ProcessPoolExecutor timeout tests.
+# Must be defined at module level (not inside a class) so it can be pickled
+# for use with multiprocessing's fork/spawn contexts.
+# ---------------------------------------------------------------------------
+
+
+def _slow_classify_chunk(chunk_args):
+    """Worker that simulates a slow fuzzy matching operation.
+
+    Sleeps for 3 seconds, which is long enough to trigger a short timeout
+    but short enough that the worker process exits naturally, avoiding
+    zombie processes in the test runner.
+    """
+    time.sleep(3)
+    return set(), set(), set(), {}
+
+
+def _fast_classify_chunk(chunk_args):
+    """Worker that completes immediately for the non-hanging chunk."""
+    artists, chunk_by_artist = chunk_args
+    keep = set()
+    prune = set()
+    for artist in artists:
+        for release_id, _, _ in chunk_by_artist[artist]:
+            prune.add(release_id)
+    return keep, prune, set(), {}
+
+
+class TestProcessPoolExecutorTimeout:
+    """Verify that ProcessPoolExecutor futures can be timed out gracefully.
+
+    The current classify_all_releases() calls future.result() without a timeout,
+    which means a single hung worker stalls the entire pipeline. These tests
+    verify that the timeout mechanism (future.result(timeout=N)) works correctly
+    and that timed-out results can be safely skipped.
+
+    Uses a 3-second sleep (not an infinite hang) so worker processes exit
+    naturally and don't leak across test runs.
+    """
+
+    def _build_small_index(self):
+        """Build a minimal LibraryIndex for testing."""
+        rows = [
+            ("Juana Molina", "DOGA"),
+            ("Stereolab", "Aluminum Tunes"),
+            ("Cat Power", "Moon Pix"),
+            ("Jessica Pratt", "On Your Own Love Again"),
+            ("Chuquimamani-Condori", "Edits"),
+            ("Duke Ellington", "Duke Ellington & John Coltrane"),
+        ]
+        return LibraryIndex.from_rows(rows)
+
+    def test_future_result_timeout_raises(self) -> None:
+        """future.result(timeout=N) raises TimeoutError when worker is slow.
+
+        Submits a worker that sleeps for 3 seconds to a ProcessPoolExecutor,
+        then calls future.result(timeout=0.2). Verifies TimeoutError is raised.
+        The worker completes on its own after 3s so no process leak occurs.
+        """
+        ctx = multiprocessing.get_context("fork")
+        executor = ProcessPoolExecutor(max_workers=1, mp_context=ctx)
+        future = executor.submit(
+            _slow_classify_chunk,
+            (["fake_artist"], {"fake_artist": [(1, "Fake", "Fake Album")]}),
+        )
+        with pytest.raises(FuturesTimeoutError):
+            future.result(timeout=0.2)
+
+        # Let the worker finish naturally so the process pool can clean up
+        future.result(timeout=10)
+        executor.shutdown(wait=True)
+
+    def test_mixed_fast_and_slow_workers(self) -> None:
+        """When one chunk is slow but others complete, completed results are available.
+
+        Submits two chunks: one fast (completes immediately) and one slow (3s).
+        Verifies that the fast chunk's results are collected before the timeout
+        fires on the slow chunk, demonstrating that partial results can be
+        harvested even when some workers are stalled.
+        """
+        fast_chunk_artists = [normalize_artist("Sessa")]
+        fast_chunk_by_artist = {
+            normalize_artist("Sessa"): [
+                (101, "Sessa", "Pequena Vertigem"),
+            ]
+        }
+
+        ctx = multiprocessing.get_context("fork")
+        executor = ProcessPoolExecutor(max_workers=2, mp_context=ctx)
+        fast_future = executor.submit(
+            _fast_classify_chunk,
+            (fast_chunk_artists, fast_chunk_by_artist),
+        )
+        slow_future = executor.submit(
+            _slow_classify_chunk,
+            (["slow_artist"], {"slow_artist": [(999, "Slow", "Slow Album")]}),
+        )
+
+        # Fast future should complete quickly
+        fast_keep, fast_prune, fast_review, fast_review_by = fast_future.result(timeout=5)
+        assert 101 in fast_prune  # Sessa not in our small index
+
+        # Slow future should time out with a short deadline
+        with pytest.raises(FuturesTimeoutError):
+            slow_future.result(timeout=0.2)
+
+        # But it does complete eventually (after 3s)
+        slow_keep, slow_prune, slow_review, slow_review_by = slow_future.result(timeout=10)
+        assert slow_keep == set()
+        assert slow_prune == set()
+
+        executor.shutdown(wait=True)
+
+    def test_timed_out_futures_do_not_corrupt_results(self) -> None:
+        """Results from timed-out futures are not included in the final aggregation.
+
+        Demonstrates the pattern for graceful timeout handling: iterate futures
+        with as_completed(), apply a per-future timeout, and skip any that
+        exceed the deadline. This is the pattern verify_cache.py should adopt.
+        """
+        from concurrent.futures import as_completed
+
+        ctx = multiprocessing.get_context("fork")
+        executor = ProcessPoolExecutor(max_workers=2, mp_context=ctx)
+
+        fast_artists = [normalize_artist("Anne Gillis")]
+        fast_by_artist = {
+            normalize_artist("Anne Gillis"): [
+                (201, "Anne Gillis", "Round & Round & Round"),
+            ]
+        }
+
+        futures = {}
+        futures[executor.submit(_fast_classify_chunk, (fast_artists, fast_by_artist))] = "fast"
+        futures[executor.submit(
+            _slow_classify_chunk,
+            (["slow"], {"slow": [(999, "X", "Y")]}),
+        )] = "slow"
+
+        collected_prune = set()
+        timed_out_chunks = []
+
+        for future in as_completed(futures, timeout=5):
+            chunk_name = futures[future]
+            try:
+                keep, prune, review, review_by = future.result(timeout=0.3)
+                collected_prune |= prune
+            except FuturesTimeoutError:
+                timed_out_chunks.append(chunk_name)
+
+        # Fast chunk was collected; slow chunk may or may not have timed out
+        # depending on completion order. The key assertion is that only
+        # successfully completed results are in collected_prune.
+        assert 201 in collected_prune, "Fast chunk results should be collected"
+        assert 999 not in collected_prune, "Slow chunk should not contribute results"
+
+        # Wait for slow worker to finish naturally
+        for future in futures:
+            try:
+                future.result(timeout=10)
+            except Exception:
+                pass
+        executor.shutdown(wait=True)
+
+    def test_classify_fuzzy_batch_completes_normally(self) -> None:
+        """classify_fuzzy_batch returns correct results for WXYC example artists.
+
+        Verifies that the batch classification function works correctly with
+        a small index, serving as a baseline for the timeout tests above.
+        """
+        index = self._build_small_index()
+        matcher = MultiIndexMatcher(index)
+
+        # Exact match artist with exact match title
+        artists = [normalize_artist("Juana Molina")]
+        by_artist = {
+            normalize_artist("Juana Molina"): [
+                (5001, "Juana Molina", "DOGA"),
+            ]
+        }
+
+        keep, prune, review, review_by = classify_fuzzy_batch(
+            artists, by_artist, index, matcher
+        )
+        assert 5001 in keep, "Exact match should be KEEP"
+
+    def test_classify_fuzzy_batch_prunes_unknown(self) -> None:
+        """Unknown artists are classified as PRUNE by fuzzy batch."""
+        index = self._build_small_index()
+        matcher = MultiIndexMatcher(index)
+
+        artists = [normalize_artist("Completely Unknown Band")]
+        by_artist = {
+            normalize_artist("Completely Unknown Band"): [
+                (9999, "Completely Unknown Band", "Nonexistent Album"),
+            ]
+        }
+
+        keep, prune, review, review_by = classify_fuzzy_batch(
+            artists, by_artist, index, matcher
+        )
+        assert 9999 in prune, "Unknown artist should be PRUNE"
+        assert 9999 not in keep

--- a/tests/integration/test_verify_cache.py
+++ b/tests/integration/test_verify_cache.py
@@ -305,10 +305,12 @@ class TestProcessPoolExecutorTimeout:
 
         futures = {}
         futures[executor.submit(_fast_classify_chunk, (fast_artists, fast_by_artist))] = "fast"
-        futures[executor.submit(
-            _slow_classify_chunk,
-            (["slow"], {"slow": [(999, "X", "Y")]}),
-        )] = "slow"
+        futures[
+            executor.submit(
+                _slow_classify_chunk,
+                (["slow"], {"slow": [(999, "X", "Y")]}),
+            )
+        ] = "slow"
 
         collected_prune = set()
         timed_out_chunks = []
@@ -352,9 +354,7 @@ class TestProcessPoolExecutorTimeout:
             ]
         }
 
-        keep, prune, review, review_by = classify_fuzzy_batch(
-            artists, by_artist, index, matcher
-        )
+        keep, prune, review, review_by = classify_fuzzy_batch(artists, by_artist, index, matcher)
         assert 5001 in keep, "Exact match should be KEEP"
 
     def test_classify_fuzzy_batch_prunes_unknown(self) -> None:
@@ -369,8 +369,6 @@ class TestProcessPoolExecutorTimeout:
             ]
         }
 
-        keep, prune, review, review_by = classify_fuzzy_batch(
-            artists, by_artist, index, matcher
-        )
+        keep, prune, review, review_by = classify_fuzzy_batch(artists, by_artist, index, matcher)
         assert 9999 in prune, "Unknown artist should be PRUNE"
         assert 9999 not in keep


### PR DESCRIPTION
## Summary

- **`tests/integration/test_connection_resilience.py`** (`@pytest.mark.postgres`): Tests PG COPY with simulated network failure using `pg_terminate_backend()` via `pg_stat_activity` polling, verifying transaction rollback on connection loss. Tests pipeline state file does not mark step complete on COPY failure. Tests import resume after connection loss with state file tracking across attempts.
- **`tests/integration/test_dedup.py`**: Adds `TestDedupCopySwapAbortCleanup` class verifying that dangling `new_*` temp tables from a crashed previous dedup run are cleaned up by `copy_table()`'s `DROP TABLE IF EXISTS`, and that a full dedup cycle succeeds despite leftover artifacts.
- **`tests/integration/test_verify_cache.py`**: Adds `TestProcessPoolExecutorTimeout` class verifying that `ProcessPoolExecutor` `future.result(timeout=N)` raises `TimeoutError` for slow workers, that fast workers' results are harvestable while slow workers are still running, and that timed-out futures don't corrupt aggregated results. Also fixes a pre-existing bug where the file failed to register `verify_cache` in `sys.modules` before `exec_module`, causing `@dataclass` resolution failures when the file was collected independently of the unit test suite.

All test data uses WXYC canonical artists (Juana Molina, Stereolab, Cat Power, Sessa, Anne Gillis, etc.).

Closes WXYC/discogs-cache#77

## Test plan

- [ ] `DATABASE_URL_TEST=postgresql://discogs:discogs@localhost:5433/postgres pytest -m postgres tests/integration/test_connection_resilience.py -v` (6 tests)
- [ ] `DATABASE_URL_TEST=postgresql://discogs:discogs@localhost:5433/postgres pytest -m postgres tests/integration/test_dedup.py::TestDedupCopySwapAbortCleanup -v` (3 tests)
- [ ] `pytest tests/integration/test_verify_cache.py::TestProcessPoolExecutorTimeout -v` (5 tests, no PG required)
- [ ] `pytest tests/unit/ -v` (519 tests, no regressions)