### PR TITLE
Add release_video table and import pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
           cd /tmp/wxyc-etl/wxyc-etl-python && maturin build --release && pip install /tmp/wxyc-etl/target/wheels/*.whl
       - name: Install wxyc-catalog from git
         run: |
-          git clone --depth 1 --branch etl-unification/3c-wxyc-catalog https://github.com/WXYC/wxyc-catalog.git /tmp/wxyc-catalog
+          git clone --depth 1 --branch main https://github.com/WXYC/wxyc-catalog.git /tmp/wxyc-catalog
           cd /tmp/wxyc-catalog && sed -i 's|setuptools.backends._legacy:_Backend|setuptools.build_meta|' pyproject.toml && pip install -e .
       - run: pip install -e ".[dev]"
       - run: pytest tests/unit/ -v
@@ -67,7 +67,7 @@ jobs:
           cd /tmp/wxyc-etl/wxyc-etl-python && maturin build --release && pip install /tmp/wxyc-etl/target/wheels/*.whl
       - name: Install wxyc-catalog from git
         run: |
-          git clone --depth 1 --branch etl-unification/3c-wxyc-catalog https://github.com/WXYC/wxyc-catalog.git /tmp/wxyc-catalog
+          git clone --depth 1 --branch main https://github.com/WXYC/wxyc-catalog.git /tmp/wxyc-catalog
           cd /tmp/wxyc-catalog && sed -i 's|setuptools.backends._legacy:_Backend|setuptools.build_meta|' pyproject.toml && pip install -e .
       - run: pip install -e ".[dev]" pytest-cov
       - name: Enable pg_trgm extension

--- a/schema/create_database.sql
+++ b/schema/create_database.sql
@@ -27,6 +27,7 @@ DROP TABLE IF EXISTS artist_member CASCADE;
 DROP TABLE IF EXISTS artist_name_variation CASCADE;
 DROP TABLE IF EXISTS artist_alias CASCADE;
 DROP TABLE IF EXISTS artist CASCADE;
+DROP TABLE IF EXISTS release_video CASCADE;
 DROP TABLE IF EXISTS release_track_artist CASCADE;
 DROP TABLE IF EXISTS release_track CASCADE;
 DROP TABLE IF EXISTS release_label CASCADE;
@@ -69,6 +70,16 @@ CREATE TABLE release_track (
     position        text,              -- "A1", "B2", etc.
     title           text NOT NULL,
     duration        text
+);
+
+-- Videos on releases
+CREATE TABLE release_video (
+    release_id integer NOT NULL REFERENCES release(id) ON DELETE CASCADE,
+    sequence   integer NOT NULL,
+    src        text NOT NULL,
+    title      text,
+    duration   integer,
+    embed      boolean DEFAULT true
 );
 
 -- Artists on specific tracks (for compilations)
@@ -133,6 +144,7 @@ CREATE INDEX IF NOT EXISTS idx_release_artist_release_id ON release_artist(relea
 CREATE INDEX IF NOT EXISTS idx_release_label_release_id ON release_label(release_id);
 CREATE INDEX IF NOT EXISTS idx_release_track_release_id ON release_track(release_id);
 CREATE INDEX IF NOT EXISTS idx_release_track_artist_release_id ON release_track_artist(release_id);
+CREATE INDEX IF NOT EXISTS idx_release_video_release_id ON release_video(release_id);
 
 -- Artist detail indexes
 CREATE INDEX IF NOT EXISTS idx_artist_alias_artist_id ON artist_alias(artist_id);

--- a/scripts/import_csv.py
+++ b/scripts/import_csv.py
@@ -136,6 +136,18 @@ TRACK_TABLES: list[TableConfig] = [
     },
 ]
 
+VIDEO_TABLES: list[TableConfig] = [
+    {
+        "csv_file": "release_video.csv",
+        "table": "release_video",
+        "csv_columns": ["release_id", "sequence", "src", "title", "duration", "embed"],
+        "db_columns": ["release_id", "sequence", "src", "title", "duration", "embed"],
+        "required": ["release_id", "src"],
+        "transforms": {},
+        "unique_key": ["release_id", "sequence"],
+    },
+]
+
 ARTIST_TABLES: list[TableConfig] = [
     {
         "csv_file": "artist_alias.csv",
@@ -157,7 +169,7 @@ ARTIST_TABLES: list[TableConfig] = [
     },
 ]
 
-TABLES: list[TableConfig] = BASE_TABLES + TRACK_TABLES
+TABLES: list[TableConfig] = BASE_TABLES + TRACK_TABLES + VIDEO_TABLES
 
 
 def import_csv(
@@ -654,12 +666,12 @@ def main():
             release_ids = {row[0] for row in cur.fetchall()}
         conn.close()
         logger.info(f"Filtering tracks to {len(release_ids):,} surviving releases")
-        # release_track and release_track_artist are independent — import in parallel
+        # release_track, release_track_artist, and release_video are independent — import in parallel
         total = _import_tables_parallel(
             db_url,
             csv_dir,
             parent_tables=[],
-            child_tables=TRACK_TABLES,
+            child_tables=TRACK_TABLES + VIDEO_TABLES,
             release_id_filter=release_ids,
         )
     elif args.base_only:

--- a/tests/e2e/test_pipeline.py
+++ b/tests/e2e/test_pipeline.py
@@ -115,6 +115,7 @@ class TestPipeline:
             "release_artist",
             "release_label",
             "release_track",
+            "release_video",
             "cache_metadata",
         ):
             with conn.cursor() as cur:
@@ -239,6 +240,7 @@ class TestPipeline:
             "release_label",
             "release_track",
             "release_track_artist",
+            "release_video",
             "cache_metadata",
         }
         assert expected.issubset(fk_tables)
@@ -252,6 +254,45 @@ class TestPipeline:
         conn.close()
         assert count == 0
 
+    def test_release_video_table_populated(self) -> None:
+        """release_video has rows after pipeline completes."""
+        conn = self._connect()
+        with conn.cursor() as cur:
+            cur.execute("SELECT count(*) FROM release_video")
+            count = cur.fetchone()[0]
+        conn.close()
+        assert count > 0, "release_video should have rows after pipeline"
+
+    def test_release_video_surviving_release(self) -> None:
+        """Videos for a surviving release (3001) are present after prune."""
+        conn = self._connect()
+        with conn.cursor() as cur:
+            cur.execute("SELECT count(*) FROM release_video WHERE release_id = 3001")
+            count = cur.fetchone()[0]
+        conn.close()
+        assert count == 1, "Release 3001 (Kid A) should have its video after pipeline"
+
+    def test_release_video_cascade_delete_on_prune(self) -> None:
+        """Videos for pruned release 5001 are removed via ON DELETE CASCADE."""
+        conn = self._connect()
+        with conn.cursor() as cur:
+            cur.execute("SELECT count(*) FROM release_video WHERE release_id = 5001")
+            count = cur.fetchone()[0]
+        conn.close()
+        assert count == 0, "Release 5001 was pruned; its videos should be gone"
+
+    def test_release_video_fk_constraint(self) -> None:
+        """release_video has a FK constraint referencing release."""
+        conn = self._connect()
+        with conn.cursor() as cur:
+            cur.execute("""
+                SELECT count(*) FROM information_schema.table_constraints
+                WHERE table_name = 'release_video' AND constraint_type = 'FOREIGN KEY'
+            """)
+            count = cur.fetchone()[0]
+        conn.close()
+        assert count >= 1, "release_video should have a FK constraint"
+
     def test_tables_are_logged(self) -> None:
         """All tables are LOGGED after pipeline completion (not UNLOGGED)."""
         conn = self._connect()
@@ -261,7 +302,7 @@ class TestPipeline:
                 FROM pg_class
                 WHERE relname IN (
                     'release', 'release_artist', 'release_label',
-                    'release_track', 'release_track_artist', 'cache_metadata'
+                    'release_track', 'release_track_artist', 'release_video', 'cache_metadata'
                 )
             """)
             results = cur.fetchall()
@@ -556,6 +597,7 @@ class TestPipelineWithCopyTo:
             "release_artist",
             "release_label",
             "release_track",
+            "release_video",
             "cache_metadata",
         ):
             with conn.cursor() as cur:
@@ -563,6 +605,25 @@ class TestPipelineWithCopyTo:
                 count = cur.fetchone()[0]
             assert count > 0, f"Table {table} is empty in target"
         conn.close()
+
+    def test_target_has_videos_for_matched_release(self) -> None:
+        """Videos for matched releases are copied to the target database."""
+        conn = psycopg.connect(self.target_url)
+        with conn.cursor() as cur:
+            # Release 3001 (Kid A) should be in target with its video
+            cur.execute("SELECT count(*) FROM release_video WHERE release_id = 3001")
+            count = cur.fetchone()[0]
+        conn.close()
+        assert count == 1, "Release 3001 (Kid A) should have its video in target"
+
+    def test_target_pruned_release_has_no_videos(self) -> None:
+        """Videos for pruned releases are not in the target database."""
+        conn = psycopg.connect(self.target_url)
+        with conn.cursor() as cur:
+            cur.execute("SELECT count(*) FROM release_video WHERE release_id = 10001")
+            count = cur.fetchone()[0]
+        conn.close()
+        assert count == 0, "Pruned release 10001 should have no videos in target"
 
     def _count_releases(self, db_url: str) -> int:
         conn = psycopg.connect(db_url)

--- a/tests/fixtures/create_fixtures.py
+++ b/tests/fixtures/create_fixtures.py
@@ -232,6 +232,37 @@ def create_release_label_csv() -> None:
     write_csv("release_label.csv", headers, rows)
 
 
+def create_release_video_csv() -> None:
+    """Create release_video.csv with video entries for various releases.
+
+    Includes:
+    - Multiple videos for one release (1001: 2 videos)
+    - embed=false (2001: one video without embed)
+    - Missing duration (5001: empty duration → NULL)
+    - A release that will be pruned (5001: Unknown Album, not in library)
+    """
+    headers = ["release_id", "sequence", "src", "title", "duration", "embed"]
+    rows = [
+        # OK Computer UK CD (1001) — survives pipeline prune
+        [1001, 1, "https://www.youtube.com/watch?v=abcdef01", "Airbag", 284, "true"],
+        [1001, 2, "https://www.youtube.com/watch?v=abcdef02", "Paranoid Android", 383, "true"],
+        # Unknown Pleasures UK LP (2001) — survives pipeline prune; embed=false
+        [2001, 1, "https://www.youtube.com/watch?v=uvwxyz01", "Disorder", 209, "false"],
+        # Kid A (3001) — survives pipeline prune
+        [
+            3001,
+            1,
+            "https://www.youtube.com/watch?v=ghijkl01",
+            "Everything In Its Right Place",
+            251,
+            "true",
+        ],
+        # Unknown Album (5001) — pruned; empty duration
+        [5001, 1, "https://www.youtube.com/watch?v=mnopqr01", "Unknown Track", "", "true"],
+    ]
+    write_csv("release_video.csv", headers, rows)
+
+
 def create_release_image_csv() -> None:
     """Create release_image.csv for artwork URL testing."""
     headers = ["release_id", "type", "width", "height", "uri"]
@@ -390,6 +421,7 @@ def main() -> None:
     create_release_track_csv()
     create_release_track_artist_csv()
     create_release_label_csv()
+    create_release_video_csv()
     create_release_image_csv()
     create_library_labels_csv()
     create_label_hierarchy_csv()

--- a/tests/fixtures/csv/release_video.csv
+++ b/tests/fixtures/csv/release_video.csv
@@ -1,0 +1,6 @@
+release_id,sequence,src,title,duration,embed
+1001,1,https://www.youtube.com/watch?v=abcdef01,Airbag,284,true
+1001,2,https://www.youtube.com/watch?v=abcdef02,Paranoid Android,383,true
+2001,1,https://www.youtube.com/watch?v=uvwxyz01,Disorder,209,false
+3001,1,https://www.youtube.com/watch?v=ghijkl01,Everything In Its Right Place,251,true
+5001,1,https://www.youtube.com/watch?v=mnopqr01,Unknown Track,,true

--- a/tests/integration/test_connection_resilience.py
+++ b/tests/integration/test_connection_resilience.py
@@ -21,7 +21,22 @@ from pathlib import Path
 
 import psycopg
 import pytest
-from lib.pipeline_state import PipelineState
+
+wxyc_etl_state = pytest.importorskip("wxyc_etl.state", reason="wxyc-etl not installed")
+PipelineState = wxyc_etl_state.PipelineState
+
+# STEP_NAMES mirrors the canonical list in scripts/run_pipeline.py
+STEP_NAMES = [
+    "create_schema",
+    "import_csv",
+    "create_indexes",
+    "dedup",
+    "import_tracks",
+    "create_track_indexes",
+    "prune",
+    "vacuum",
+    "set_logged",
+]
 
 SCHEMA_DIR = Path(__file__).parent.parent.parent / "schema"
 FIXTURES_DIR = Path(__file__).parent.parent / "fixtures"
@@ -189,9 +204,9 @@ class TestCopyConnectionLoss:
         """
         _apply_schema(self.db_url)
 
-        state = PipelineState(db_url=self.db_url, csv_dir=str(CSV_DIR))
+        state = PipelineState(db_url=self.db_url, csv_dir=str(CSV_DIR), steps=STEP_NAMES)
         state_file = tmp_path / ".pipeline_state.json"
-        state.save(state_file)
+        state.save(str(state_file))
 
         # Create a CSV that will cause COPY to fail — use a non-nullable column
         # with an empty value that passes the Python filter but violates the DB constraint.
@@ -219,12 +234,12 @@ class TestCopyConnectionLoss:
                 # mark_completed is NOT called on failure.
             except Exception:
                 state.mark_failed("import_csv", "COPY failed: table not found")
-                state.save(state_file)
+                state.save(str(state_file))
         finally:
             bad_conn.close()
 
         # Reload state and verify import_csv is NOT completed
-        loaded = PipelineState.load(state_file)
+        loaded = PipelineState.load(str(state_file))
         assert not loaded.is_completed("import_csv"), (
             "import_csv should not be marked completed after COPY failure"
         )
@@ -321,16 +336,16 @@ class TestImportResumeAfterConnectionLoss:
         """
         _apply_schema(self.db_url)
 
-        state = PipelineState(db_url=self.db_url, csv_dir=str(CSV_DIR))
+        state = PipelineState(db_url=self.db_url, csv_dir=str(CSV_DIR), steps=STEP_NAMES)
         state_file = tmp_path / ".pipeline_state.json"
 
         # First attempt: mark schema complete, fail import
         state.mark_completed("create_schema")
         state.mark_failed("import_csv", "Connection terminated during COPY")
-        state.save(state_file)
+        state.save(str(state_file))
 
         # Verify state persisted
-        loaded = PipelineState.load(state_file)
+        loaded = PipelineState.load(str(state_file))
         assert loaded.is_completed("create_schema")
         assert not loaded.is_completed("import_csv")
         assert loaded.step_status("import_csv") == "failed"
@@ -354,10 +369,10 @@ class TestImportResumeAfterConnectionLoss:
 
         # Mark step complete
         loaded.mark_completed("import_csv")
-        loaded.save(state_file)
+        loaded.save(str(state_file))
 
         # Verify final state
-        final = PipelineState.load(state_file)
+        final = PipelineState.load(str(state_file))
         assert final.is_completed("create_schema")
         assert final.is_completed("import_csv")
         assert total > 0

--- a/tests/integration/test_connection_resilience.py
+++ b/tests/integration/test_connection_resilience.py
@@ -21,7 +21,6 @@ from pathlib import Path
 
 import psycopg
 import pytest
-
 from lib.pipeline_state import PipelineState
 
 SCHEMA_DIR = Path(__file__).parent.parent.parent / "schema"

--- a/tests/integration/test_import.py
+++ b/tests/integration/test_import.py
@@ -28,6 +28,7 @@ _import_tables = _ic._import_tables
 TABLES = _ic.TABLES
 BASE_TABLES = _ic.BASE_TABLES
 TRACK_TABLES = _ic.TRACK_TABLES
+VIDEO_TABLES = _ic.VIDEO_TABLES
 
 pytestmark = pytest.mark.postgres
 
@@ -233,6 +234,7 @@ class TestImportCsv:
 
 ALL_TABLES = (
     "cache_metadata",
+    "release_video",
     "release_track_artist",
     "release_track",
     "release_label",
@@ -730,3 +732,271 @@ class TestImportTables:
         total = _import_tables(conn, tmp_path, TRACK_TABLES)
         conn.close()
         assert total == 0
+
+
+class TestImportReleaseVideo:
+    """Import release_video.csv into a real database and verify results."""
+
+    @pytest.fixture(autouse=True, scope="class")
+    def _set_up_database(self, db_url):
+        """Apply schema, import release data, then import release_video."""
+        self.__class__._db_url = db_url
+        _clean_db(db_url)
+
+        conn = psycopg.connect(db_url, autocommit=True)
+        with conn.cursor() as cur:
+            cur.execute(SCHEMA_DIR.joinpath("create_database.sql").read_text())
+        conn.close()
+
+        conn = psycopg.connect(db_url)
+        for table_config in BASE_TABLES:
+            csv_path = CSV_DIR / table_config["csv_file"]
+            if csv_path.exists():
+                import_csv_func(
+                    conn,
+                    csv_path,
+                    table_config["table"],
+                    table_config["csv_columns"],
+                    table_config["db_columns"],
+                    table_config["required"],
+                    table_config["transforms"],
+                )
+        for table_config in VIDEO_TABLES:
+            csv_path = CSV_DIR / table_config["csv_file"]
+            if csv_path.exists():
+                import_csv_func(
+                    conn,
+                    csv_path,
+                    table_config["table"],
+                    table_config["csv_columns"],
+                    table_config["db_columns"],
+                    table_config["required"],
+                    table_config["transforms"],
+                    unique_key=table_config.get("unique_key"),
+                )
+        conn.close()
+
+    @pytest.fixture(autouse=True)
+    def _store_url(self):
+        self.db_url = self.__class__._db_url
+
+    def _connect(self):
+        return psycopg.connect(self.db_url)
+
+    def test_row_count(self) -> None:
+        """All 5 fixture rows are imported (no required fields missing)."""
+        conn = self._connect()
+        with conn.cursor() as cur:
+            cur.execute("SELECT count(*) FROM release_video")
+            count = cur.fetchone()[0]
+        conn.close()
+        assert count == 5
+
+    def test_multiple_videos_per_release(self) -> None:
+        """Release 1001 has two video rows imported in sequence order."""
+        conn = self._connect()
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT sequence, title FROM release_video WHERE release_id = 1001 ORDER BY sequence"
+            )
+            rows = cur.fetchall()
+        conn.close()
+        assert len(rows) == 2
+        assert rows[0] == (1, "Airbag")
+        assert rows[1] == (2, "Paranoid Android")
+
+    def test_embed_false_stored_correctly(self) -> None:
+        """embed=false in CSV is stored as FALSE boolean in the database."""
+        conn = self._connect()
+        with conn.cursor() as cur:
+            cur.execute("SELECT embed FROM release_video WHERE release_id = 2001")
+            embed = cur.fetchone()[0]
+        conn.close()
+        assert embed is False
+
+    def test_embed_true_stored_correctly(self) -> None:
+        """embed=true in CSV is stored as TRUE boolean in the database."""
+        conn = self._connect()
+        with conn.cursor() as cur:
+            cur.execute("SELECT embed FROM release_video WHERE release_id = 1001 AND sequence = 1")
+            embed = cur.fetchone()[0]
+        conn.close()
+        assert embed is True
+
+    def test_duration_null_when_empty(self) -> None:
+        """Empty duration in CSV becomes NULL in the database."""
+        conn = self._connect()
+        with conn.cursor() as cur:
+            cur.execute("SELECT duration FROM release_video WHERE release_id = 5001")
+            duration = cur.fetchone()[0]
+        conn.close()
+        assert duration is None
+
+    def test_duration_integer_when_present(self) -> None:
+        """Non-empty duration is stored as an integer (seconds)."""
+        conn = self._connect()
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT duration FROM release_video WHERE release_id = 1001 AND sequence = 1"
+            )
+            duration = cur.fetchone()[0]
+        conn.close()
+        assert duration == 284
+
+    def test_src_stored(self) -> None:
+        """src URL is stored as-is."""
+        conn = self._connect()
+        with conn.cursor() as cur:
+            cur.execute("SELECT src FROM release_video WHERE release_id = 3001 AND sequence = 1")
+            src = cur.fetchone()[0]
+        conn.close()
+        assert src == "https://www.youtube.com/watch?v=ghijkl01"
+
+    def test_empty_src_skipped(self, tmp_path) -> None:
+        """Rows with empty src (required field) are skipped during import."""
+        csv_path = tmp_path / "release_video.csv"
+        csv_path.write_text(
+            "release_id,sequence,src,title,duration,embed\n"
+            "1001,99,,Empty src title,100,true\n"
+            "1001,98,https://www.youtube.com/watch?v=valid,Valid,100,true\n"
+        )
+        conn = self._connect()
+        config = VIDEO_TABLES[0]
+        count = import_csv_func(
+            conn,
+            csv_path,
+            config["table"],
+            config["csv_columns"],
+            config["db_columns"],
+            config["required"],
+            config["transforms"],
+            unique_key=config.get("unique_key"),
+            release_id_filter={1001},
+        )
+        conn.close()
+        assert count == 1  # only the row with valid src is imported
+
+    def test_index_exists(self) -> None:
+        """idx_release_video_release_id index exists on release_video."""
+        conn = self._connect()
+        with conn.cursor() as cur:
+            cur.execute("""
+                SELECT indexname FROM pg_indexes
+                WHERE tablename = 'release_video'
+                  AND indexname = 'idx_release_video_release_id'
+            """)
+            result = cur.fetchone()
+        conn.close()
+        assert result is not None, "idx_release_video_release_id index should exist"
+
+    def test_on_delete_cascade(self) -> None:
+        """Deleting a release cascades to delete its release_video rows."""
+        conn = self._connect()
+        with conn.cursor() as cur:
+            # Verify 5001 has a video before deletion
+            cur.execute("SELECT count(*) FROM release_video WHERE release_id = 5001")
+            before = cur.fetchone()[0]
+        conn.close()
+        assert before == 1
+
+        # Delete release 5001 — should cascade to release_video
+        conn = self._connect()
+        with conn.cursor() as cur:
+            cur.execute("DELETE FROM release WHERE id = 5001")
+        conn.commit()
+        with conn.cursor() as cur:
+            cur.execute("SELECT count(*) FROM release_video WHERE release_id = 5001")
+            after = cur.fetchone()[0]
+        conn.close()
+        assert after == 0
+
+
+class TestFilteredVideoImport:
+    """Import videos filtered to a subset of release IDs."""
+
+    @pytest.fixture(autouse=True, scope="class")
+    def _set_up_database(self, db_url):
+        """Import base tables, then import videos filtered to a subset."""
+        self.__class__._db_url = db_url
+        _clean_db(db_url)
+        conn = psycopg.connect(db_url, autocommit=True)
+        with conn.cursor() as cur:
+            cur.execute(SCHEMA_DIR.joinpath("create_database.sql").read_text())
+        conn.close()
+
+        conn = psycopg.connect(db_url)
+        # Import base tables
+        for table_config in BASE_TABLES:
+            csv_path = CSV_DIR / table_config["csv_file"]
+            if csv_path.exists():
+                import_csv_func(
+                    conn,
+                    csv_path,
+                    table_config["table"],
+                    table_config["csv_columns"],
+                    table_config["db_columns"],
+                    table_config["required"],
+                    table_config["transforms"],
+                )
+
+        # Import videos filtered to only a subset of releases
+        filter_ids = {1001, 3001}
+        for table_config in VIDEO_TABLES:
+            csv_path = CSV_DIR / table_config["csv_file"]
+            if csv_path.exists():
+                import_csv_func(
+                    conn,
+                    csv_path,
+                    table_config["table"],
+                    table_config["csv_columns"],
+                    table_config["db_columns"],
+                    table_config["required"],
+                    table_config["transforms"],
+                    unique_key=table_config.get("unique_key"),
+                    release_id_filter=filter_ids,
+                )
+        conn.close()
+
+    @pytest.fixture(autouse=True)
+    def _store_url(self):
+        self.db_url = self.__class__._db_url
+
+    def _connect(self):
+        return psycopg.connect(self.db_url)
+
+    def test_only_filtered_videos_imported(self) -> None:
+        """Only videos for the filtered release IDs should be present."""
+        conn = self._connect()
+        with conn.cursor() as cur:
+            cur.execute("SELECT DISTINCT release_id FROM release_video ORDER BY release_id")
+            ids = [row[0] for row in cur.fetchall()]
+        conn.close()
+        assert ids == [1001, 3001]
+
+    def test_excluded_release_has_no_videos(self) -> None:
+        """Releases not in the filter set should have no videos."""
+        conn = self._connect()
+        with conn.cursor() as cur:
+            cur.execute("SELECT count(*) FROM release_video WHERE release_id = 2001")
+            count = cur.fetchone()[0]
+        conn.close()
+        assert count == 0
+
+    def test_included_release_has_correct_video_count(self) -> None:
+        """Release 1001 should have all 2 videos."""
+        conn = self._connect()
+        with conn.cursor() as cur:
+            cur.execute("SELECT count(*) FROM release_video WHERE release_id = 1001")
+            count = cur.fetchone()[0]
+        conn.close()
+        assert count == 2
+
+    def test_total_video_count(self) -> None:
+        """Total videos should be the sum for the filtered releases."""
+        conn = self._connect()
+        with conn.cursor() as cur:
+            cur.execute("SELECT count(*) FROM release_video")
+            count = cur.fetchone()[0]
+        conn.close()
+        # 1001: 2, 3001: 1 = 3
+        assert count == 3

--- a/tests/unit/test_fallback_paths.py
+++ b/tests/unit/test_fallback_paths.py
@@ -20,11 +20,25 @@ from pathlib import Path
 
 import pytest
 
-# Ensure lib/ is importable (matches verify_cache.py's own sys.path setup)
-sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+# These modules were extracted to wxyc_etl; skip if not installed
+wxyc_etl_text = pytest.importorskip("wxyc_etl.text", reason="wxyc-etl not installed")
+wxyc_etl_state = pytest.importorskip("wxyc_etl.state", reason="wxyc-etl not installed")
 
-from lib.matching import is_compilation_artist  # noqa: E402
-from lib.pipeline_state import STEP_NAMES, PipelineState  # noqa: E402
+is_compilation_artist = wxyc_etl_text.is_compilation_artist
+PipelineState = wxyc_etl_state.PipelineState
+
+# STEP_NAMES mirrors the canonical list in scripts/run_pipeline.py
+STEP_NAMES = [
+    "create_schema",
+    "import_csv",
+    "create_indexes",
+    "dedup",
+    "import_tracks",
+    "create_track_indexes",
+    "prune",
+    "vacuum",
+    "set_logged",
+]
 
 # Load verify_cache module from scripts directory
 _SCRIPT_PATH = Path(__file__).parent.parent.parent / "scripts" / "verify_cache.py"
@@ -278,7 +292,7 @@ class TestPipelineStateV1Resume:
         import_csv in v1 included tracks, so import_tracks should also be completed.
         """
         state_file = self._make_v1_state(tmp_path, ["create_schema", "import_csv"])
-        state = PipelineState.load(state_file)
+        state = PipelineState.load(str(state_file))
 
         assert state.is_completed("create_schema")
         assert state.is_completed("import_csv")
@@ -295,7 +309,7 @@ class TestPipelineStateV1Resume:
         state_file = self._make_v1_state(
             tmp_path, ["create_schema", "import_csv", "create_indexes", "dedup"]
         )
-        state = PipelineState.load(state_file)
+        state = PipelineState.load(str(state_file))
 
         assert state.is_completed("import_tracks")
         assert state.is_completed("create_track_indexes")
@@ -309,7 +323,7 @@ class TestPipelineStateV1Resume:
             tmp_path,
             ["create_schema", "import_csv", "create_indexes", "dedup", "prune", "vacuum"],
         )
-        state = PipelineState.load(state_file)
+        state = PipelineState.load(str(state_file))
 
         for step in STEP_NAMES:
             assert state.is_completed(step), f"Step {step} should be completed after v1 migration"
@@ -317,9 +331,9 @@ class TestPipelineStateV1Resume:
     def test_v1_metadata_preserved(self, tmp_path: Path) -> None:
         """V1 migration preserves database_url and csv_dir."""
         state_file = self._make_v1_state(tmp_path, [])
-        state = PipelineState.load(state_file)
-        assert state.db_url == "postgresql://localhost:5433/test"
-        assert state.csv_dir == "/tmp/csv"
+        state = PipelineState.load(str(state_file))
+        # validate_resume raises ValueError if db_url or csv_dir don't match
+        state.validate_resume("postgresql://localhost:5433/test", "/tmp/csv")
 
 
 class TestPipelineStateV2Resume:
@@ -370,7 +384,7 @@ class TestPipelineStateV2Resume:
                 "vacuum",
             ],
         )
-        state = PipelineState.load(state_file)
+        state = PipelineState.load(str(state_file))
         assert state.is_completed("set_logged")
 
     def test_v2_vacuum_not_completed_leaves_set_logged_pending(self, tmp_path: Path) -> None:
@@ -387,7 +401,7 @@ class TestPipelineStateV2Resume:
                 "prune",
             ],
         )
-        state = PipelineState.load(state_file)
+        state = PipelineState.load(str(state_file))
         assert not state.is_completed("set_logged")
 
     def test_v2_partial_resume_preserves_failed_step(self, tmp_path: Path) -> None:
@@ -417,7 +431,7 @@ class TestPipelineStateV2Resume:
         state_file = tmp_path / "state.json"
         state_file.write_text(json.dumps(data))
 
-        state = PipelineState.load(state_file)
+        state = PipelineState.load(str(state_file))
         assert state.is_completed("create_schema")
         assert state.is_completed("import_csv")
         assert state.step_status("create_indexes") == "failed"
@@ -440,5 +454,5 @@ class TestPipelineStateFutureVersionRejected:
                 }
             )
         )
-        with pytest.raises(ValueError, match="version 99"):
-            PipelineState.load(state_file)
+        with pytest.raises((ValueError, RuntimeError)):
+            PipelineState.load(str(state_file))

--- a/tests/unit/test_import_csv.py
+++ b/tests/unit/test_import_csv.py
@@ -20,6 +20,7 @@ import_csv = _ic.import_csv
 TABLES = _ic.TABLES
 BASE_TABLES = _ic.BASE_TABLES
 TRACK_TABLES = _ic.TRACK_TABLES
+VIDEO_TABLES = _ic.VIDEO_TABLES
 ARTIST_TABLES = _ic.ARTIST_TABLES
 TableConfig = _ic.TableConfig
 _import_tables_parallel = _ic._import_tables_parallel
@@ -340,10 +341,10 @@ class TestParallelImport:
 
 
 class TestTableSplit:
-    """TABLES is the union of BASE_TABLES and TRACK_TABLES."""
+    """TABLES is the union of BASE_TABLES, TRACK_TABLES, and VIDEO_TABLES."""
 
     def test_tables_is_union(self) -> None:
-        assert TABLES == BASE_TABLES + TRACK_TABLES
+        assert TABLES == BASE_TABLES + TRACK_TABLES + VIDEO_TABLES
 
     def test_base_tables_names(self) -> None:
         names = [t["table"] for t in BASE_TABLES]
@@ -353,10 +354,17 @@ class TestTableSplit:
         names = [t["table"] for t in TRACK_TABLES]
         assert names == ["release_track", "release_track_artist"]
 
+    def test_video_tables_are_release_video(self) -> None:
+        names = [t["table"] for t in VIDEO_TABLES]
+        assert names == ["release_video"]
+
     def test_no_overlap(self) -> None:
         base_names = {t["table"] for t in BASE_TABLES}
         track_names = {t["table"] for t in TRACK_TABLES}
+        video_names = {t["table"] for t in VIDEO_TABLES}
         assert base_names.isdisjoint(track_names)
+        assert base_names.isdisjoint(video_names)
+        assert track_names.isdisjoint(video_names)
 
 
 # ---------------------------------------------------------------------------
@@ -514,9 +522,9 @@ class TestMainArgParsing:
 
         mock_parallel.assert_called_once()
         call_args = mock_parallel.call_args
-        # --tracks-only passes empty parent_tables and TRACK_TABLES as children
+        # --tracks-only passes empty parent_tables and TRACK_TABLES + VIDEO_TABLES as children
         assert call_args[1]["parent_tables"] == []
-        assert call_args[1]["child_tables"] == TRACK_TABLES
+        assert call_args[1]["child_tables"] == TRACK_TABLES + VIDEO_TABLES
         assert call_args[1]["release_id_filter"] == {5001, 5002, 5003}
 
 
@@ -549,6 +557,70 @@ class TestReleaseTrackUniqueKey:
         config = next(t for t in TRACK_TABLES if t["table"] == "release_track")
         assert "unique_key" in config
         assert config["unique_key"] == ["release_id", "sequence"]
+
+
+class TestVideoTablesConfig:
+    """VIDEO_TABLES must have correct structure for release_video import."""
+
+    def test_video_tables_has_release_video(self) -> None:
+        """VIDEO_TABLES contains exactly one entry for release_video."""
+        assert len(VIDEO_TABLES) == 1
+        assert VIDEO_TABLES[0]["table"] == "release_video"
+
+    def test_release_video_csv_file(self) -> None:
+        config = VIDEO_TABLES[0]
+        assert config["csv_file"] == "release_video.csv"
+
+    def test_release_video_has_all_columns(self) -> None:
+        config = VIDEO_TABLES[0]
+        expected = ["release_id", "sequence", "src", "title", "duration", "embed"]
+        assert config["csv_columns"] == expected
+        assert config["db_columns"] == expected
+
+    def test_release_video_matching_column_lengths(self) -> None:
+        config = VIDEO_TABLES[0]
+        assert len(config["csv_columns"]) == len(config["db_columns"])
+
+    def test_release_video_required_columns(self) -> None:
+        """release_id and src are required; title/duration/embed are optional."""
+        config = VIDEO_TABLES[0]
+        assert "release_id" in config["required"]
+        assert "src" in config["required"]
+        assert "title" not in config["required"]
+        assert "duration" not in config["required"]
+        assert "embed" not in config["required"]
+
+    def test_release_video_no_transforms(self) -> None:
+        config = VIDEO_TABLES[0]
+        assert config["transforms"] == {}
+
+    def test_release_video_unique_key(self) -> None:
+        """release_video must dedup on (release_id, sequence)."""
+        config = VIDEO_TABLES[0]
+        assert "unique_key" in config
+        assert config["unique_key"] == ["release_id", "sequence"]
+
+    def test_release_video_unique_key_subset_of_csv_columns(self) -> None:
+        config = VIDEO_TABLES[0]
+        key_set = set(config["unique_key"])
+        csv_set = set(config["csv_columns"])
+        assert key_set.issubset(csv_set)
+
+    def test_release_video_has_all_required_keys(self) -> None:
+        required_keys = {"csv_file", "table", "csv_columns", "db_columns", "required", "transforms"}
+        assert required_keys.issubset(VIDEO_TABLES[0].keys())
+
+    def test_release_video_csv_has_expected_headers(self) -> None:
+        import csv as csv_mod
+
+        csv_path = CSV_DIR / "release_video.csv"
+        assert csv_path.exists(), "release_video.csv fixture must exist"
+        with open(csv_path) as f:
+            reader = csv_mod.DictReader(f)
+            headers = reader.fieldnames
+        assert headers is not None
+        for col in VIDEO_TABLES[0]["csv_columns"]:
+            assert col in headers, f"Column {col!r} missing from release_video.csv"
 
 
 class TestImportArtistDetailsFiltersById:


### PR DESCRIPTION
## Summary

- Add `release_video` table to schema (release_id FK, sequence, src, title, duration, embed)
- Add `TableConfig` for `release_video.csv` import in `import_csv.py`
- Add fixture CSV and test data

## Test plan

- [x] Unit tests: VideoTablesConfig validation
- [x] Integration tests: FK index, filtered import, cascade
- [x] E2E tests: Pipeline populates video table, dedup/prune cascade