### PR TITLE
Add master and master_artist tables for canonical album titles

### DIFF
--- a/schema/create_database.sql
+++ b/schema/create_database.sql
@@ -177,6 +177,7 @@ CREATE INDEX IF NOT EXISTS idx_release_master_id ON release(master_id) WHERE mas
 
 -- Master indexes
 CREATE INDEX IF NOT EXISTS idx_master_artist_master_id ON master_artist(master_id);
+CREATE INDEX IF NOT EXISTS idx_master_title_trgm ON master USING GIN (lower(f_unaccent(title)) gin_trgm_ops);
 
 -- Cache metadata indexes
 CREATE INDEX IF NOT EXISTS idx_cache_metadata_cached_at ON cache_metadata(cached_at);

--- a/schema/create_database.sql
+++ b/schema/create_database.sql
@@ -22,6 +22,8 @@ CREATE EXTENSION IF NOT EXISTS unaccent;
 
 -- Drop in FK order: children first, then parent
 DROP TABLE IF EXISTS cache_metadata CASCADE;
+DROP TABLE IF EXISTS master_artist CASCADE;
+DROP TABLE IF EXISTS master CASCADE;
 DROP TABLE IF EXISTS artist_url CASCADE;
 DROP TABLE IF EXISTS artist_member CASCADE;
 DROP TABLE IF EXISTS artist_name_variation CASCADE;
@@ -125,6 +127,23 @@ CREATE TABLE artist_url (
 );
 
 -- ============================================
+-- Masters (canonical album groupings)
+-- ============================================
+
+CREATE TABLE master (
+    id              integer PRIMARY KEY,
+    title           text NOT NULL,
+    main_release_id integer,
+    year            smallint
+);
+
+CREATE TABLE master_artist (
+    master_id       integer NOT NULL REFERENCES master(id) ON DELETE CASCADE,
+    artist_id       integer,
+    artist_name     text NOT NULL
+);
+
+-- ============================================
 -- Cache metadata (for tracking data freshness)
 -- ============================================
 
@@ -155,6 +174,9 @@ CREATE INDEX IF NOT EXISTS idx_artist_url_artist_id ON artist_url(artist_id);
 -- Partial index on master_id for dedup performance.
 -- Transient: dropped automatically by dedup copy-swap (which excludes master_id).
 CREATE INDEX IF NOT EXISTS idx_release_master_id ON release(master_id) WHERE master_id IS NOT NULL;
+
+-- Master indexes
+CREATE INDEX IF NOT EXISTS idx_master_artist_master_id ON master_artist(master_id);
 
 -- Cache metadata indexes
 CREATE INDEX IF NOT EXISTS idx_cache_metadata_cached_at ON cache_metadata(cached_at);

--- a/scripts/import_csv.py
+++ b/scripts/import_csv.py
@@ -169,6 +169,27 @@ ARTIST_TABLES: list[TableConfig] = [
     },
 ]
 
+MASTER_TABLES: list[TableConfig] = [
+    {
+        "csv_file": "master.csv",
+        "table": "master",
+        "csv_columns": ["id", "title", "main_release_id", "year"],
+        "db_columns": ["id", "title", "main_release_id", "year"],
+        "required": ["id", "title"],
+        "transforms": {},
+        "unique_key": ["id"],
+    },
+    {
+        "csv_file": "master_artist.csv",
+        "table": "master_artist",
+        "csv_columns": ["master_id", "artist_id", "artist_name"],
+        "db_columns": ["master_id", "artist_id", "artist_name"],
+        "required": ["master_id", "artist_name"],
+        "transforms": {},
+        "unique_key": ["master_id", "artist_id"],
+    },
+]
+
 TABLES: list[TableConfig] = BASE_TABLES + TRACK_TABLES + VIDEO_TABLES
 
 
@@ -623,6 +644,15 @@ def import_artist_details(conn, csv_dir: Path) -> int:
     return total
 
 
+def import_masters(conn, csv_dir: Path) -> int:
+    """Import master tables from CSV.
+
+    Imports master.csv first (parent), then master_artist.csv (child).
+    Returns total rows imported.
+    """
+    return _import_tables(conn, csv_dir, MASTER_TABLES)
+
+
 def main():
     import argparse
 
@@ -694,6 +724,9 @@ def main():
         logger.info("Importing artist details...")
         import_artist_details(conn, csv_dir)
         logger.info("Artist details complete")
+        logger.info("Importing masters...")
+        import_masters(conn, csv_dir)
+        logger.info("Masters complete")
         conn.close()
     else:
         total = _import_tables(conn, csv_dir, TABLES)
@@ -707,6 +740,9 @@ def main():
         logger.info("Importing artist details...")
         import_artist_details(conn, csv_dir)
         logger.info("Artist details complete")
+        logger.info("Importing masters...")
+        import_masters(conn, csv_dir)
+        logger.info("Masters complete")
         conn.close()
 
     logger.info(f"Total: {total:,} rows imported")

--- a/tests/unit/test_import_csv.py
+++ b/tests/unit/test_import_csv.py
@@ -456,6 +456,7 @@ class TestMainArgParsing:
             patch.object(_ic, "populate_release_year", return_value=50),
             patch.object(_ic, "populate_cache_metadata", return_value=50),
             patch.object(_ic, "import_artist_details", return_value=20),
+            patch.object(_ic, "import_masters", return_value=10),
         ):
             _ic.main()
 


### PR DESCRIPTION
## Summary

- Add `master` and `master_artist` tables to schema
- Add `MASTER_TABLES` import config and `import_masters()` function
- Integrated into both `--base-only` and default import paths

Depends on WXYC/discogs-xml-converter#30 for CSV generation.

Closes #80

## Test plan

- [x] Schema DDL is valid SQL
- [x] Import config matches CSV column layout from converter
- [x] Existing tests unaffected (no schema migration needed — tables are additive)