### PR TITLE
Add streaming links enrichment to library sync

### DIFF
--- a/scripts/sync-library.sh
+++ b/scripts/sync-library.sh
@@ -109,6 +109,23 @@ fi
 cat "$ETL_OUTPUT" >> "$LOG_FILE"
 rm -f "$ETL_OUTPUT"
 
+# Enrich with streaming links (optional — skipped if streaming_availability.db unavailable)
+LML_DIR="${LML_REPO_DIR:-$(dirname "$REPO_DIR")/library-metadata-lookup}"
+STREAMING_DB="$LML_DIR/streaming_availability.db"
+
+if [[ -f "$STREAMING_DB" && -f "$LML_DIR/scripts/export_streaming_links.py" ]]; then
+    log "Enriching with streaming links..."
+    if $PYTHON "$LML_DIR/scripts/export_streaming_links.py" \
+        --library-db "$DB_PATH" \
+        --streaming-db "$STREAMING_DB" 2>&1 | tee -a "$LOG_FILE"; then
+        log "Streaming links enrichment complete"
+    else
+        log "WARNING: Streaming links enrichment failed (continuing without)"
+    fi
+else
+    log "Skipping streaming links (streaming_availability.db not found)"
+fi
+
 # Upload to staging (if URL configured)
 if [[ -n "$STAGING_URL" ]]; then
     upload_library_db "$STAGING_URL" "staging" "$DB_PATH" || EXIT_CODE=1


### PR DESCRIPTION
## Summary
- Add optional streaming links enrichment step to `scripts/sync-library.sh` between build and upload
- Uses `export_streaming_links.py` from sibling library-metadata-lookup repo
- Gracefully skips when `streaming_availability.db` or LML repo is not available (e.g., in GitHub Actions)

Closes #82

Depends on WXYC/library-metadata-lookup#118

## Test plan
- [ ] Run `sync-library.sh` locally with `LML_REPO_DIR` set — verify streaming links appear in uploaded `library.db`
- [ ] Run GitHub Actions workflow — verify enrichment step is skipped gracefully and upload succeeds