### PR TITLE
Fix sync-library workflow: Rust toolchain, MySQL 4.1 auth, SSH tunnel, CLI args

### DIFF
--- a/.github/workflows/sync-library.yml
+++ b/.github/workflows/sync-library.yml
@@ -16,6 +16,19 @@ jobs:
         with:
           python-version: "3.12"
 
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Install wxyc-etl from git (Rust/PyO3)
+        run: |
+          pip install maturin
+          git clone --depth 1 --branch etl-unification/1g-pyo3-bindings https://github.com/WXYC/wxyc-etl.git /tmp/wxyc-etl
+          cd /tmp/wxyc-etl/wxyc-etl-python && maturin build --release && pip install /tmp/wxyc-etl/target/wheels/*.whl
+
+      - name: Install wxyc-catalog from git
+        run: |
+          git clone --depth 1 --branch fix-mysql41-auth https://github.com/WXYC/wxyc-catalog.git /tmp/wxyc-catalog
+          cd /tmp/wxyc-catalog && sed -i 's|setuptools.backends._legacy:_Backend|setuptools.build_meta|' pyproject.toml && pip install -e ".[mysql]"
+
       - run: pip install -e "."
 
       - uses: webfactory/ssh-agent@v0.9.0

--- a/.github/workflows/sync-library.yml
+++ b/.github/workflows/sync-library.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Install wxyc-catalog from git
         run: |
-          git clone --depth 1 --branch fix-mysql41-auth https://github.com/WXYC/wxyc-catalog.git /tmp/wxyc-catalog
+          git clone --depth 1 --branch main https://github.com/WXYC/wxyc-catalog.git /tmp/wxyc-catalog
           cd /tmp/wxyc-catalog && sed -i 's|setuptools.backends._legacy:_Backend|setuptools.build_meta|' pyproject.toml && pip install -e ".[mysql]"
 
       - run: pip install -e "."

--- a/scripts/sync-library.sh
+++ b/scripts/sync-library.sh
@@ -94,12 +94,37 @@ fi
 
 log "Starting library sync"
 
+# Build MySQL connection URL from individual env vars
+if [[ -z "$LIBRARY_DB_HOST" || -z "$LIBRARY_DB_USER" || -z "$LIBRARY_DB_PASSWORD" || -z "$LIBRARY_DB_NAME" ]]; then
+    notify_error "Missing required LIBRARY_DB_* environment variables"
+    exit 1
+fi
+# Set up SSH tunnel to Kattare if LIBRARY_SSH_HOST is configured
+if [[ -n "$LIBRARY_SSH_HOST" && -n "$LIBRARY_SSH_USER" ]]; then
+    LOCAL_DB_PORT=13306
+    log "Opening SSH tunnel to $LIBRARY_SSH_HOST..."
+    ssh -f -N -L "${LOCAL_DB_PORT}:${LIBRARY_DB_HOST}:3306" \
+        "${LIBRARY_SSH_USER}@${LIBRARY_SSH_HOST}" \
+        -o StrictHostKeyChecking=no -o ConnectTimeout=10
+    # URL-encode user/password to handle special characters
+    ENCODED_PASSWORD=$($PYTHON -c "from urllib.parse import quote; import os; print(quote(os.environ['LIBRARY_DB_PASSWORD'], safe=''))")
+    ENCODED_USER=$($PYTHON -c "from urllib.parse import quote; import os; print(quote(os.environ['LIBRARY_DB_USER'], safe=''))")
+    CATALOG_DB_URL="mysql://${ENCODED_USER}:${ENCODED_PASSWORD}@127.0.0.1:${LOCAL_DB_PORT}/${LIBRARY_DB_NAME}"
+    log "SSH tunnel established on port $LOCAL_DB_PORT"
+else
+    ENCODED_PASSWORD=$($PYTHON -c "from urllib.parse import quote; import os; print(quote(os.environ['LIBRARY_DB_PASSWORD'], safe=''))")
+    ENCODED_USER=$($PYTHON -c "from urllib.parse import quote; import os; print(quote(os.environ['LIBRARY_DB_USER'], safe=''))")
+    CATALOG_DB_URL="mysql://${ENCODED_USER}:${ENCODED_PASSWORD}@${LIBRARY_DB_HOST}/${LIBRARY_DB_NAME}"
+fi
+
 # Run ETL, capturing output for error reporting
 DB_PATH=$(mktemp -d)/library.db
-export LIBRARY_DB_OUTPUT_PATH="$DB_PATH"
 
 ETL_OUTPUT=$(mktemp)
-if ! wxyc-export-to-sqlite 2>&1 | tee "$ETL_OUTPUT"; then
+if ! wxyc-export-to-sqlite \
+    --catalog-source tubafrenzy \
+    --catalog-db-url "$CATALOG_DB_URL" \
+    --output "$DB_PATH" 2>&1 | tee "$ETL_OUTPUT"; then
     ERROR_DETAILS=$(grep -v '^[[:space:]]' "$ETL_OUTPUT" | grep -v '^$' | tail -1 | sed 's/"/\\"/g')
     cat "$ETL_OUTPUT" >> "$LOG_FILE"
     rm -f "$ETL_OUTPUT" "$DB_PATH"


### PR DESCRIPTION
## Summary

The `sync-library.yml` workflow was broken in multiple ways. This PR fixes all of them:

- **Missing Rust toolchain**: `wxyc-export-to-sqlite` comes from `wxyc-catalog` which depends on `wxyc-etl` (a Rust/PyO3 crate). The workflow now installs the Rust toolchain and builds `wxyc-etl` from source before installing `wxyc-catalog`.
- **MySQL 4.1 auth**: Kattare runs MySQL 4.1.22 which uses pre-plugin authentication that `pymysql` can't handle. This uses the `fix-mysql41-auth` branch of wxyc-catalog (WXYC/wxyc-catalog#9) which switches to `mysql-connector-python` with `allow_old_password=True`.
- **Missing SSH tunnel**: The MySQL DB is on Kattare, accessed via SSH. The script now opens an SSH tunnel when `LIBRARY_SSH_HOST` is configured, forwarding to a local port.
- **Missing CLI args**: `wxyc-export-to-sqlite` requires `--catalog-source tubafrenzy --catalog-db-url <URL> --output <path>` but the script was calling it bare with only an env var.
- **URL-encoded credentials**: The MySQL password may contain special characters that break URL parsing. Credentials are now URL-encoded via `urllib.parse.quote`.

## Dependencies

- Depends on WXYC/wxyc-catalog#9 (`fix-mysql41-auth` branch) for MySQL 4.1 old-password authentication support.

## Test plan

- [ ] Trigger the workflow manually via `workflow_dispatch` and verify the SSH tunnel connects to Kattare
- [ ] Verify `wxyc-export-to-sqlite` runs successfully with the CLI args and produces `library.db`
- [ ] Verify the upload to staging succeeds