### PR TITLE
Extract tsv_to_sqlite.py from sync-library.sh and add tests

### DIFF
--- a/scripts/sync-library.sh
+++ b/scripts/sync-library.sh
@@ -138,44 +138,7 @@ ROW_COUNT=$(wc -l < "$CSV_FILE" | tr -d ' ')
 log "Fetched $ROW_COUNT rows from MySQL"
 
 # Build SQLite database from TSV output
-if ! $PYTHON - "$CSV_FILE" "$DB_PATH" <<'PYEOF'
-import sqlite3, sys
-
-tsv_path, db_path = sys.argv[1], sys.argv[2]
-
-conn = sqlite3.connect(db_path)
-cur = conn.cursor()
-cur.execute("""CREATE TABLE library (
-    id INTEGER PRIMARY KEY, title TEXT, artist TEXT, call_letters TEXT,
-    artist_call_number INTEGER, release_call_number INTEGER,
-    genre TEXT, format TEXT, alternate_artist_name TEXT
-)""")
-cur.execute("""CREATE VIRTUAL TABLE library_fts USING fts5(
-    title, artist, alternate_artist_name, content='library', content_rowid='id'
-)""")
-
-count = 0
-with open(tsv_path, encoding="utf-8") as f:
-    for line in f:
-        fields = line.rstrip("\n").split("\t")
-        if len(fields) != 9:
-            print(f"WARNING: skipping malformed row with {len(fields)} fields", file=sys.stderr)
-            continue
-        # MySQL -B outputs \N for NULL
-        row = [None if v == "\\N" else v for v in fields]
-        cur.execute("INSERT INTO library VALUES (?,?,?,?,?,?,?,?,?)", row)
-        count += 1
-
-cur.execute("""INSERT INTO library_fts(rowid, title, artist, alternate_artist_name)
-    SELECT id, title, artist, alternate_artist_name FROM library""")
-cur.execute("CREATE INDEX idx_artist ON library(artist)")
-cur.execute("CREATE INDEX idx_title ON library(title)")
-cur.execute("CREATE INDEX idx_alternate_artist ON library(alternate_artist_name)")
-conn.commit()
-conn.close()
-print(f"Exported {count} rows to {db_path}")
-PYEOF
-then
+if ! $PYTHON scripts/tsv_to_sqlite.py "$CSV_FILE" "$DB_PATH" 2>&1 | tee -a "$LOG_FILE"; then
     rm -f "$CSV_FILE" "$DB_PATH"
     notify_error "SQLite export failed"
     exit 1

--- a/scripts/tsv_to_sqlite.py
+++ b/scripts/tsv_to_sqlite.py
@@ -1,0 +1,75 @@
+"""Convert a MySQL TSV dump to a SQLite database with FTS5 index.
+
+Reads a tab-separated file (as produced by ``mysql -B -N``) with 9 columns
+corresponding to the WXYC library catalog schema and creates a SQLite
+database containing:
+
+- A ``library`` table with id, title, artist, call_letters,
+  artist_call_number, release_call_number, genre, format, and
+  alternate_artist_name columns.
+- An FTS5 virtual table (``library_fts``) for full-text search on title,
+  artist, and alternate_artist_name.
+- Indexes on artist, title, and alternate_artist_name.
+
+MySQL ``\\N`` values are converted to SQL NULL. Rows that do not contain
+exactly 9 tab-separated fields are skipped with a warning on stderr.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import sys
+
+
+def tsv_to_sqlite(tsv_path: str, db_path: str) -> int:
+    """Import a MySQL TSV dump into a new SQLite database.
+
+    Args:
+        tsv_path: Path to the tab-separated input file.
+        db_path: Path where the SQLite database will be created.
+
+    Returns:
+        The number of rows successfully imported.
+    """
+    conn = sqlite3.connect(db_path)
+    cur = conn.cursor()
+    cur.execute("""CREATE TABLE library (
+        id INTEGER PRIMARY KEY, title TEXT, artist TEXT, call_letters TEXT,
+        artist_call_number INTEGER, release_call_number INTEGER,
+        genre TEXT, format TEXT, alternate_artist_name TEXT
+    )""")
+    cur.execute("""CREATE VIRTUAL TABLE library_fts USING fts5(
+        title, artist, alternate_artist_name, content='library', content_rowid='id'
+    )""")
+
+    count = 0
+    with open(tsv_path, encoding="utf-8") as f:
+        for line in f:
+            fields = line.rstrip("\n").split("\t")
+            if len(fields) != 9:
+                print(
+                    f"WARNING: skipping malformed row with {len(fields)} fields",
+                    file=sys.stderr,
+                )
+                continue
+            # MySQL -B outputs \N for NULL
+            row = [None if v == "\\N" else v for v in fields]
+            cur.execute("INSERT INTO library VALUES (?,?,?,?,?,?,?,?,?)", row)
+            count += 1
+
+    cur.execute("""INSERT INTO library_fts(rowid, title, artist, alternate_artist_name)
+        SELECT id, title, artist, alternate_artist_name FROM library""")
+    cur.execute("CREATE INDEX idx_artist ON library(artist)")
+    cur.execute("CREATE INDEX idx_title ON library(title)")
+    cur.execute("CREATE INDEX idx_alternate_artist ON library(alternate_artist_name)")
+    conn.commit()
+    conn.close()
+    return count
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 3:
+        print(f"Usage: {sys.argv[0]} <tsv_path> <db_path>", file=sys.stderr)
+        sys.exit(1)
+    n = tsv_to_sqlite(sys.argv[1], sys.argv[2])
+    print(f"Exported {n} rows to {sys.argv[2]}")

--- a/tests/e2e/test_sync_library_e2e.py
+++ b/tests/e2e/test_sync_library_e2e.py
@@ -1,0 +1,164 @@
+"""E2E test for the library sync pipeline: tsv_to_sqlite + export_streaming_links."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sqlite3
+import sys
+from argparse import Namespace
+from pathlib import Path
+
+import pytest
+
+# Load tsv_to_sqlite from scripts directory
+_SCRIPT_PATH = Path(__file__).resolve().parents[2] / "scripts" / "tsv_to_sqlite.py"
+_spec = importlib.util.spec_from_file_location("tsv_to_sqlite", _SCRIPT_PATH)
+assert _spec is not None and _spec.loader is not None
+_tsv_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_tsv_mod)
+
+tsv_to_sqlite = _tsv_mod.tsv_to_sqlite
+
+# Load export_streaming_links from the sibling library-metadata-lookup repo
+_LML_DIR = Path(__file__).resolve().parents[3] / "library-metadata-lookup"
+_LML_SCRIPT = _LML_DIR / "scripts" / "export_streaming_links.py"
+
+_has_lml = _LML_SCRIPT.exists()
+
+
+def _load_export_streaming_links():
+    """Dynamically load export_streaming_links.main from the LML repo."""
+    sys.path.insert(0, str(_LML_DIR))
+    try:
+        from scripts.export_streaming_links import main
+
+        return main
+    finally:
+        sys.path.pop(0)
+
+
+@pytest.mark.e2e
+@pytest.mark.skipif(not _has_lml, reason="library-metadata-lookup repo not found")
+class TestSyncLibraryE2E:
+    """End-to-end test: generate TSV, build library.db, enrich with streaming links."""
+
+    def test_tsv_to_sqlite_then_streaming_export(self, tmp_path: Path) -> None:
+        """Generate TSV, run tsv_to_sqlite, create streaming_availability.db,
+        run export_streaming_links, verify both tables exist with correct data."""
+        # Step 1: Generate TSV data
+        lines = [
+            "10001\tAluminum Tunes\tStereolab\tST\t1234\t1\tRock\tCD\t\\N",
+            "10002\tDOGA\tJuana Molina\tMO\t5678\t2\tRock\tLP\t\\N",
+            "10003\tConfield\tAutechre\tAU\t9012\t3\tElectronic\tCD\t\\N",
+        ]
+        tsv_file = tmp_path / "mysql_output.tsv"
+        tsv_file.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+        # Step 2: Run tsv_to_sqlite
+        library_db_path = tmp_path / "library.db"
+        count = tsv_to_sqlite(str(tsv_file), str(library_db_path))
+        assert count == 3
+
+        # Step 3: Create a streaming_availability.db with test data
+        streaming_db_path = tmp_path / "streaming_availability.db"
+        sa_conn = sqlite3.connect(str(streaming_db_path))
+        sa_conn.execute("""
+            CREATE TABLE albums (
+                id INTEGER PRIMARY KEY,
+                library_ids TEXT,
+                spotify_url TEXT,
+                apple_url TEXT,
+                deezer_url TEXT,
+                bandcamp_url TEXT,
+                tidal_url TEXT,
+                youtube_music_url TEXT,
+                soundcloud_url TEXT
+            )
+        """)
+        sa_conn.execute(
+            "INSERT INTO albums (library_ids, spotify_url, apple_url, deezer_url, "
+            "bandcamp_url, tidal_url, youtube_music_url, soundcloud_url) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                json.dumps([10001]),
+                "https://open.spotify.com/album/stereolab-aluminum",
+                "https://music.apple.com/album/stereolab-aluminum",
+                None,
+                None,
+                None,
+                None,
+                None,
+            ),
+        )
+        sa_conn.execute(
+            "INSERT INTO albums (library_ids, spotify_url, apple_url, deezer_url, "
+            "bandcamp_url, tidal_url, youtube_music_url, soundcloud_url) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                json.dumps([10003]),
+                "https://open.spotify.com/album/autechre-confield",
+                None,
+                "https://www.deezer.com/album/autechre-confield",
+                None,
+                None,
+                None,
+                None,
+            ),
+        )
+        sa_conn.commit()
+        sa_conn.close()
+
+        # Step 4: Run export_streaming_links
+        export_main = _load_export_streaming_links()
+        args = Namespace(
+            library_db=str(library_db_path),
+            streaming_db=str(streaming_db_path),
+            dry_run=False,
+        )
+        export_main(args)
+
+        # Step 5: Verify both tables exist with correct data
+        conn = sqlite3.connect(str(library_db_path))
+
+        # Verify library table
+        lib_count = conn.execute("SELECT COUNT(*) FROM library").fetchone()[0]
+        assert lib_count == 3
+
+        # Verify streaming_links table was created
+        tables = {
+            row[0]
+            for row in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type = 'table'"
+            ).fetchall()
+        }
+        assert "library" in tables
+        assert "streaming_links" in tables
+
+        # Verify streaming links content
+        links = conn.execute(
+            "SELECT library_id, spotify_url, apple_music_url, deezer_url "
+            "FROM streaming_links ORDER BY library_id"
+        ).fetchall()
+        assert len(links) == 2
+
+        # Stereolab entry
+        assert links[0][0] == 10001
+        assert links[0][1] == "https://open.spotify.com/album/stereolab-aluminum"
+        assert links[0][2] == "https://music.apple.com/album/stereolab-aluminum"
+        assert links[0][3] is None
+
+        # Autechre entry
+        assert links[1][0] == 10003
+        assert links[1][1] == "https://open.spotify.com/album/autechre-confield"
+        assert links[1][2] is None
+        assert links[1][3] == "https://www.deezer.com/album/autechre-confield"
+
+        # Verify FTS still works after streaming enrichment
+        fts_hits = conn.execute(
+            "SELECT rowid FROM library_fts WHERE library_fts MATCH 'Autechre'"
+        ).fetchall()
+        assert len(fts_hits) == 1
+        assert fts_hits[0][0] == 10003
+
+        conn.close()

--- a/tests/integration/test_tsv_to_sqlite.py
+++ b/tests/integration/test_tsv_to_sqlite.py
@@ -1,0 +1,108 @@
+"""Integration tests for scripts/tsv_to_sqlite.py."""
+
+from __future__ import annotations
+
+import importlib.util
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+# Load tsv_to_sqlite module from scripts directory
+_SCRIPT_PATH = Path(__file__).parent.parent.parent / "scripts" / "tsv_to_sqlite.py"
+_spec = importlib.util.spec_from_file_location("tsv_to_sqlite", _SCRIPT_PATH)
+assert _spec is not None and _spec.loader is not None
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+
+tsv_to_sqlite = _mod.tsv_to_sqlite
+
+
+@pytest.mark.integration
+class TestTsvToSqliteIntegration:
+    """Integration tests using realistic MySQL output."""
+
+    def test_realistic_mysql_output(self, tmp_path: Path) -> None:
+        """TSV mimicking real MySQL -B -N output imports correctly and FTS search works."""
+        # Realistic MySQL batch-mode output with mix of NULLs, Unicode, and varied genres
+        lines = [
+            "10001\tAluminum Tunes\tStereolab\tST\t1234\t1\tRock\tCD\t\\N",
+            "10002\tDOGA\tJuana Molina\tMO\t5678\t2\tRock\tLP\t\\N",
+            "10003\tConfield\tAutechre\tAU\t9012\t3\tElectronic\tCD\t\\N",
+            "10004\tMoon Pix\tCat Power\tCA\t3456\t1\tRock\tLP\tCharlyn Marie Marshall",
+            "10005\tPequena Vertigem de Amor\tSessa\tSE\t7890\t1\tLatin\tLP\t\\N",
+            "10006\tDuke Ellington & John Coltrane\tDuke Ellington\tEL\t2345\t1\tJazz\tLP\tEdward Kennedy Ellington",
+            "10007\tOn Your Own Love Again\tJessica Pratt\tPR\t6789\t1\tRock\tLP\t\\N",
+            "10008\tEdits\tChuquimamani-Condori\tCH\t\\N\t\\N\tElectronic\tCD\t\\N",
+        ]
+        tsv_file = tmp_path / "mysql_output.tsv"
+        tsv_file.write_text("\n".join(lines) + "\n", encoding="utf-8")
+        db_path = tmp_path / "library.db"
+
+        count = tsv_to_sqlite(str(tsv_file), str(db_path))
+        assert count == 8
+
+        conn = sqlite3.connect(str(db_path))
+
+        # FTS search for artist
+        hits = conn.execute(
+            "SELECT l.id, l.title FROM library l "
+            "JOIN library_fts ON library_fts.rowid = l.id "
+            "WHERE library_fts MATCH 'Stereolab'"
+        ).fetchall()
+        assert len(hits) == 1
+        assert hits[0] == (10001, "Aluminum Tunes")
+
+        # FTS search for title
+        hits = conn.execute(
+            "SELECT l.id, l.artist FROM library l "
+            "JOIN library_fts ON library_fts.rowid = l.id "
+            "WHERE library_fts MATCH 'Confield'"
+        ).fetchall()
+        assert len(hits) == 1
+        assert hits[0] == (10002, "Juana Molina") or hits[0] == (10003, "Autechre")
+        assert hits[0] == (10003, "Autechre")
+
+        # FTS search for alternate artist name
+        hits = conn.execute(
+            "SELECT l.id, l.artist FROM library l "
+            "JOIN library_fts ON library_fts.rowid = l.id "
+            "WHERE library_fts MATCH 'Marshall'"
+        ).fetchall()
+        assert len(hits) == 1
+        assert hits[0] == (10004, "Cat Power")
+
+        # Verify NULLs handled correctly
+        row = conn.execute(
+            "SELECT artist_call_number, release_call_number FROM library WHERE id = 10008"
+        ).fetchone()
+        assert row[0] is None
+        assert row[1] is None
+
+        conn.close()
+
+    def test_schema_matches_wxyc_catalog(self, tmp_path: Path) -> None:
+        """PRAGMA table_info columns match the expected WXYC library schema."""
+        tsv_file = tmp_path / "empty.tsv"
+        tsv_file.write_text("", encoding="utf-8")
+        db_path = tmp_path / "library.db"
+
+        tsv_to_sqlite(str(tsv_file), str(db_path))
+
+        conn = sqlite3.connect(str(db_path))
+        columns = conn.execute("PRAGMA table_info(library)").fetchall()
+        conn.close()
+
+        expected_columns = [
+            (0, "id", "INTEGER", 0, None, 1),
+            (1, "title", "TEXT", 0, None, 0),
+            (2, "artist", "TEXT", 0, None, 0),
+            (3, "call_letters", "TEXT", 0, None, 0),
+            (4, "artist_call_number", "INTEGER", 0, None, 0),
+            (5, "release_call_number", "INTEGER", 0, None, 0),
+            (6, "genre", "TEXT", 0, None, 0),
+            (7, "format", "TEXT", 0, None, 0),
+            (8, "alternate_artist_name", "TEXT", 0, None, 0),
+        ]
+
+        assert columns == expected_columns

--- a/tests/unit/test_tsv_to_sqlite.py
+++ b/tests/unit/test_tsv_to_sqlite.py
@@ -1,0 +1,325 @@
+"""Unit tests for scripts/tsv_to_sqlite.py."""
+
+from __future__ import annotations
+
+import importlib.util
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+# Load tsv_to_sqlite module from scripts directory
+_SCRIPT_PATH = Path(__file__).parent.parent.parent / "scripts" / "tsv_to_sqlite.py"
+_spec = importlib.util.spec_from_file_location("tsv_to_sqlite", _SCRIPT_PATH)
+assert _spec is not None and _spec.loader is not None
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+
+tsv_to_sqlite = _mod.tsv_to_sqlite
+
+
+def _make_tsv(rows: list[list[str]]) -> str:
+    """Build a TSV string from a list of field lists."""
+    return "\n".join("\t".join(r) for r in rows) + "\n"
+
+
+class TestTsvToSqlite:
+    """Tests for the tsv_to_sqlite function."""
+
+    def test_basic_export(self, tmp_path: Path) -> None:
+        """3-row TSV produces a library table with 3 rows and correct data."""
+        tsv = _make_tsv(
+            [
+                ["1", "Aluminum Tunes", "Stereolab", "ST", "100", "1", "Rock", "CD", "\\N"],
+                ["2", "DOGA", "Juana Molina", "MO", "200", "2", "Rock", "LP", "\\N"],
+                ["3", "Confield", "Autechre", "AU", "300", "3", "Electronic", "CD", "\\N"],
+            ]
+        )
+        tsv_file = tmp_path / "input.tsv"
+        tsv_file.write_text(tsv, encoding="utf-8")
+        db_path = tmp_path / "library.db"
+
+        tsv_to_sqlite(str(tsv_file), str(db_path))
+
+        conn = sqlite3.connect(str(db_path))
+        rows = conn.execute("SELECT id, title, artist, genre FROM library ORDER BY id").fetchall()
+        conn.close()
+
+        assert len(rows) == 3
+        assert rows[0] == (1, "Aluminum Tunes", "Stereolab", "Rock")
+        assert rows[1] == (2, "DOGA", "Juana Molina", "Rock")
+        assert rows[2] == (3, "Confield", "Autechre", "Electronic")
+
+    def test_null_handling(self, tmp_path: Path) -> None:
+        """TSV with \\N values are stored as Python None (SQL NULL) in SQLite."""
+        tsv = _make_tsv(
+            [
+                ["1", "Aluminum Tunes", "Stereolab", "ST", "100", "\\N", "Rock", "CD", "\\N"],
+            ]
+        )
+        tsv_file = tmp_path / "input.tsv"
+        tsv_file.write_text(tsv, encoding="utf-8")
+        db_path = tmp_path / "library.db"
+
+        tsv_to_sqlite(str(tsv_file), str(db_path))
+
+        conn = sqlite3.connect(str(db_path))
+        row = conn.execute(
+            "SELECT release_call_number, alternate_artist_name FROM library WHERE id = 1"
+        ).fetchone()
+        conn.close()
+
+        assert row[0] is None
+        assert row[1] is None
+
+    def test_nine_column_validation(self, tmp_path: Path) -> None:
+        """Rows with != 9 fields are skipped; valid rows are still imported."""
+        tsv = (
+            "1\tAluminum Tunes\tStereolab\tST\t100\t1\tRock\tCD\t\\N\n"
+            "bad\trow\twith\ttoo\tfew\n"
+            "2\tDOGA\tJuana Molina\tMO\t200\t2\tRock\tLP\t\\N\n"
+            "3\textra\tfields\there\t1\t2\t3\t4\t5\t6\n"
+        )
+        tsv_file = tmp_path / "input.tsv"
+        tsv_file.write_text(tsv, encoding="utf-8")
+        db_path = tmp_path / "library.db"
+
+        count = tsv_to_sqlite(str(tsv_file), str(db_path))
+
+        assert count == 2
+
+        conn = sqlite3.connect(str(db_path))
+        rows = conn.execute("SELECT id FROM library ORDER BY id").fetchall()
+        conn.close()
+        assert [r[0] for r in rows] == [1, 2]
+
+    def test_fts5_index_created(self, tmp_path: Path) -> None:
+        """After import, FTS MATCH queries work against artist and title."""
+        tsv = _make_tsv(
+            [
+                ["1", "Aluminum Tunes", "Stereolab", "ST", "100", "1", "Rock", "CD", "\\N"],
+                ["2", "DOGA", "Juana Molina", "MO", "200", "2", "Rock", "LP", "\\N"],
+                ["3", "Confield", "Autechre", "AU", "300", "3", "Electronic", "CD", "\\N"],
+            ]
+        )
+        tsv_file = tmp_path / "input.tsv"
+        tsv_file.write_text(tsv, encoding="utf-8")
+        db_path = tmp_path / "library.db"
+
+        tsv_to_sqlite(str(tsv_file), str(db_path))
+
+        conn = sqlite3.connect(str(db_path))
+        # FTS search by artist
+        hits = conn.execute(
+            "SELECT rowid FROM library_fts WHERE library_fts MATCH 'Autechre'"
+        ).fetchall()
+        assert len(hits) == 1
+        assert hits[0][0] == 3
+
+        # FTS search by title
+        hits = conn.execute(
+            "SELECT rowid FROM library_fts WHERE library_fts MATCH 'Aluminum'"
+        ).fetchall()
+        assert len(hits) == 1
+        assert hits[0][0] == 1
+        conn.close()
+
+    def test_indexes_created(self, tmp_path: Path) -> None:
+        """idx_artist, idx_title, and idx_alternate_artist indexes exist."""
+        tsv = _make_tsv(
+            [
+                ["1", "Aluminum Tunes", "Stereolab", "ST", "100", "1", "Rock", "CD", "\\N"],
+            ]
+        )
+        tsv_file = tmp_path / "input.tsv"
+        tsv_file.write_text(tsv, encoding="utf-8")
+        db_path = tmp_path / "library.db"
+
+        tsv_to_sqlite(str(tsv_file), str(db_path))
+
+        conn = sqlite3.connect(str(db_path))
+        indexes = {
+            row[0]
+            for row in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type = 'index' AND tbl_name = 'library'"
+            ).fetchall()
+        }
+        conn.close()
+
+        assert "idx_artist" in indexes
+        assert "idx_title" in indexes
+        assert "idx_alternate_artist" in indexes
+
+    def test_empty_tsv_creates_schema(self, tmp_path: Path) -> None:
+        """An empty TSV creates the schema but contains 0 rows."""
+        tsv_file = tmp_path / "input.tsv"
+        tsv_file.write_text("", encoding="utf-8")
+        db_path = tmp_path / "library.db"
+
+        count = tsv_to_sqlite(str(tsv_file), str(db_path))
+
+        assert count == 0
+
+        conn = sqlite3.connect(str(db_path))
+        tables = {
+            row[0]
+            for row in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type IN ('table', 'shadow')"
+            ).fetchall()
+        }
+        row_count = conn.execute("SELECT COUNT(*) FROM library").fetchone()[0]
+        conn.close()
+
+        assert "library" in tables
+        assert row_count == 0
+
+    def test_unicode_data(self, tmp_path: Path) -> None:
+        """Unicode characters (accents, non-Latin scripts) round-trip correctly."""
+        tsv = _make_tsv(
+            [
+                ["1", "DOGA", "Juana Molina", "MO", "200", "2", "Rock", "LP", "\\N"],
+                [
+                    "2",
+                    "Pequena Vertigem de Amor",
+                    "Sessa",
+                    "SE",
+                    "300",
+                    "1",
+                    "Latin",
+                    "LP",
+                    "\\N",
+                ],
+                [
+                    "3",
+                    "( )",
+                    "Sigur R\u00f3s",
+                    "SI",
+                    "400",
+                    "1",
+                    "Rock",
+                    "CD",
+                    "Sigur R\u00f3s",
+                ],
+            ]
+        )
+        tsv_file = tmp_path / "input.tsv"
+        tsv_file.write_text(tsv, encoding="utf-8")
+        db_path = tmp_path / "library.db"
+
+        tsv_to_sqlite(str(tsv_file), str(db_path))
+
+        conn = sqlite3.connect(str(db_path))
+        rows = conn.execute(
+            "SELECT artist, alternate_artist_name FROM library ORDER BY id"
+        ).fetchall()
+        conn.close()
+
+        assert rows[0] == ("Juana Molina", None)
+        assert rows[1] == ("Sessa", None)
+        assert rows[2] == ("Sigur R\u00f3s", "Sigur R\u00f3s")
+
+    def test_returns_row_count(self, tmp_path: Path) -> None:
+        """Return value matches the number of rows inserted."""
+        tsv = _make_tsv(
+            [
+                ["1", "Aluminum Tunes", "Stereolab", "ST", "100", "1", "Rock", "CD", "\\N"],
+                ["2", "DOGA", "Juana Molina", "MO", "200", "2", "Rock", "LP", "\\N"],
+                ["3", "Confield", "Autechre", "AU", "300", "3", "Electronic", "CD", "\\N"],
+                [
+                    "4",
+                    "Pequena Vertigem de Amor",
+                    "Sessa",
+                    "SE",
+                    "400",
+                    "1",
+                    "Latin",
+                    "LP",
+                    "\\N",
+                ],
+            ]
+        )
+        tsv_file = tmp_path / "input.tsv"
+        tsv_file.write_text(tsv, encoding="utf-8")
+        db_path = tmp_path / "library.db"
+
+        count = tsv_to_sqlite(str(tsv_file), str(db_path))
+
+        assert count == 4
+
+    def test_malformed_row_logged(self, tmp_path: Path, capsys: pytest.CaptureFixture) -> None:
+        """Wrong column count produces a WARNING on stderr."""
+        tsv = "1\tAluminum Tunes\tStereolab\n"
+        tsv_file = tmp_path / "input.tsv"
+        tsv_file.write_text(tsv, encoding="utf-8")
+        db_path = tmp_path / "library.db"
+
+        tsv_to_sqlite(str(tsv_file), str(db_path))
+
+        captured = capsys.readouterr()
+        assert "WARNING" in captured.err
+        assert "3 fields" in captured.err
+
+    def test_cli_invocation(self, tmp_path: Path) -> None:
+        """Running as a subprocess produces a valid SQLite database."""
+        tsv = _make_tsv(
+            [
+                ["1", "Aluminum Tunes", "Stereolab", "ST", "100", "1", "Rock", "CD", "\\N"],
+                ["2", "DOGA", "Juana Molina", "MO", "200", "2", "Rock", "LP", "\\N"],
+            ]
+        )
+        tsv_file = tmp_path / "input.tsv"
+        tsv_file.write_text(tsv, encoding="utf-8")
+        db_path = tmp_path / "library.db"
+
+        result = subprocess.run(
+            [sys.executable, str(_SCRIPT_PATH), str(tsv_file), str(db_path)],
+            capture_output=True,
+            text=True,
+        )
+
+        assert result.returncode == 0
+        assert "Exported 2 rows" in result.stdout
+
+        conn = sqlite3.connect(str(db_path))
+        count = conn.execute("SELECT COUNT(*) FROM library").fetchone()[0]
+        conn.close()
+        assert count == 2
+
+    def test_tab_in_field_value(self, tmp_path: Path) -> None:
+        r"""MySQL escapes literal tabs in fields as \t; they should be unescaped."""
+        # MySQL -B -N escapes real tabs inside data as the two-char sequence \t.
+        # Our code splits on real tabs (\t), so literal \t in the data arrives as
+        # the two characters backslash-t, which are preserved as-is in the field.
+        tsv = "1\tAluminum\\tTunes\tStereolab\tST\t100\t1\tRock\tCD\t\\N\n"
+        tsv_file = tmp_path / "input.tsv"
+        tsv_file.write_text(tsv, encoding="utf-8")
+        db_path = tmp_path / "library.db"
+
+        tsv_to_sqlite(str(tsv_file), str(db_path))
+
+        conn = sqlite3.connect(str(db_path))
+        title = conn.execute("SELECT title FROM library WHERE id = 1").fetchone()[0]
+        conn.close()
+
+        # The escaped sequence \t is stored literally (two chars: backslash + t)
+        assert title == "Aluminum\\tTunes"
+
+    def test_newline_in_field_value(self, tmp_path: Path) -> None:
+        r"""MySQL escapes literal newlines in fields as \n; they should be preserved."""
+        # Similar to tabs: MySQL -B outputs literal \n (two chars) for embedded newlines.
+        # Since we split on real newlines, the two-char sequence stays intact.
+        tsv = "1\tNotes\\nMore notes\tAutechre\tAU\t300\t3\tElectronic\tCD\t\\N\n"
+        tsv_file = tmp_path / "input.tsv"
+        tsv_file.write_text(tsv, encoding="utf-8")
+        db_path = tmp_path / "library.db"
+
+        tsv_to_sqlite(str(tsv_file), str(db_path))
+
+        conn = sqlite3.connect(str(db_path))
+        title = conn.execute("SELECT title FROM library WHERE id = 1").fetchone()[0]
+        conn.close()
+
+        # The escaped sequence \n is stored literally (two chars: backslash + n)
+        assert title == "Notes\\nMore notes"


### PR DESCRIPTION
## Summary
- Extract inline Python heredoc from `sync-library.sh` into testable `scripts/tsv_to_sqlite.py`
- Update `sync-library.sh` to call the extracted script
- Add 12 unit tests, 2 integration tests, 1 E2E test (15 total)
- Tests cover: TSV parsing, NULL handling, column validation, FTS5, Unicode, CLI invocation, full pipeline

Closes #89

## Test plan
- [x] 15 new tests pass
- [x] All existing tests continue to pass
- [x] Ruff lint and format clean
- [ ] Trigger sync-library workflow to verify end-to-end