### PR TITLE
Standardize pytest markers in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,11 +44,12 @@ ignore = [
 
 [tool.pytest.ini_options]
 markers = [
-    "integration: marks tests as integration tests (needs library.db)",
-    "postgres: marks tests that need a PostgreSQL database",
+    "unit: pure logic tests, no external dependencies",
+    "postgres: needs PostgreSQL (gated by DATABASE_URL_TEST)",
+    "integration: needs external service or fixture data",
     "e2e: full pipeline end-to-end test",
-    "slow: marks tests as slow (deselect with '-m \"not slow\"')",
     "parity: old vs new implementation comparison",
+    "slow: marks tests as slow",
 ]
-addopts = "-m 'not integration and not postgres and not e2e and not slow and not parity'"
+addopts = "-m 'not integration and not postgres and not e2e and not parity and not slow'"
 testpaths = ["tests"]


### PR DESCRIPTION
## Summary

Replaces the local pytest marker block in `pyproject.toml` with the canonical 6-marker WXYC ETL block (`unit`, `postgres`, `integration`, `e2e`, `parity`, `slow`) defined in the org-local `plans/test-patterns.md`.

The previous block was missing the `unit` marker, so `pytest -m unit` failed in this repo. Marker descriptions are also brought into alignment with the other ETL repos (library-metadata-lookup, semantic-index, wxyc-catalog).

Part of WXYC/wxyc-etl#23 (test pattern standardization across ETL repos). This is the discogs-etl sub-PR (PR-A1 of the planned chain). Fixture data migration — originally bundled into #23 — has been split out to a focused follow-up: WXYC/discogs-etl#97.

## Test plan

- [x] \`pytest\` (no args) — only unit tests run, default-deselect behavior preserved
- [x] \`pytest -m unit\` — succeeds (was failing on \`main\` due to missing marker)
- [x] No new test failures introduced (189 collectable tests pass; 9 pre-existing collection errors due to local \`wxyc_etl\` install — unchanged from \`main\`)
- [ ] CI green