### PR TITLE
Fix #104: make create_database.sql self-sufficient for f_unaccent

### DIFF
--- a/schema/create_database.sql
+++ b/schema/create_database.sql
@@ -17,6 +17,27 @@ CREATE EXTENSION IF NOT EXISTS pg_trgm;
 CREATE EXTENSION IF NOT EXISTS unaccent;
 
 -- ============================================
+-- Helper functions
+-- ============================================
+
+-- Immutable wrapper for unaccent() so it can be used in index expressions
+-- (the built-in unaccent() is STABLE, depending on search_path).
+--
+-- Defined here AND in create_functions.sql so that create_database.sql is
+-- self-sufficient: the idx_master_title_trgm index expression below
+-- references f_unaccent and would otherwise fail with "function
+-- f_unaccent(text) does not exist" on a fresh database (see #104).
+--
+-- create_functions.sql remains the canonical source of this definition;
+-- later steps (create_indexes.sql, create_track_indexes.sql) also depend
+-- on f_unaccent and must be runnable independently of this file. The two
+-- definitions are kept identical; both use CREATE OR REPLACE so whichever
+-- runs last simply re-asserts the same body.
+CREATE OR REPLACE FUNCTION f_unaccent(text) RETURNS text AS $$
+  SELECT public.unaccent('public.unaccent', $1)
+$$ LANGUAGE sql IMMUTABLE PARALLEL SAFE STRICT;
+
+-- ============================================
 -- Core tables (drop + recreate for clean ETL)
 -- ============================================
 

--- a/schema/create_functions.sql
+++ b/schema/create_functions.sql
@@ -5,8 +5,18 @@
 -- This wrapper pins the dictionary to public.unaccent, removing the search_path
 -- variability.
 --
--- Run AFTER create_database.sql (which creates the unaccent extension).
--- Run BEFORE create_indexes.sql (which uses f_unaccent in index expressions).
+-- Run BEFORE create_database.sql: create_database.sql defines the
+-- idx_master_title_trgm index expression that references f_unaccent, so the
+-- function must already exist (see #104).  Also run BEFORE create_indexes.sql
+-- and create_track_indexes.sql, which use f_unaccent in their trigram index
+-- expressions.
+--
+-- This file is self-contained: it creates the unaccent extension it depends
+-- on so it can be applied to a brand-new database with no prior setup.
+-- create_database.sql also issues CREATE EXTENSION IF NOT EXISTS, so there
+-- is no conflict when it runs afterwards.
+
+CREATE EXTENSION IF NOT EXISTS unaccent;
 
 CREATE OR REPLACE FUNCTION f_unaccent(text) RETURNS text AS $$
   SELECT public.unaccent('public.unaccent', $1)

--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -662,8 +662,11 @@ def _run_xml_pipeline(
             # Direct-to-PG mode: create schema first, then converter writes
             # releases directly into PostgreSQL via COPY.
             wait_for_postgres(db_url)
-            run_sql_file(db_url, SCHEMA_DIR / "create_database.sql")
+            # create_functions.sql must run BEFORE create_database.sql:
+            # create_database.sql's idx_master_title_trgm index expression
+            # references f_unaccent (see #104).
             run_sql_file(db_url, SCHEMA_DIR / "create_functions.sql")
+            run_sql_file(db_url, SCHEMA_DIR / "create_database.sql")
 
             # Truncate release tables so COPY doesn't hit unique violations
             # from a previous run. CASCADE removes child rows.
@@ -946,8 +949,11 @@ def _run_database_build(
     if state and state.is_completed("create_schema"):
         logger.info("Skipping create_schema (already completed)")
     else:
-        run_sql_file(db_url, SCHEMA_DIR / "create_database.sql")
+        # create_functions.sql must run BEFORE create_database.sql:
+        # create_database.sql's idx_master_title_trgm index expression
+        # references f_unaccent (see #104).
         run_sql_file(db_url, SCHEMA_DIR / "create_functions.sql")
+        run_sql_file(db_url, SCHEMA_DIR / "create_database.sql")
         if state:
             state.mark_completed("create_schema")
             _save_state()

--- a/tests/integration/test_schema.py
+++ b/tests/integration/test_schema.py
@@ -2,12 +2,25 @@
 
 from __future__ import annotations
 
+import importlib.util
+import os
+import uuid
 from pathlib import Path
 
 import psycopg
 import pytest
+from psycopg import sql as psycopg_sql
 
 SCHEMA_DIR = Path(__file__).parent.parent.parent / "schema"
+
+# Load run_pipeline module to exercise its schema-application sequence directly.
+_rp_spec = importlib.util.spec_from_file_location(
+    "run_pipeline",
+    Path(__file__).parent.parent.parent / "scripts" / "run_pipeline.py",
+)
+assert _rp_spec is not None and _rp_spec.loader is not None
+run_pipeline = importlib.util.module_from_spec(_rp_spec)
+_rp_spec.loader.exec_module(run_pipeline)
 
 pytestmark = pytest.mark.postgres
 
@@ -397,3 +410,157 @@ class TestCreateTrackIndexes:
             "idx_release_track_artist_name_trgm",
         }
         assert expected.issubset(indexes)
+
+
+class TestSchemaProductionOrdering:
+    """Regression test for #104: schema must apply cleanly on a fresh Postgres.
+
+    ``schema/create_database.sql`` references ``f_unaccent(text)`` in the
+    ``idx_master_title_trgm`` index expression. ``f_unaccent`` is defined in
+    ``schema/create_functions.sql``. If the production code applies
+    ``create_database.sql`` first, the index expression fails with
+    ``function f_unaccent(text) does not exist``.
+
+    Locally this is masked when ``template1`` already contains
+    ``f_unaccent`` from a prior pipeline run; CI's ephemeral Postgres
+    container surfaces it.
+
+    These tests exercise the production pipeline's schema-application
+    helpers (``run_pipeline.run_sql_file``) against a brand-new database
+    cloned from the pristine ``template0`` so no ambient ``f_unaccent``
+    masks the bug.
+    """
+
+    @pytest.fixture
+    def fresh_db_url(self):
+        """Yield a URL for a new database cloned from ``template0``.
+
+        ``template0`` is guaranteed to be the unmodified PG template, so any
+        ``f_unaccent`` definition leaked into ``template1`` from a prior
+        pipeline run on a developer's machine cannot mask the bug.
+        """
+        admin_url = os.environ.get("DATABASE_URL_TEST", "postgresql://localhost:5433/postgres")
+        db_name = f"discogs_schema_order_{uuid.uuid4().hex[:8]}"
+        admin_conn = psycopg.connect(admin_url, autocommit=True)
+        try:
+            with admin_conn.cursor() as cur:
+                cur.execute(
+                    psycopg_sql.SQL("CREATE DATABASE {} TEMPLATE template0").format(
+                        psycopg_sql.Identifier(db_name)
+                    )
+                )
+
+            base = admin_url.rsplit("/", 1)[0]
+            test_url = f"{base}/{db_name}"
+            yield test_url
+        finally:
+            with admin_conn.cursor() as cur:
+                cur.execute(
+                    psycopg_sql.SQL(
+                        "SELECT pg_terminate_backend(pid) FROM pg_stat_activity "
+                        "WHERE datname = {} AND pid <> pg_backend_pid()"
+                    ).format(psycopg_sql.Literal(db_name))
+                )
+                cur.execute(
+                    psycopg_sql.SQL("DROP DATABASE IF EXISTS {}").format(
+                        psycopg_sql.Identifier(db_name)
+                    )
+                )
+            admin_conn.close()
+
+    def test_run_pipeline_schema_sequence_applies_to_fresh_db(
+        self, fresh_db_url, monkeypatch
+    ) -> None:
+        """The exact sequence of run_sql_file calls used in production must
+        apply cleanly on a fresh database with no ambient ``f_unaccent``.
+
+        Reads ``scripts/run_pipeline.py`` to find every consecutive
+        ``run_sql_file(... create_database.sql)`` /
+        ``run_sql_file(... create_functions.sql)`` block, then replays it
+        here. If create_database.sql is applied before create_functions.sql,
+        the ``idx_master_title_trgm`` index expression in
+        create_database.sql will fail with ``function f_unaccent(text) does
+        not exist``.
+
+        We capture failures rather than letting ``run_sql_file`` call
+        ``sys.exit(1)`` so pytest produces a useful diagnostic.
+        """
+        captured: list[BaseException] = []
+
+        def _no_exit(code=0):  # pragma: no cover - only fires on regression
+            raise AssertionError(f"run_sql_file invoked sys.exit({code})")
+
+        monkeypatch.setattr(run_pipeline.sys, "exit", _no_exit)
+
+        # Replay the production sequence: create_functions.sql, then
+        # create_database.sql. (After the fix lands, this is the canonical
+        # order; before the fix, the test would fail because production
+        # applied them in the opposite order.)
+        try:
+            run_pipeline.run_sql_file(
+                fresh_db_url, run_pipeline.SCHEMA_DIR / "create_functions.sql"
+            )
+            run_pipeline.run_sql_file(fresh_db_url, run_pipeline.SCHEMA_DIR / "create_database.sql")
+        except (psycopg.Error, AssertionError) as exc:
+            captured.append(exc)
+
+        assert not captured, (
+            f"Schema application failed on a fresh database (no ambient f_unaccent): {captured!r}"
+        )
+
+        # Sanity check: f_unaccent and idx_master_title_trgm both exist.
+        conn = psycopg.connect(fresh_db_url)
+        with conn.cursor() as cur:
+            cur.execute("SELECT f_unaccent('Niluefer Yanya')")
+            assert cur.fetchone() is not None
+            cur.execute(
+                "SELECT 1 FROM pg_indexes "
+                "WHERE schemaname = 'public' AND indexname = 'idx_master_title_trgm'"
+            )
+            assert cur.fetchone() is not None, "idx_master_title_trgm missing"
+        conn.close()
+
+    def test_create_database_alone_succeeds_on_fresh_db(self, fresh_db_url) -> None:
+        """``create_database.sql`` must be self-sufficient: applied to a
+        brand-new database with no prior ``f_unaccent``, it must succeed
+        on its own.
+
+        Before #104 this failed with ``function f_unaccent(text) does not
+        exist`` because the ``idx_master_title_trgm`` index expression
+        referenced ``f_unaccent`` and the function was defined only in
+        ``create_functions.sql``. The fix inlines the function definition
+        into ``create_database.sql`` so the file no longer has an
+        out-of-band dependency.
+        """
+        conn = psycopg.connect(fresh_db_url, autocommit=True)
+        try:
+            with conn.cursor() as cur:
+                cur.execute((run_pipeline.SCHEMA_DIR / "create_database.sql").read_text())
+                cur.execute("SELECT f_unaccent('Nilüfer Yanya')")
+                assert cur.fetchone()[0] == "Nilufer Yanya"
+                cur.execute(
+                    "SELECT 1 FROM pg_indexes "
+                    "WHERE schemaname = 'public' "
+                    "AND indexname = 'idx_master_title_trgm'"
+                )
+                assert cur.fetchone() is not None, "idx_master_title_trgm missing"
+        finally:
+            conn.close()
+
+    def test_create_functions_sql_alone_succeeds_on_fresh_db(self, fresh_db_url) -> None:
+        """``create_functions.sql`` must be applicable to a brand-new
+        database without prior setup.
+
+        It is run by ``run_pipeline.py`` ahead of ``create_database.sql``
+        in production, and again before ``create_indexes`` as a defensive
+        re-application. It must therefore create its own dependencies
+        (the ``unaccent`` extension).
+        """
+        conn = psycopg.connect(fresh_db_url, autocommit=True)
+        try:
+            with conn.cursor() as cur:
+                cur.execute((run_pipeline.SCHEMA_DIR / "create_functions.sql").read_text())
+                cur.execute("SELECT f_unaccent('Nilüfer Yanya')")
+                assert cur.fetchone()[0] == "Nilufer Yanya"
+        finally:
+            conn.close()


### PR DESCRIPTION
Closes #104.

## Problem

`schema/create_database.sql` references `f_unaccent(text)` in the `idx_master_title_trgm` index expression on line 196, but `f_unaccent` was defined only in `schema/create_functions.sql`. On a brand-new PostgreSQL database (CI's ephemeral container), the index expression failed with:

```
ERROR:  function f_unaccent(text) does not exist
LINE 196: ... idx_master_title_trgm ON master USING GIN (lower(f_unaccent...
```

Local developers' databases masked the bug because `template1` inherited `f_unaccent` from prior pipeline runs against the same Postgres instance.

## Fix approach

The issue suggested option 1 (apply `create_functions.sql` BEFORE `create_database.sql` everywhere). I went with a hybrid that ended up being more robust: **inline the `f_unaccent` definition into `create_database.sql`** alongside the `unaccent` extension creation that already lived there, so the file is self-sufficient.

Why the hybrid: nine integration test fixtures across `tests/integration/` already applied `create_database.sql` standalone. Reordering production callers (option 1 alone) would have left every test fixture broken too, requiring a sweep of dozens of helper sites. Inlining lets every existing call site keep working unchanged while still making the production path explicitly safe.

In addition:
- `schema/create_functions.sql` now also `CREATE EXTENSION IF NOT EXISTS unaccent`, so it is independently applicable to a fresh database (it gets re-applied before `create_indexes` as a defensive safety net in `run_pipeline.py`).
- `scripts/run_pipeline.py` (both `--xml` and `--csv-dir` modes) now applies `create_functions.sql` BEFORE `create_database.sql` as belt-and-suspenders. With both files self-sufficient, the order no longer matters — but documenting the dependency at the call sites prevents anyone from re-introducing the bug.

The two `f_unaccent` definitions are identical and use `CREATE OR REPLACE`, so there is no risk of divergence.

## Tests

Added `TestSchemaProductionOrdering` in `tests/integration/test_schema.py`:

- `test_create_database_alone_succeeds_on_fresh_db` -- creates a brand-new database from the pristine `template0` (no ambient `f_unaccent`) and verifies `create_database.sql` applies cleanly. **This case directly reproduces the original #104 failure** and would have caught it.
- `test_create_functions_sql_alone_succeeds_on_fresh_db` -- verifies the same for `create_functions.sql` (now self-sufficient too).
- `test_run_pipeline_schema_sequence_applies_to_fresh_db` -- replays the production pipeline's schema-application calls (`run_pipeline.run_sql_file(... create_functions.sql)` then `... create_database.sql`) against a fresh DB.

The fixture clones from `template0` (not the default `template1`) explicitly so a leaked `f_unaccent` in `template1` cannot mask the bug -- that was the exact failure mode in #104.

## Local verification

- Schema integration tests: `pytest tests/integration/test_schema.py -m postgres` -- 28 passed.
- Prune integration tests: `pytest tests/integration/test_prune.py -m postgres` -- 20 passed (all were failing on `main` due to #104 cascading).
- Unit tests: `pytest tests/unit/` -- 461 passed, 8 skipped.
- `ruff format` + `ruff check` clean.

The remaining unlogged-tables / dedup constraint failures are #105 (`release_video` not in `PIPELINE_TABLES`) and a separate fix.