### PR TITLE
Fix #105: include release_video in PIPELINE_TABLES

### DIFF
--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -62,7 +62,16 @@ SCHEMA_DIR = SCRIPT_DIR.parent / "schema"
 # Maximum seconds to wait for Postgres to become ready.
 PG_CONNECT_TIMEOUT = 30
 
-# Tables managed by the pipeline (shared by run_vacuum, set_tables_unlogged, set_tables_logged).
+# Tables managed by the pipeline (shared by run_vacuum, set_tables_unlogged,
+# set_tables_logged).
+#
+# Every table with a FK to ``release`` must be listed here. PostgreSQL prohibits
+# an UNLOGGED table from being referenced by a LOGGED table (and vice versa),
+# so any FK referrer of ``release`` that is missing from this list will cause
+# ``ALTER TABLE release SET UNLOGGED`` to fail with ``could not change table
+# "release" to unlogged because it references logged table "<missing>"`` (see
+# #105). The ``test_pipeline_tables_covers_all_release_fk_referrers`` unit test
+# enforces this invariant against ``schema/create_database.sql``.
 PIPELINE_TABLES = [
     "release",
     "release_artist",
@@ -71,6 +80,7 @@ PIPELINE_TABLES = [
     "release_style",
     "release_track",
     "release_track_artist",
+    "release_video",
     "cache_metadata",
 ]
 

--- a/tests/integration/test_dedup.py
+++ b/tests/integration/test_dedup.py
@@ -826,7 +826,12 @@ class TestAddConstraintsAndIndexes:
         with conn.cursor() as cur:
             cur.execute(SCHEMA_DIR.joinpath("create_database.sql").read_text())
             cur.execute(SCHEMA_DIR.joinpath("create_functions.sql").read_text())
-            # Drop all FK constraints and indexes (schema creates them)
+            # Drop all FK constraints and indexes (schema creates them).
+            # release_video must be included so the subsequent
+            # ``DROP CONSTRAINT release_pkey`` doesn't fail with
+            # ``cannot drop constraint release_pkey on table release because
+            # other objects depend on it`` (release_video's FK depends on
+            # the release primary key index; see #105).
             for constraint, table in [
                 ("release_artist_release_id_fkey", "release_artist"),
                 ("release_label_release_id_fkey", "release_label"),
@@ -834,6 +839,7 @@ class TestAddConstraintsAndIndexes:
                 ("release_style_release_id_fkey", "release_style"),
                 ("release_track_release_id_fkey", "release_track"),
                 ("release_track_artist_release_id_fkey", "release_track_artist"),
+                ("release_video_release_id_fkey", "release_video"),
                 ("cache_metadata_release_id_fkey", "cache_metadata"),
             ]:
                 cur.execute(f"ALTER TABLE {table} DROP CONSTRAINT IF EXISTS {constraint}")

--- a/tests/unit/test_run_pipeline.py
+++ b/tests/unit/test_run_pipeline.py
@@ -286,7 +286,10 @@ class TestRunVacuum:
         args, kwargs = mock_parallel.call_args
         db_url, statements = args[0], args[1]
         assert db_url == "postgresql:///test"
-        assert len(statements) == 8
+        # One VACUUM FULL per pipeline table (derived from the constant so this
+        # test stays in sync as PIPELINE_TABLES grows; see #105 for the
+        # ``release_video`` addition).
+        assert len(statements) == len(run_pipeline.PIPELINE_TABLES)
         assert all(s.startswith("VACUUM FULL ") for s in statements)
         assert "VACUUM FULL release" in statements
         assert "VACUUM FULL cache_metadata" in statements
@@ -306,9 +309,62 @@ class TestPipelineTables:
             "release_style",
             "release_track",
             "release_track_artist",
+            "release_video",
             "cache_metadata",
         }
         assert set(run_pipeline.PIPELINE_TABLES) == expected
+
+    def test_release_video_included(self) -> None:
+        """Regression for #105: ``release_video`` must be in PIPELINE_TABLES.
+
+        ``release_video`` has a FK to ``release``. PostgreSQL prohibits an
+        UNLOGGED table from being referenced by a LOGGED table (and vice
+        versa), so ``ALTER TABLE release SET UNLOGGED`` fails with
+        ``could not change table "release" to unlogged because it
+        references logged table "release_video"`` unless ``release_video``
+        is toggled in lockstep with the other pipeline tables.
+        """
+        assert "release_video" in run_pipeline.PIPELINE_TABLES, (
+            "release_video must be in PIPELINE_TABLES so set_tables_unlogged "
+            "and set_tables_logged toggle it together with release; otherwise "
+            "the FK constraint blocks the ALTER TABLE (see #105)."
+        )
+
+    def test_pipeline_tables_covers_all_release_fk_referrers(self) -> None:
+        """Every table with a FK to ``release`` in create_database.sql must
+        be in PIPELINE_TABLES, so the SET UNLOGGED / SET LOGGED toggles
+        cannot leave the schema in a mixed-persistence state that PG
+        rejects.
+
+        This static check catches the next ``release_video``-style
+        omission at unit-test time, before it manifests as an integration
+        failure.
+        """
+        import re
+
+        schema_sql = (
+            Path(__file__).parent.parent.parent / "schema" / "create_database.sql"
+        ).read_text()
+        # Find every "CREATE TABLE <name> (" header followed by a body
+        # containing "REFERENCES release(id)". This is intentionally
+        # forgiving of whitespace.
+        table_pattern = re.compile(
+            r"CREATE\s+TABLE\s+(\w+)\s*\((.*?)\n\);",
+            re.DOTALL | re.IGNORECASE,
+        )
+        referrers: set[str] = set()
+        for match in table_pattern.finditer(schema_sql):
+            name, body = match.group(1), match.group(2)
+            if re.search(r"REFERENCES\s+release\s*\(\s*id\s*\)", body, re.IGNORECASE):
+                referrers.add(name)
+        assert referrers, "expected to find FK references to release(id)"
+        # release itself is the parent and is always in PIPELINE_TABLES.
+        missing = referrers - set(run_pipeline.PIPELINE_TABLES)
+        assert not missing, (
+            f"Tables with FK to release(id) missing from PIPELINE_TABLES: "
+            f"{sorted(missing)}. They will block ALTER TABLE release "
+            "SET UNLOGGED/LOGGED (see #105)."
+        )
 
     def test_run_vacuum_uses_pipeline_tables(self) -> None:
         """run_vacuum should generate VACUUM FULL from PIPELINE_TABLES."""


### PR DESCRIPTION
Closes #105.

## Problem

`release_video` has a FK to `release` but was not in `PIPELINE_TABLES`. PostgreSQL prohibits an UNLOGGED table from being referenced by a LOGGED table (and vice versa), so `set_tables_unlogged()` failed with:

```
could not change table "release" to unlogged because it references logged table "release_video"
```

This blocked the `TestUnloggedEdgeCases::test_set_unlogged_idempotent` and `test_unlogged_to_logged_preserves_data` tests called out in the issue.

## Fix approach

Took option 1 from the issue: add `release_video` to `PIPELINE_TABLES` so it gets toggled in lockstep with `release` and the other FK referrers. This is consistent with how `release_genre` and `release_style` (other FK referrers without separate import logic) are already handled.

The leading comment on `PIPELINE_TABLES` is expanded to document the FK invariant so future maintainers see it alongside the constant. All three callers (`run_vacuum`, `set_tables_unlogged`, `set_tables_logged`) iterate over the constant and need no further changes.

## Tests

Added in `tests/unit/test_run_pipeline.py::TestPipelineTables`:

- `test_release_video_included` -- direct assertion that `release_video` is in `PIPELINE_TABLES` with an explanatory message that points to #105.
- `test_pipeline_tables_covers_all_release_fk_referrers` -- parses `schema/create_database.sql` and asserts every table with a FK to `release(id)` is in `PIPELINE_TABLES`. **This static check catches the next `release_video`-style omission at unit-test time** before it manifests as an integration failure.
- `test_pipeline_tables_matches_vacuum_tables` -- updated to include `release_video` in the expected set.

`test_vacuum_uses_parallel_execution` previously hardcoded `len(statements) == 8`; switched to `len(run_pipeline.PIPELINE_TABLES)` so it stays in sync as the constant grows.

Also updated `tests/integration/test_dedup.py::TestAddConstraintsAndIndexes` fixture to drop `release_video_release_id_fkey` alongside the other FK constraints; otherwise the subsequent `DROP CONSTRAINT release_pkey` failed with `release_video FK depends on release_pkey`. This was a related test-fixture bug surfaced by the same root cause.

## Local verification (CI doesn't run postgres tests)

CI's `test-postgres` job currently silently deselects postgres tests (per #103), so this fix cannot be validated by CI. Verified locally against PostgreSQL 16 on port 5433:

```bash
DATABASE_URL_TEST=postgresql://discogs:discogs@localhost:5433/postgres \
  pytest tests/integration/test_error_resilience.py::TestUnloggedEdgeCases \
         tests/integration/test_unlogged_tables.py \
         tests/unit/test_run_pipeline.py::TestPipelineTables -v -m postgres
```

Both target tests now pass:

- `test_set_unlogged_idempotent` PASSED
- `test_unlogged_to_logged_preserves_data` PASSED

Plus all 6 `test_unlogged_tables.py` cases, all 3 new unit-test regressions, and all 3 `TestAddConstraintsAndIndexes` cases (which fixture had to be updated for `release_video` too).

Full unit-test suite: 463 passed, 8 skipped.
`ruff format` + `ruff check` clean.

## Builds on #104

This PR depends on the schema-ordering fix in #104; without it, the test fixture for `test_set_unlogged_idempotent` could not even apply the schema (the `f_unaccent` failure would mask the real issue).