### PR TITLE
Verify #110: schema regression test runs in pre-merge CI

### DIFF
--- a/schema/create_database.sql
+++ b/schema/create_database.sql
@@ -3,6 +3,9 @@
 --
 -- This schema includes all columns used by cache_service.py and downstream consumers.
 -- FK constraints with ON DELETE CASCADE enable single-table pruning.
+-- Schema regression coverage: tests/integration/test_schema.py::TestSchemaProductionOrdering
+-- guards against ordering bugs (e.g. #104) by applying these files to a pristine
+-- template0-cloned database in CI.
 
 -- Create database (run as superuser)
 -- CREATE DATABASE discogs;


### PR DESCRIPTION
Verifies #110.

Confirms that `tests/integration/test_schema.py::TestSchemaProductionOrdering` (added in #106 for the f_unaccent ordering bug #104) actually runs in pre-merge CI now that #103/#108 enabled postgres tests in the `test-postgres` job.

## What was verified

- `TestSchemaProductionOrdering` is module-marked `@pytest.mark.postgres`. The `test-postgres` CI job runs `pytest -v -m "not slow" ...` with `DATABASE_URL_TEST` set, so postgres-marked tests are no longer deselected.
- The fixture clones from `template0` (not `template1`), so any ambient `f_unaccent` definition leaked into a developer's local PG can't mask the bug.
- Locally reproduced the regression: temporarily removed the inlined `CREATE OR REPLACE FUNCTION f_unaccent` from `schema/create_database.sql` and ran the test class. `test_create_database_alone_succeeds_on_fresh_db` failed with the exact error the regression guards against:
  ```
  psycopg.errors.UndefinedFunction: function f_unaccent(text) does not exist
  LINE 196: ... idx_master_title_trgm ON master USING GIN (lower(f_unaccent...
  ```
  The local change was reverted before this commit; the only diff in this PR is a header comment in `schema/create_database.sql` pointing at the regression test, which also serves as the trivial schema touch needed to trigger CI on this PR.

## Acceptance from #110

- [x] PR touches `schema/create_database.sql`
- [x] `test-postgres` CI job will run `TestSchemaProductionOrdering::*` (verified via marker + `-m "not slow"` selection; CI run on this PR will show it in the log)
- [x] Test would fail if the schema-ordering bug were re-introduced (verified locally)

Closes #110.