### PR TITLE
chore: migrate pytest markers to architecture A

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,12 +74,17 @@ jobs:
         run: |
           PGPASSWORD=discogs psql -h localhost -p 5433 -U discogs -d postgres \
             -c "CREATE EXTENSION IF NOT EXISTS pg_trgm;"
-      - name: Run pg-marked tests with coverage
+      - name: Run pg-marked + default tests with coverage
         env:
           DATABASE_URL_TEST: postgresql://discogs:discogs@localhost:5433/postgres
+        # The expression "pg or not slow" selects PG-marked tests plus the
+        # default no-marker tests (everything that is not `slow`). Running
+        # both in a single invocation means the --cov-fail-under gate sees
+        # combined coverage. The positive `pg` term satisfies the marker
+        # sync-check.
         run: >-
           pytest -v
-          -m "pg and not slow"
+          -m "pg or not slow"
           --cov=scripts --cov=lib
           --cov-report=term-missing
           --cov-fail-under=60

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
       - run: pip install -e ".[dev]"
       - run: pytest tests/unit/ -v
 
-  test-postgres:
+  pg:
     runs-on: ubuntu-latest
     services:
       postgres:
@@ -74,12 +74,19 @@ jobs:
         run: |
           PGPASSWORD=discogs psql -h localhost -p 5433 -U discogs -d postgres \
             -c "CREATE EXTENSION IF NOT EXISTS pg_trgm;"
-      - name: Run all tests with coverage
+      - name: Run pg-marked tests with coverage
         env:
           DATABASE_URL_TEST: postgresql://discogs:discogs@localhost:5433/postgres
         run: >-
           pytest -v
-          -m "not slow"
+          -m "pg and not slow"
           --cov=scripts --cov=lib
           --cov-report=term-missing
           --cov-fail-under=60
+
+  marker-sync:
+    uses: WXYC/wxyc-etl/.github/workflows/check-ci-marker-sync.yml@main
+    with:
+      repo-path: "."
+      workflows-dir: ".github/workflows"
+      tests-dir: "tests"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,22 +101,35 @@ Functionality that was previously local to this repo has been extracted to share
 
 ### Testing
 
-Three test layers with pytest markers:
+The repo follows architecture A from `wxyc/plans/test-patterns.md`: markers route CI by infrastructure, not by tier. Directory layout (`tests/unit/`, `tests/integration/`, `tests/e2e/`) documents the tier; markers describe operational requirements only.
+
+Declared markers:
+
+| Marker | Meaning | When to use |
+|---|---|---|
+| `pg` | needs a PostgreSQL service (`DATABASE_URL_TEST`) | every test that connects to Postgres, regardless of tier |
+| `slow` | takes longer than ~10s (orthogonal to infra) | perf benchmarks; opt-out from CI sync-check, run manually |
+
+Tests with no marker are the default pytest run (no infrastructure required).
 
 ```bash
-# Unit tests (no external dependencies, run by default)
-pytest tests/unit/ -v
+# Default run: no-marker tests only (pure-logic unit tests + in-memory SQLite + library.db fixture tests)
+pytest
 
-# Integration tests (needs PostgreSQL on port 5433)
+# PG-backed tests (integration + E2E that touch Postgres)
+docker compose up db -d
 DATABASE_URL_TEST=postgresql://discogs:discogs@localhost:5433/postgres \
-  pytest -m postgres -v
+  pytest -m pg -v
 
-# E2E tests (runs full pipeline as subprocess against test Postgres)
+# Combine PG with the default tier
 DATABASE_URL_TEST=postgresql://discogs:discogs@localhost:5433/postgres \
-  pytest -m e2e -v
+  pytest -m "pg or not pg" -v --ignore-glob='*slow*'   # everything but slow
+
+# Perf benchmarks (rare, manual)
+pytest -m slow -v
 ```
 
-Markers: `postgres` (needs PostgreSQL), `e2e` (full pipeline), `integration` (needs library.db). Integration and E2E tests are excluded from the default `pytest` run via `addopts` in `pyproject.toml`.
+CI runs three pytest jobs per push/PR: `lint`, `test` (default no-marker run, unit dir only), `pg` (PG-marked tests with coverage), and `marker-sync` (the reusable sync-check workflow from wxyc-etl that catches markers silently deselected by addopts).
 
 Test fixtures are in `tests/fixtures/` (CSV files, library.db, library_artists.txt). Regenerate with `python tests/fixtures/create_fixtures.py`.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,15 +121,15 @@ docker compose up db -d
 DATABASE_URL_TEST=postgresql://discogs:discogs@localhost:5433/postgres \
   pytest -m pg -v
 
-# Combine PG with the default tier
+# Everything that is not slow (PG-backed plus default tier in one run, for coverage)
 DATABASE_URL_TEST=postgresql://discogs:discogs@localhost:5433/postgres \
-  pytest -m "pg or not pg" -v --ignore-glob='*slow*'   # everything but slow
+  pytest -m "pg or not slow" -v
 
-# Perf benchmarks (rare, manual)
+# Perf benchmarks (rare, manual; opted-out from the marker sync-check)
 pytest -m slow -v
 ```
 
-CI runs three pytest jobs per push/PR: `lint`, `test` (default no-marker run, unit dir only), `pg` (PG-marked tests with coverage), and `marker-sync` (the reusable sync-check workflow from wxyc-etl that catches markers silently deselected by addopts).
+CI runs four jobs per push/PR: `lint`, `test` (default no-marker run, unit dir only), `pg` (`-m "pg or not slow"` against PostgreSQL with `--cov-fail-under=60` -- the PG-and-default combined run is what hits the gate), and `marker-sync` (the reusable sync-check workflow from wxyc-etl that catches markers silently deselected by addopts).
 
 Test fixtures are in `tests/fixtures/` (CSV files, library.db, library_artists.txt). Regenerate with `python tests/fixtures/create_fixtures.py`.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,13 +43,10 @@ ignore = [
 ]
 
 [tool.pytest.ini_options]
+# ci-sync-skip: slow reason: perf benchmarks are run manually on demand, not in CI
 markers = [
-    "unit: pure logic tests, no external dependencies",
-    "postgres: needs PostgreSQL (gated by DATABASE_URL_TEST)",
-    "integration: needs external service or fixture data",
-    "e2e: full pipeline end-to-end test",
-    "parity: old vs new implementation comparison",
-    "slow: marks tests as slow",
+    "pg: needs a PostgreSQL service (DATABASE_URL_TEST)",
+    "slow: takes longer than ~10s (orthogonal to infra)",
 ]
-addopts = "-m 'not integration and not postgres and not e2e and not parity and not slow'"
+addopts = "-m 'not pg and not slow'"
 testpaths = ["tests"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,7 @@
 
 The fixtures create a temporary test database, run the schema, and clean up
 on teardown.  Tests that need Postgres should use the ``db_url`` or ``db_conn``
-fixtures and be marked with ``@pytest.mark.postgres``.
+fixtures and be marked with ``@pytest.mark.pg``.
 
 Connection target:
     DATABASE_URL_TEST env var, default ``postgresql://localhost:5433/postgres``.

--- a/tests/e2e/test_discogs_pipeline_e2e.py
+++ b/tests/e2e/test_discogs_pipeline_e2e.py
@@ -60,7 +60,7 @@ try:
 except ImportError:
     HAS_ASYNCPG = False
 
-pytestmark = pytest.mark.e2e
+pytestmark = pytest.mark.pg
 
 
 @pytest.fixture(scope="class")

--- a/tests/e2e/test_entity_resolution_e2e.py
+++ b/tests/e2e/test_entity_resolution_e2e.py
@@ -90,7 +90,7 @@ UNKNOWN_ARTISTS = [
     "Fake Artist 12345",
 ]
 
-pytestmark = pytest.mark.e2e
+pytestmark = pytest.mark.pg
 
 # -- Entity schema DDL (matches wxyc-etl schema/entity.rs) --
 

--- a/tests/e2e/test_pipeline.py
+++ b/tests/e2e/test_pipeline.py
@@ -24,7 +24,7 @@ RUN_PIPELINE = Path(__file__).parent.parent.parent / "scripts" / "run_pipeline.p
 
 ADMIN_URL = os.environ.get("DATABASE_URL_TEST", "postgresql://localhost:5433/postgres")
 
-pytestmark = pytest.mark.e2e
+pytestmark = pytest.mark.pg
 
 
 @pytest.fixture(scope="class")

--- a/tests/e2e/test_rust_fuzzy_e2e.py
+++ b/tests/e2e/test_rust_fuzzy_e2e.py
@@ -34,7 +34,7 @@ VERIFY_CACHE = Path(__file__).parent.parent.parent / "scripts" / "verify_cache.p
 
 ADMIN_URL = os.environ.get("DATABASE_URL_TEST", "postgresql://localhost:5433/postgres")
 
-pytestmark = pytest.mark.e2e
+pytestmark = pytest.mark.pg
 
 
 def _postgres_available() -> bool:

--- a/tests/e2e/test_sync_library_e2e.py
+++ b/tests/e2e/test_sync_library_e2e.py
@@ -38,7 +38,6 @@ def _load_export_streaming_links():
         sys.path.pop(0)
 
 
-@pytest.mark.e2e
 @pytest.mark.skipif(not _has_lml, reason="library-metadata-lookup repo not found")
 class TestSyncLibraryE2E:
     """End-to-end test: generate TSV, build library.db, enrich with streaming links."""

--- a/tests/integration/test_connection_resilience.py
+++ b/tests/integration/test_connection_resilience.py
@@ -54,7 +54,7 @@ import_csv_func = _ic.import_csv
 populate_cache_metadata = _ic.populate_cache_metadata
 BASE_TABLES = _ic.BASE_TABLES
 
-pytestmark = pytest.mark.postgres
+pytestmark = pytest.mark.pg
 
 
 ALL_TABLES = (

--- a/tests/integration/test_copy_to_target.py
+++ b/tests/integration/test_copy_to_target.py
@@ -64,7 +64,7 @@ Decision = _vc.Decision
 classify_all_releases = _vc.classify_all_releases
 copy_releases_to_target = _vc.copy_releases_to_target
 
-pytestmark = [pytest.mark.postgres]
+pytestmark = [pytest.mark.pg]
 
 
 def _fresh_import(db_url: str) -> None:

--- a/tests/integration/test_dedup.py
+++ b/tests/integration/test_dedup.py
@@ -40,7 +40,7 @@ load_library_labels = _dd.load_library_labels
 load_label_hierarchy = _dd.load_label_hierarchy
 create_label_match_table = _dd.create_label_match_table
 
-pytestmark = pytest.mark.postgres
+pytestmark = pytest.mark.pg
 
 ALL_TABLES = (
     "cache_metadata",

--- a/tests/integration/test_error_resilience.py
+++ b/tests/integration/test_error_resilience.py
@@ -6,7 +6,7 @@ Tests that external dependency failures are handled gracefully:
 - Dedup mid-ANALYZE / mid-copy-swap connection termination
 - Import COPY interruption (malformed data, partial failures)
 
-All tests require PostgreSQL and are marked with @pytest.mark.postgres.
+All tests require PostgreSQL and are marked with @pytest.mark.pg.
 Uses WXYC example artists for fixture data.
 """
 
@@ -49,7 +49,7 @@ assert _dd_spec is not None and _dd_spec.loader is not None
 dedup_releases = importlib.util.module_from_spec(_dd_spec)
 _dd_spec.loader.exec_module(dedup_releases)
 
-pytestmark = pytest.mark.postgres
+pytestmark = pytest.mark.pg
 
 PIPELINE_TABLES = run_pipeline.PIPELINE_TABLES
 

--- a/tests/integration/test_import.py
+++ b/tests/integration/test_import.py
@@ -30,7 +30,7 @@ BASE_TABLES = _ic.BASE_TABLES
 TRACK_TABLES = _ic.TRACK_TABLES
 VIDEO_TABLES = _ic.VIDEO_TABLES
 
-pytestmark = pytest.mark.postgres
+pytestmark = pytest.mark.pg
 
 
 class TestImportCsv:

--- a/tests/integration/test_prune.py
+++ b/tests/integration/test_prune.py
@@ -62,7 +62,7 @@ get_table_sizes = _vc.get_table_sizes
 count_rows_to_delete = _vc.count_rows_to_delete
 prune_releases = _vc.prune_releases
 
-pytestmark = [pytest.mark.postgres]
+pytestmark = [pytest.mark.pg]
 
 
 def _fresh_import(db_url: str) -> None:

--- a/tests/integration/test_schema.py
+++ b/tests/integration/test_schema.py
@@ -22,7 +22,7 @@ assert _rp_spec is not None and _rp_spec.loader is not None
 run_pipeline = importlib.util.module_from_spec(_rp_spec)
 _rp_spec.loader.exec_module(run_pipeline)
 
-pytestmark = pytest.mark.postgres
+pytestmark = pytest.mark.pg
 
 
 class TestCreateDatabase:

--- a/tests/integration/test_state_resume_old_format.py
+++ b/tests/integration/test_state_resume_old_format.py
@@ -35,7 +35,7 @@ SCHEMA_DIR = Path(__file__).parent.parent.parent / "schema"
 
 ADMIN_URL = os.environ.get("DATABASE_URL_TEST", "postgresql://localhost:5433/postgres")
 
-pytestmark = [pytest.mark.postgres, pytest.mark.e2e]
+pytestmark = pytest.mark.pg
 
 
 # v1 had 6 steps (no separate import_tracks/create_track_indexes/set_logged).

--- a/tests/integration/test_tsv_to_sqlite.py
+++ b/tests/integration/test_tsv_to_sqlite.py
@@ -6,8 +6,6 @@ import importlib.util
 import sqlite3
 from pathlib import Path
 
-import pytest
-
 # Load tsv_to_sqlite module from scripts directory
 _SCRIPT_PATH = Path(__file__).parent.parent.parent / "scripts" / "tsv_to_sqlite.py"
 _spec = importlib.util.spec_from_file_location("tsv_to_sqlite", _SCRIPT_PATH)
@@ -18,7 +16,6 @@ _spec.loader.exec_module(_mod)
 tsv_to_sqlite = _mod.tsv_to_sqlite
 
 
-@pytest.mark.integration
 class TestTsvToSqliteIntegration:
     """Integration tests using realistic MySQL output."""
 

--- a/tests/integration/test_unlogged_tables.py
+++ b/tests/integration/test_unlogged_tables.py
@@ -22,7 +22,7 @@ _spec = importlib.util.spec_from_file_location(
 run_pipeline = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(run_pipeline)
 
-pytestmark = pytest.mark.postgres
+pytestmark = pytest.mark.pg
 
 
 def _get_table_persistence(db_url: str, table_name: str) -> str:

--- a/tests/integration/test_verify_cache.py
+++ b/tests/integration/test_verify_cache.py
@@ -57,7 +57,6 @@ def matcher(library_index):
     return MultiIndexMatcher(library_index)
 
 
-@pytest.mark.integration
 class TestMultiIndexRealLibrary:
     """Test multi-index matching against the real WXYC library catalog."""
 
@@ -151,7 +150,6 @@ SCRIPT_PATH = Path(__file__).parent.parent.parent / "scripts" / "verify_cache.py
 PYTHON = sys.executable
 
 
-@pytest.mark.integration
 class TestVerifyCacheE2E:
     """Test the verify_cache.py script as a subprocess."""
 

--- a/tests/unit/test_fuzzy_parity.py
+++ b/tests/unit/test_fuzzy_parity.py
@@ -30,8 +30,6 @@ wxyc_etl_fuzzy = pytest.importorskip("wxyc_etl.fuzzy", reason="wxyc-etl not inst
 batch_fuzzy_resolve = wxyc_etl_fuzzy.batch_fuzzy_resolve
 jaro_winkler_similarity = wxyc_etl_fuzzy.jaro_winkler_similarity
 
-pytestmark = pytest.mark.parity
-
 # ---------------------------------------------------------------------------
 # Load verify_cache module from scripts directory (same pattern as test_verify_cache.py)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Adopts the marker scheme defined in `plans/test-patterns.md` Section 3 (architecture A): markers describe operational requirements only -- the infrastructure CI must provision. Tier (`unit/integration/e2e`) is documented by directory layout; lifecycle (`parity`) is a property of test names; cost (`slow`) is one orthogonal marker.

This is the org-wide cleanup tracked at `plans/test-patterns.md` Section 3 ("Migration from the legacy 6-marker scheme"), not tied to a specific issue.

## Migration mapping (legacy 6-marker scheme to architecture A)

| Legacy | Replacement applied here |
|---|---|
| `unit` | default (no marker). Was unused in code anyway. |
| `postgres` | `pg`. Mechanical rename. |
| `integration` | default for all three call sites -- none need infrastructure. |
| `e2e` | `pg` for the four PG-pipeline files; default for `test_sync_library_e2e` (pure SQLite). |
| `parity` | default. Per Section 7, parity is not a marker. |
| `slow` | `slow` (unchanged). Two perf benchmarks; marked as `ci-sync-skip` in `pyproject.toml`. |

## Per-marker count breakdown

`@pytest.mark.X` and `pytestmark = pytest.mark.X` references in `tests/`, before -> after:

| Marker | Before | After | Notes |
|---|---|---|---|
| `unit` | 0 | 0 | declared in pyproject but never used |
| `postgres` | 9 (8 module-level + 1 in combined list) | 0 | renamed to `pg` |
| `integration` | 3 (1 in test_tsv_to_sqlite, 2 in test_verify_cache) | 0 | dropped; tests need only in-memory SQLite or fixture library.db |
| `e2e` | 6 (4 module-level + 1 class decorator + 1 in combined list) | 0 | 5 became `pg`, 1 (sync_library_e2e) became unmarked |
| `parity` | 1 (test_fuzzy_parity module-level) | 0 | dropped per Section 7 |
| `slow` | 2 (decorators on perf benchmark classes) | 2 | unchanged |
| `pg` | 0 | 13 (12 module-level + 1 collapsed from combined `[postgres, e2e]`) | new, replacing `postgres` and PG-using `e2e` |

After: declared markers in `pyproject.toml` are exactly `pg` and `slow`.

## Judgment calls

1. **All three `@pytest.mark.integration` tests dropped to default.** `test_tsv_to_sqlite.py` writes a TSV to `tmp_path` and reads it back via SQLite. `test_verify_cache.py::TestMultiIndexRealLibrary` and `::TestVerifyCacheE2E` use the committed `library.db` fixture and a subprocess. None need PostgreSQL, an external API, or the full stack -- so per Section 3 they belong in the default tier.

2. **`test_sync_library_e2e.py` dropped to default**, even though it lives in `tests/e2e/`. It's pure SQLite plus a subprocess that runs a sibling-repo script -- no infrastructure marker applies. The directory survives as documentation of the tier (per Section 3, "Tier directories survive for taxonomy; markers are independent").

3. **Combined `[pytest.mark.postgres, pytest.mark.e2e]` collapsed to `pytest.mark.pg`** in `test_state_resume_old_format.py`. Both legacy markers were resolving to the same infrastructure (PG); the combined form was redundant under the new scheme.

4. **`parity` marker dropped, parity tests kept.** Section 7 is explicit: "Under architecture A (Section 3) parity is not a marker." The `test_fuzzy_parity.py` Rust-vs-Python parity tests stay -- they're now regular unit tests (no marker), and Section 7 calls out that descriptive class names + docstrings carry the lifecycle signal. The Rust replacement (`batch_classify_releases`) is still being landed in `wxyc-etl`, so the conservative "keep parity tests until next quarter" stance applies; we just stop *marking* them.

5. **`slow` opted out via `# ci-sync-skip` rather than wired into a CI job.** These are local perf benchmarks; running them on every PR adds CI time with no signal change. The opt-out follows the precedent set by `wxyc-etl/wxyc-etl-python` for its `perf` marker.

6. **The `pg` job runs `-m "pg or not slow"`, not pure `-m pg`.** This selects the PG-marked tests *and* the default no-marker tests in a single pytest invocation, so the `--cov-fail-under=60` gate sees the combined coverage from both tiers (pg-only would land at ~45%). The positive `pg` term in the expression still satisfies the marker sync-check.

## CI changes

- Rename `test-postgres` job to `pg`. The `-m` arg is `"pg or not slow"`.
- Add `marker-sync` job that calls the reusable workflow at `WXYC/wxyc-etl/.github/workflows/check-ci-marker-sync.yml@main` (the safety invariant from Section 3 that catches markers silently deselected by addopts).
- `lint` and `test` (default no-marker unit run) are unchanged.

## Test plan

- [x] Local `python3 scripts/check_marker_ci_sync.py --repo-path .` PASSes.
- [x] Local `pytest tests/unit/` -> 526 passed, 8 skipped.
- [x] Local `DATABASE_URL_TEST=... pytest -m "pg and not slow"` -> 241 passed, 14 skipped (skips are pre-existing pickling-bug skips and missing-sibling-repo skips).
- [x] `ruff check .` and `ruff format --check .` pass.
- [x] CI `lint` job passes.
- [x] CI `test` job passes (pytest tests/unit/).
- [x] CI `pg` job passes (pytest -m "pg or not slow" --cov, gate at 60% met).
- [x] CI `marker-sync` job passes.