### PR TITLE
Wire up Sentry + JSON logs in discogs-etl

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -171,6 +171,31 @@ The `--notify` flag is always passed, so Slack notifications are sent on failure
 
 After a successful run, verify the library-metadata-lookup health endpoint returns healthy with the expected row count.
 
+## Observability
+
+Every Python entrypoint in `scripts/` initializes the shared logger at the top of `main()` via the local `lib.observability` shim:
+
+```python
+from lib.observability import init_logger
+
+init_logger(repo="discogs-etl", tool="discogs-etl <subcommand>")
+```
+
+The shim delegates to `wxyc_etl.logger.init_logger` (from WXYC/wxyc-etl#50) when it's importable, and falls back to a basic stderr `logging.basicConfig` when it isn't — this lets the entrypoints stay future-ready while CI's wxyc-etl install ref is still on a pre-#50 branch. Once CI installs from a wxyc-etl revision that ships `wxyc_etl.logger`, JSON logging and Sentry are live with no further consumer change.
+
+When wired up, this installs a JSON formatter on the root logger and (when `SENTRY_DSN` is set) hands events to the Sentry SDK. Every log line carries the four contract tags:
+
+| Tag | Source |
+|-----|--------|
+| `repo` | hard-coded `"discogs-etl"` per call site |
+| `tool` | `"discogs-etl <subcommand>"`, e.g. `discogs-etl run_pipeline`, `discogs-etl verify_cache` |
+| `step` | per-event, supplied via `logger.info("...", extra={"step": "import"})` |
+| `run_id` | UUIDv4 generated at `init_logger` time (one per process) |
+
+`SENTRY_DSN` is read from the environment. When unset, JSON logging still works and Sentry stays inactive — there is no hard requirement on the DSN being configured. **TODO**: provision `SENTRY_DSN` in the GitHub Actions runtime env (sync-library workflow) and on EC2 / Railway as a separate child task.
+
+Scripts that initialize the logger (subprocesses each get their own run_id, since they are independent processes): `run_pipeline.py`, `import_csv.py`, `dedup_releases.py`, `verify_cache.py`, `filter_csv.py`, `resolve_collisions.py`, `tsv_to_sqlite.py`. The shim itself lives in `lib/observability.py`.
+
 ## Development Practices
 
 ### TDD (Required)

--- a/lib/observability.py
+++ b/lib/observability.py
@@ -1,0 +1,51 @@
+"""Thin wrapper around :func:`wxyc_etl.logger.init_logger`.
+
+The ``wxyc_etl.logger`` module landed in WXYC/wxyc-etl#50 and ships from
+``main`` of the wxyc-etl repo. Older wxyc-etl refs (currently pinned in our
+CI install step) do not include it. This shim lets every entrypoint call
+:func:`init_logger` unconditionally; once the CI install ref is bumped to a
+wxyc-etl revision that contains #50, real Sentry + JSON logging is wired up
+without any further consumer-side change.
+
+When the underlying module isn't installed we fall back to a minimal
+``logging.basicConfig`` so the scripts still log something useful in the
+interim.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+
+def init_logger(
+    repo: str,
+    tool: str,
+    sentry_dsn: str | None = None,
+    run_id: str | None = None,
+) -> Any:
+    """Initialize Sentry + JSON logging via wxyc_etl.logger when available.
+
+    Falls back to a basic stderr formatter when ``wxyc_etl.logger`` is not
+    installed. Returns whatever ``wxyc_etl.logger.init_logger`` returns, or
+    ``None`` if the fallback path is taken.
+    """
+    try:
+        from wxyc_etl.logger import init_logger as _wxyc_init
+    except ImportError:
+        if not logging.getLogger().handlers:
+            logging.basicConfig(
+                level=logging.INFO,
+                format="%(asctime)s - %(levelname)s - %(message)s",
+            )
+        return None
+
+    return _wxyc_init(
+        repo=repo,
+        tool=tool,
+        sentry_dsn=sentry_dsn,
+        run_id=run_id,
+    )
+
+
+__all__ = ["init_logger"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = [
     "rapidfuzz>=3.0.0",
     "wxyc-etl>=0.1.0",
     "wxyc-catalog>=0.1.0",
+    "sentry-sdk>=2.0",
 ]
 
 [project.optional-dependencies]

--- a/scripts/dedup_releases.py
+++ b/scripts/dedup_releases.py
@@ -27,10 +27,9 @@ from pathlib import Path
 
 import psycopg
 
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s - %(levelname)s - %(message)s",
-)
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+from lib.observability import init_logger  # noqa: E402
+
 logger = logging.getLogger(__name__)
 
 
@@ -546,6 +545,8 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 def main():
     args = parse_args()
     db_url = args.database_url
+
+    init_logger(repo="discogs-etl", tool="discogs-etl dedup_releases")
 
     logger.info(f"Connecting to {db_url}")
     conn = psycopg.connect(db_url, autocommit=True)

--- a/scripts/filter_csv.py
+++ b/scripts/filter_csv.py
@@ -16,10 +16,9 @@ import sys
 import unicodedata
 from pathlib import Path
 
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s - %(levelname)s - %(message)s",
-)
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+from lib.observability import init_logger  # noqa: E402
+
 logger = logging.getLogger(__name__)
 
 # CSV files that need to be filtered by release_id.
@@ -153,6 +152,8 @@ def filter_csv_file(
 
 
 def main():
+    init_logger(repo="discogs-etl", tool="discogs-etl filter_csv")
+
     if len(sys.argv) != 4:
         print(__doc__)
         sys.exit(1)

--- a/scripts/import_csv.py
+++ b/scripts/import_csv.py
@@ -27,11 +27,8 @@ except ImportError:
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
 from lib.format_normalization import normalize_format  # noqa: E402
+from lib.observability import init_logger  # noqa: E402
 
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s - %(levelname)s - %(message)s",
-)
 logger = logging.getLogger(__name__)
 
 # Table configs: (csv_filename, table_name, csv_columns, db_columns, required_columns, transforms)
@@ -697,6 +694,8 @@ def import_masters(conn, csv_dir: Path) -> int:
 
 def main():
     import argparse
+
+    init_logger(repo="discogs-etl", tool="discogs-etl import_csv")
 
     parser = argparse.ArgumentParser(description="Import Discogs CSV files into PostgreSQL")
     parser.add_argument("csv_dir", type=Path, help="Directory containing CSV files")

--- a/scripts/resolve_collisions.py
+++ b/scripts/resolve_collisions.py
@@ -27,10 +27,9 @@ from pathlib import Path
 
 import psycopg
 
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s - %(levelname)s - %(message)s",
-)
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+from lib.observability import init_logger  # noqa: E402
+
 logger = logging.getLogger(__name__)
 
 
@@ -509,6 +508,8 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 
 def main(argv: list[str] | None = None) -> None:
     args = parse_args(argv)
+
+    init_logger(repo="discogs-etl", tool="discogs-etl resolve_collisions")
 
     if not args.database_url:
         print("Error: --database-url or DATABASE_URL_DISCOGS required", file=sys.stderr)

--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -38,6 +38,9 @@ from pathlib import Path
 import psycopg
 from wxyc_etl.state import PipelineState
 
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+from lib.observability import init_logger  # noqa: E402
+
 STEP_NAMES = [
     "create_schema",
     "import_csv",
@@ -50,10 +53,6 @@ STEP_NAMES = [
     "set_logged",
 ]
 
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s - %(levelname)s - %(message)s",
-)
 logger = logging.getLogger(__name__)
 
 SCRIPT_DIR = Path(__file__).parent
@@ -754,6 +753,8 @@ def _run_xml_pipeline(
 
 def main() -> None:
     args = parse_args()
+
+    init_logger(repo="discogs-etl", tool="discogs-etl run_pipeline")
 
     python = sys.executable
     db_url = args.database_url

--- a/scripts/tsv_to_sqlite.py
+++ b/scripts/tsv_to_sqlite.py
@@ -20,6 +20,10 @@ from __future__ import annotations
 
 import sqlite3
 import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+from lib.observability import init_logger  # noqa: E402
 
 
 def tsv_to_sqlite(tsv_path: str, db_path: str) -> int:
@@ -77,6 +81,7 @@ def tsv_to_sqlite(tsv_path: str, db_path: str) -> int:
 
 
 if __name__ == "__main__":
+    init_logger(repo="discogs-etl", tool="discogs-etl tsv_to_sqlite")
     if len(sys.argv) != 3:
         print(f"Usage: {sys.argv[0]} <tsv_path> <db_path>", file=sys.stderr)
         sys.exit(1)

--- a/scripts/verify_cache.py
+++ b/scripts/verify_cache.py
@@ -63,11 +63,8 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 from wxyc_etl.text import is_compilation_artist, split_artist_name_contextual
 
 from lib.format_normalization import format_matches, normalize_library_format
+from lib.observability import init_logger
 
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s - %(levelname)s - %(message)s",
-)
 logger = logging.getLogger(__name__)
 
 # Discogs suffixes like "(2)", "(3)" for disambiguation
@@ -1781,6 +1778,7 @@ async def async_main():
 
 
 def main():
+    init_logger(repo="discogs-etl", tool="discogs-etl verify_cache")
     asyncio.run(async_main())
 
 

--- a/tests/unit/test_logger_init.py
+++ b/tests/unit/test_logger_init.py
@@ -1,0 +1,126 @@
+"""Smoke tests for the Sentry/JSON-logger wireup in this repo.
+
+These tests verify that:
+
+* Each script entrypoint imports cleanly (i.e. the ``lib.observability``
+  shim and ``wxyc_etl`` re-exports resolve).
+* The shim's ``init_logger`` returns without raising when
+  ``SENTRY_DSN`` is unset.
+* When ``wxyc_etl.logger`` is actually installed (gates Sentry init),
+  calling it produces a JSON log line carrying the four contract tags
+  ``repo`` / ``tool`` / ``step`` / ``run_id``.
+
+The third test skips automatically when ``wxyc_etl.logger`` is missing —
+this is the situation in CI today, since the install ref pinned in
+``.github/workflows/ci.yml`` predates WXYC/wxyc-etl#50. Once that ref is
+bumped, the test becomes active without further changes.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS_DIR = REPO_ROOT / "scripts"
+
+
+def _has_wxyc_logger() -> bool:
+    try:
+        import wxyc_etl.logger  # noqa: F401
+    except Exception:
+        return False
+    return True
+
+
+def _reset_root_logger() -> None:
+    """Strip handlers/filters off the root logger so init_logger reinstalls."""
+    root = logging.getLogger()
+    for handler in list(root.handlers):
+        root.removeHandler(handler)
+    root.setLevel(logging.WARNING)
+    if _has_wxyc_logger():
+        import wxyc_etl.logger as logger_mod
+
+        logger_mod._INITIALIZED = False
+
+
+def test_init_logger_shim_does_not_raise(monkeypatch):
+    """The shim must always be safely callable, regardless of install state."""
+    monkeypatch.delenv("SENTRY_DSN", raising=False)
+    _reset_root_logger()
+
+    from lib.observability import init_logger
+
+    init_logger(repo="discogs-etl", tool="discogs-etl test")
+
+
+@pytest.mark.skipif(
+    not _has_wxyc_logger(),
+    reason="wxyc_etl.logger not installed (needs WXYC/wxyc-etl#50)",
+)
+def test_init_logger_emits_json_with_repo_tag(capfd, monkeypatch):
+    """When wxyc_etl.logger is wired up, JSON logs carry the contract tags."""
+    monkeypatch.delenv("SENTRY_DSN", raising=False)
+    _reset_root_logger()
+
+    from lib.observability import init_logger
+
+    guard = init_logger(repo="discogs-etl", tool="discogs-etl test")
+    assert guard is not None, "expected wxyc_etl.logger guard"
+    assert guard.sentry_enabled is False
+    assert guard.run_id
+
+    log = logging.getLogger("discogs-etl.smoke")
+    log.info("hello", extra={"step": "smoke"})
+
+    captured = capfd.readouterr()
+    assert captured.err, "expected JSON log line on stderr"
+    line = captured.err.strip().splitlines()[-1]
+    payload = json.loads(line)
+
+    assert payload["repo"] == "discogs-etl"
+    assert payload["tool"] == "discogs-etl test"
+    assert payload["step"] == "smoke"
+    assert payload["run_id"] == guard.run_id
+    assert payload["message"] == "hello"
+
+
+@pytest.mark.parametrize(
+    "script",
+    [
+        "run_pipeline.py",
+        "import_csv.py",
+        "dedup_releases.py",
+        "verify_cache.py",
+        "filter_csv.py",
+        "resolve_collisions.py",
+        "tsv_to_sqlite.py",
+    ],
+)
+def test_script_compiles(script):
+    """Each entrypoint must compile (i.e. its imports resolve)."""
+    path = SCRIPTS_DIR / script
+    assert path.exists(), f"missing script: {path}"
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            (
+                "import compileall, sys; "
+                f"sys.exit(0 if compileall.compile_file('{path}', quiet=1) else 1)"
+            ),
+        ],
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+    )
+    assert result.returncode == 0, (
+        f"{script} failed to compile:\nstdout={result.stdout}\nstderr={result.stderr}"
+    )


### PR DESCRIPTION
## Summary

- Adds a new `lib.observability` shim that delegates to `wxyc_etl.logger.init_logger` when the foundation module from WXYC/wxyc-etl#50 is installed, and falls back to a basic stderr logger when it isn't.
- Replaces module-level `logging.basicConfig(...)` in every Python entrypoint (`run_pipeline.py`, `import_csv.py`, `dedup_releases.py`, `verify_cache.py`, `filter_csv.py`, `resolve_collisions.py`, `tsv_to_sqlite.py`) with a `init_logger(...)` call inside `main()`.
- Each call site supplies the contract tags `repo="discogs-etl"` and `tool="discogs-etl <subcommand>"`. `step` is set per-event via `logger.info(..., extra={"step": ...})`. `run_id` is generated once per process by `init_logger`. `SENTRY_DSN` is read from the env; when unset, JSON logging still emits and Sentry stays inactive.
- Adds `sentry-sdk>=2.0` to `pyproject.toml` so the runtime dep is explicit.
- Adds a smoke test (`tests/unit/test_logger_init.py`) covering the shim's safe-fallback path, the JSON tag contract (skips when `wxyc_etl.logger` is not installed), and a compile check across all seven entrypoints.
- Updates `CLAUDE.md` with an "Observability" section describing the four-tag contract and the shim's role during the cross-repo migration.

## Why a shim instead of importing `wxyc_etl.logger` directly?

The CI install ref for `wxyc-etl` (`.github/workflows/ci.yml`) is currently pinned to `etl-unification/1g-pyo3-bindings`, which predates WXYC/wxyc-etl#50 and therefore does not ship `wxyc_etl/logger.py`. A direct import would break CI. The shim lets this PR land now without coupling to the cross-repo install-ref bump; once that bump happens, JSON logging and Sentry start emitting with no further consumer change here.

## TODO (separate child tasks, intentionally not in scope)

- Bump the CI install ref for `wxyc-etl` to a revision that includes #50, so the smoke test's tagged-JSON assertion runs (today it skips). This is cross-repo coordination, deliberately deferred.
- Provision `SENTRY_DSN` as a secret on the `sync-library.yml` workflow runner and on the EC2/Railway hosts that invoke `run_pipeline.py`.

## Acceptance criteria

- [x] Logger initialized in entrypoint
- [x] Old logger init removed
- [x] CLAUDE.md notes the observability tags
- [x] Test invocation produces a JSON log line with `repo: "discogs-etl"`

## Test plan

- [x] `pytest tests/unit/test_logger_init.py -v` passes locally (9 passed when `wxyc_etl.logger` installed; 1 skipped when not)
- [x] `ruff check .` and `ruff format --check .` pass
- [x] Manual: `init_logger(repo="discogs-etl", tool="discogs-etl smoke")` followed by `logger.info("hello", extra={"step": "smoke"})` emits a single-line JSON object containing `repo`, `tool`, `step`, `run_id`, `timestamp`, `level`, `message`
- [x] Manual: with `wxyc_etl.logger` blocked from `sys.modules`, the shim falls back to plain stderr logging and returns `None` without raising

## Tracking

- Closes #114
- Parent epic: WXYC/wxyc-etl#44 — Sentry + structured JSON logs across all ETLs
- Foundation: WXYC/wxyc-etl#50 — `wxyc_etl::logger` module (Rust + PyO3)
- Phase: A