### PR TITLE
cli: align discogs-etl pipeline flags with shared cache-builder convention

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,20 @@ ETL pipeline for building and maintaining a PostgreSQL cache of Discogs release 
 - `--xml` mode: runs steps 2-10 (enrich, convert+filter, database build through SET LOGGED). `--xml` accepts a single file or a directory.
 - `--csv-dir` mode: runs steps 4-10 (database build from pre-filtered CSVs)
 
-Both modes support `--target-db-url` to copy matched releases to a separate database instead of pruning in place, and `--resume` (csv-dir only) to skip already-completed steps. `--keep-csv` (xml mode only) writes converted CSVs to a persistent directory instead of a temp dir, so they survive pipeline failures.
+Both modes support `--target-db-url` (deprecated, see below) to copy matched releases to a separate database instead of pruning in place, and `--resume` (csv-dir only) to skip already-completed steps. `--keep-csv` (xml mode only) writes converted CSVs to a persistent directory instead of a temp dir, so they survive pipeline failures.
+
+### Cache database CLI convention
+
+discogs-etl follows the shared cache-builder CLI convention defined in `wxyc-etl::cli` (Rust) and mirrored here in Python:
+
+| Flag / env | Status | Notes |
+|---|---|---|
+| `--database-url` | canonical | PostgreSQL URL for the cache database. |
+| `DATABASE_URL_DISCOGS` | canonical | Service-specific env fallback; preferred over `DATABASE_URL`. |
+| `DATABASE_URL` | deprecated fallback | Still works; emits a stderr warning that `DATABASE_URL_DISCOGS` is preferred. |
+| `--target-db-url` | deprecated | Still functional but emits a stderr warning. The cache convention is consolidating on a single `--database-url`. |
+
+Resolution order for `--database-url`: explicit flag > `DATABASE_URL_DISCOGS` > `DATABASE_URL` (deprecated) > `postgresql://localhost:5432/discogs`.
 
 Step 1 (download) is always manual.
 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,8 @@ python scripts/run_pipeline.py \
 
 - `--library-db` is optional; if omitted, the prune step is skipped
 - `--library-labels` accepts a pre-generated `library_labels.csv` for [label-aware dedup](#label-aware-dedup)
-- `--database-url` defaults to `DATABASE_URL` env var or `postgresql://localhost:5432/discogs`
+- `--database-url` defaults to `DATABASE_URL_DISCOGS`, then `DATABASE_URL` (deprecated, emits a warning), then `postgresql://localhost:5432/discogs`
+- `--target-db-url` is deprecated; the cache convention is consolidating on a single `--database-url`. Existing workflows still work.
 
 ### Docker Compose
 

--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -20,7 +20,8 @@ Two modes of operation:
       [--resume] [--state-file <path>]
 
 Environment variables:
-    DATABASE_URL  Default database URL when --database-url is not specified.
+    DATABASE_URL_DISCOGS  Preferred default for --database-url.
+    DATABASE_URL          Deprecated fallback; emits a warning when used.
 """
 
 from __future__ import annotations
@@ -72,6 +73,31 @@ PG_CONNECT_TIMEOUT = 30
 # "release" to unlogged because it references logged table "<missing>"`` (see
 # #105). The ``test_pipeline_tables_covers_all_release_fk_referrers`` unit test
 # enforces this invariant against ``schema/create_database.sql``.
+DEFAULT_DATABASE_URL = "postgresql://localhost:5432/discogs"
+
+
+def _resolve_database_url(cli_value: str | None) -> str:
+    """Resolve the cache database URL.
+
+    Priority: CLI flag > DATABASE_URL_DISCOGS env > DATABASE_URL env (deprecated)
+    > built-in default. The generic DATABASE_URL fallback emits a stderr
+    deprecation warning to nudge consumers to the service-specific name.
+    """
+    if cli_value is not None:
+        return cli_value
+    discogs_env = os.environ.get("DATABASE_URL_DISCOGS")
+    if discogs_env:
+        return discogs_env
+    generic_env = os.environ.get("DATABASE_URL")
+    if generic_env:
+        print(
+            "warning: DATABASE_URL is deprecated; set DATABASE_URL_DISCOGS instead.",
+            file=sys.stderr,
+        )
+        return generic_env
+    return DEFAULT_DATABASE_URL
+
+
 PIPELINE_TABLES = [
     "release",
     "release_artist",
@@ -169,17 +195,19 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument(
         "--database-url",
         type=str,
-        default=os.environ.get("DATABASE_URL", "postgresql://localhost:5432/discogs"),
-        help="PostgreSQL connection URL "
-        "(default: DATABASE_URL env var or postgresql://localhost:5432/discogs).",
+        default=None,
+        help="PostgreSQL connection URL for the cache database "
+        "(default: DATABASE_URL_DISCOGS env var, then DATABASE_URL with a "
+        "deprecation warning, then postgresql://localhost:5432/discogs).",
     )
     parser.add_argument(
         "--target-db-url",
         type=str,
         default=None,
         metavar="URL",
-        help="Copy matched releases to a separate target database instead of "
-        "pruning in place. Requires --library-db.",
+        help="[DEPRECATED] Copy matched releases to a separate target database "
+        "instead of pruning in place. Requires --library-db. Will be removed in "
+        "a future release.",
     )
     parser.add_argument(
         "--library-labels",
@@ -236,6 +264,15 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     )
 
     args = parser.parse_args(argv)
+
+    args.database_url = _resolve_database_url(args.database_url)
+
+    if args.target_db_url is not None:
+        print(
+            "warning: --target-db-url is deprecated; the cache convention is "
+            "moving to a single --database-url. The flag still works for now.",
+            file=sys.stderr,
+        )
 
     # Validate --xml mode dependencies
     if args.xml is not None:

--- a/tests/unit/test_run_pipeline.py
+++ b/tests/unit/test_run_pipeline.py
@@ -147,6 +147,68 @@ class TestArgParsing:
                 ]
             )
 
+    def test_target_db_url_emits_deprecation_warning(self, capsys) -> None:
+        """--target-db-url is accepted but warns it is deprecated."""
+        run_pipeline.parse_args(
+            [
+                "--csv-dir",
+                "/tmp/csv",
+                "--library-db",
+                "/tmp/library.db",
+                "--target-db-url",
+                "postgresql://localhost/target",
+            ]
+        )
+        err = capsys.readouterr().err
+        assert "--target-db-url" in err
+        assert "deprecated" in err.lower()
+
+    def test_database_url_flag_overrides_env(self, monkeypatch) -> None:
+        """Explicit --database-url takes precedence over env vars."""
+        monkeypatch.setenv("DATABASE_URL_DISCOGS", "postgresql://from-discogs-env/db")
+        monkeypatch.setenv("DATABASE_URL", "postgresql://from-generic-env/db")
+        args = run_pipeline.parse_args(
+            [
+                "--csv-dir",
+                "/tmp/csv",
+                "--database-url",
+                "postgresql://from-flag/db",
+            ]
+        )
+        assert args.database_url == "postgresql://from-flag/db"
+
+    def test_database_url_discogs_env_var_used(self, monkeypatch) -> None:
+        """DATABASE_URL_DISCOGS is the preferred env fallback."""
+        monkeypatch.delenv("DATABASE_URL", raising=False)
+        monkeypatch.setenv("DATABASE_URL_DISCOGS", "postgresql://from-discogs-env/db")
+        args = run_pipeline.parse_args(["--csv-dir", "/tmp/csv"])
+        assert args.database_url == "postgresql://from-discogs-env/db"
+
+    def test_database_url_discogs_preferred_over_generic(self, monkeypatch) -> None:
+        """DATABASE_URL_DISCOGS wins over DATABASE_URL when both are set."""
+        monkeypatch.setenv("DATABASE_URL_DISCOGS", "postgresql://from-discogs-env/db")
+        monkeypatch.setenv("DATABASE_URL", "postgresql://from-generic-env/db")
+        args = run_pipeline.parse_args(["--csv-dir", "/tmp/csv"])
+        assert args.database_url == "postgresql://from-discogs-env/db"
+
+    def test_database_url_generic_env_var_with_warning(self, monkeypatch, capsys) -> None:
+        """Falling back to DATABASE_URL still works but emits a deprecation warning."""
+        monkeypatch.delenv("DATABASE_URL_DISCOGS", raising=False)
+        monkeypatch.setenv("DATABASE_URL", "postgresql://from-generic-env/db")
+        args = run_pipeline.parse_args(["--csv-dir", "/tmp/csv"])
+        assert args.database_url == "postgresql://from-generic-env/db"
+        err = capsys.readouterr().err
+        assert "DATABASE_URL" in err
+        assert "DATABASE_URL_DISCOGS" in err
+        assert "deprecated" in err.lower()
+
+    def test_database_url_default_when_no_env(self, monkeypatch) -> None:
+        """Falls back to the built-in default when no env vars are set."""
+        monkeypatch.delenv("DATABASE_URL_DISCOGS", raising=False)
+        monkeypatch.delenv("DATABASE_URL", raising=False)
+        args = run_pipeline.parse_args(["--csv-dir", "/tmp/csv"])
+        assert args.database_url == "postgresql://localhost:5432/discogs"
+
     def test_library_labels_parsed(self) -> None:
         args = run_pipeline.parse_args(
             [


### PR DESCRIPTION
## Summary

- `--database-url` now resolves `DATABASE_URL_DISCOGS` first, then `DATABASE_URL` with a stderr deprecation warning, then the built-in default. This aligns discogs-etl's Python entrypoint with the shared cache-builder CLI convention from `wxyc-etl::cli`.
- `--target-db-url` remains functional but emits a deprecation warning; the cache convention is consolidating on a single `--database-url`.
- `CLAUDE.md` and `README.md` document the new resolution order and the deprecated flag.

## Test plan

- [x] `pytest tests/unit/test_run_pipeline.py` (69 passed; new `TestArgParsing` cases cover `DATABASE_URL_DISCOGS` preference, generic `DATABASE_URL` fallback warning, default fallback, and `--target-db-url` deprecation warning).
- [x] `ruff check` and `ruff format --check` clean.
- [x] Manual smoke: `DATABASE_URL=foo python scripts/run_pipeline.py --csv-dir /tmp/x` prints the deprecation warning and resolves the URL.

Closes #115

Parent: WXYC/wxyc-etl#45 — [Epic] Standardize cache-builder CLI shape