### PR TITLE
Schedule monthly Discogs cache rebuild via GitHub Actions

### DIFF
--- a/.github/workflows/rebuild-cache.yml
+++ b/.github/workflows/rebuild-cache.yml
@@ -1,0 +1,94 @@
+name: Rebuild Discogs Cache
+
+# Monthly Discogs cache rebuild. Discogs publishes a new dump on the 1st of
+# each month; this workflow runs a few days later to give the dump time to
+# settle and to stagger against sister cache-builder repos (e.g. wikidata-cache,
+# musicbrainz-cache).
+#
+# TODO: the Discogs releases dump is ~63 GB compressed XML; expanding +
+# converting it can exceed the GitHub Actions free-runner disk (~14 GB) and
+# 6-hour wall-clock budget. The skeleton here lets operators kick the rebuild
+# manually via workflow_dispatch on a self-hosted runner or a beefier hosted
+# runner; converting the scheduled run to use the same once one is provisioned
+# is a follow-up. Until then, the cron tick will fail loudly rather than
+# silently producing a half-built cache, which is the desired signal.
+
+on:
+  schedule:
+    # 06:00 UTC on the 4th of each month (staggered from sister rebuilds).
+    - cron: "0 6 4 * *"
+  workflow_dispatch:
+    inputs:
+      dump_url:
+        description: "Override Discogs releases.xml.gz URL (optional)"
+        required: false
+        type: string
+
+jobs:
+  rebuild:
+    runs-on: ubuntu-latest
+    timeout-minutes: 350
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Install wxyc-etl from git (Rust/PyO3)
+        run: |
+          pip install maturin
+          git clone --depth 1 --branch etl-unification/1g-pyo3-bindings https://github.com/WXYC/wxyc-etl.git /tmp/wxyc-etl
+          cd /tmp/wxyc-etl/wxyc-etl-python && maturin build --release && pip install /tmp/wxyc-etl/target/wheels/*.whl
+
+      - name: Install wxyc-catalog from git
+        run: |
+          git clone --depth 1 --branch main https://github.com/WXYC/wxyc-catalog.git /tmp/wxyc-catalog
+          cd /tmp/wxyc-catalog && sed -i 's|setuptools.backends._legacy:_Backend|setuptools.build_meta|' pyproject.toml && pip install -e .
+
+      - name: Install discogs-etl
+        run: pip install -e ".[dev]"
+
+      - name: Build discogs-xml-converter
+        run: |
+          git clone --depth 1 --branch main https://github.com/WXYC/discogs-xml-converter.git /tmp/discogs-xml-converter
+          cd /tmp/discogs-xml-converter && cargo build --release
+          echo "/tmp/discogs-xml-converter/target/release" >> "$GITHUB_PATH"
+
+      - name: Resolve dump URL
+        id: dump
+        env:
+          OVERRIDE_URL: ${{ inputs.dump_url }}
+        run: |
+          if [ -n "$OVERRIDE_URL" ]; then
+            echo "Using operator-supplied dump URL"
+            echo "url=$OVERRIDE_URL" >> "$GITHUB_OUTPUT"
+          else
+            # Discogs publishes monthly dumps named
+            # data/<YYYY>/discogs_<YYYYMMDD>_releases.xml.gz on the 1st of each
+            # month. Resolve the most recent published month relative to today.
+            year=$(date -u +%Y)
+            stamp=$(date -u +%Y%m01)
+            echo "url=https://discogs-data-dumps.s3.us-west-2.amazonaws.com/data/${year}/discogs_${stamp}_releases.xml.gz" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Download Discogs releases dump
+        run: |
+          mkdir -p data
+          curl -fL --retry 3 --retry-delay 30 -o data/releases.xml.gz "${{ steps.dump.outputs.url }}"
+
+      - name: Run pipeline
+        env:
+          DATABASE_URL_DISCOGS: ${{ secrets.DATABASE_URL_DISCOGS }}
+          DISCOGS_TOKEN: ${{ secrets.DISCOGS_TOKEN }}
+          # TODO: provision SENTRY_DSN as a separate operator task. Until then
+          # JSON logging still emits to stderr and Sentry stays inactive.
+          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+        run: |
+          python scripts/run_pipeline.py \
+            --xml data/releases.xml.gz \
+            --generate-library-db \
+            --catalog-source tubafrenzy \
+            --catalog-db-url "${{ secrets.LIBRARY_CATALOG_DB_URL }}"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -158,6 +158,23 @@ This pipeline runs monthly (or when Discogs publishes new data dumps). It has a 
 
 ## Automation
 
+### Monthly Cache Rebuild (`rebuild-cache.yml`)
+
+A GitHub Actions cron workflow runs `scripts/run_pipeline.py --xml ...` on the 4th of each month at 06:00 UTC, staggered a few days after Discogs publishes the new dump. It can also be triggered manually with an optional `dump_url` input: `gh workflow run rebuild-cache.yml`.
+
+The job downloads `releases.xml.gz` for the current month from `discogs-data-dumps.s3.us-west-2.amazonaws.com`, builds `discogs-xml-converter` from source, and runs the full XML-mode pipeline (steps 2-10) against `DATABASE_URL_DISCOGS`. Library catalog is generated inline via `--generate-library-db --catalog-source tubafrenzy`.
+
+**Caveat — runner capacity**: the Discogs releases dump is ~63 GB compressed XML and the conversion + Postgres bulk load can exceed the GitHub Actions free hosted runner's ~14 GB disk and 6-hour wall-clock budget. The workflow file is the deliverable; provisioning a self-hosted or larger hosted runner is a follow-up operator task. Until then, expect the scheduled tick to fail loudly rather than silently produce a half-built cache.
+
+**Required GitHub secrets:**
+
+| Secret | Description |
+|--------|-------------|
+| `DATABASE_URL_DISCOGS` | PostgreSQL URL for the destination cache database |
+| `LIBRARY_CATALOG_DB_URL` | MySQL URL for the tubafrenzy catalog (used by `--generate-library-db`) |
+| `DISCOGS_TOKEN` | Discogs API token (optional; only matters if rate limits are hit) |
+| `SENTRY_DSN` | Sentry DSN for error reporting (optional; JSON logging still works without it) |
+
 ### Library Sync (`sync-library.yml`)
 
 A GitHub Actions cron workflow runs `scripts/sync-library.sh` daily at noon UTC (7 AM EST / 8 AM EDT) to export the WXYC library catalog to SQLite (via `wxyc-export-to-sqlite` from wxyc-catalog) and upload it to library-metadata-lookup staging and production environments.


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/rebuild-cache.yml` with `schedule:` (`0 6 4 * *`) and `workflow_dispatch:` triggers so the monthly Discogs cache rebuild stops being a manual operator step.
- Workflow follows `ci.yml`'s wxyc-etl + wxyc-catalog install dance, builds `discogs-xml-converter` from source, downloads the current month's `releases.xml.gz`, and runs `scripts/run_pipeline.py --xml` against `DATABASE_URL_DISCOGS`. Logger init is already wired (`scripts/run_pipeline.py:794`).
- Documents the run-capacity caveat (~63 GB dump vs free hosted runner) in `CLAUDE.md` and lists the secrets the workflow expects.

The dump URL pattern, cron stagger (4th of the month, separate from sister cache-builder repos), and the runner-capacity TODO are all called out in inline comments so a follow-up self-hosted-runner task has the context it needs.

## Test plan

- [x] `actionlint .github/workflows/rebuild-cache.yml` passes
- [x] `ruff check .` and `ruff format --check .` pass
- [ ] Operator triggers `gh workflow run rebuild-cache.yml` once secrets land to confirm the skeleton end-to-end
- [ ] Scheduled tick lands on 2026-05-04 06:00 UTC after merge

Closes #118

## Tracking

Parent epic: WXYC/wxyc-etl#47 — Scheduling commitment + per-ETL audit