### PR TITLE
db: adopt alembic + 0001_initial baseline for discogs-cache

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,6 +65,37 @@ The SQL files in `schema/` define the contract between this ETL pipeline and all
 
 Consumers connect via `DATABASE_URL_DISCOGS` environment variable.
 
+### Migrations
+
+`schema/*.sql` remains the canonical, hand-maintained schema. On top of that we keep an [alembic](https://alembic.sqlalchemy.org/) revision history at `alembic/versions/` so future schema changes have a recorded order, and so that downstream services (Backend-Service, library-metadata-lookup) can rely on a stamped version when introspecting the cache.
+
+Layout:
+
+- `alembic.ini` -- alembic config; the `sqlalchemy.url` placeholder is overridden by `alembic/env.py`.
+- `alembic/env.py` -- resolves the URL from `DATABASE_URL_DISCOGS` (canonical) or `DATABASE_URL` (deprecated, warns to stderr); rewrites `postgresql://` to `postgresql+psycopg://` so SQLAlchemy uses psycopg3 instead of pulling in psycopg2.
+- `alembic/versions/0001_initial.py` -- baseline migration. Hand-written; its `upgrade()` opens an autocommit psycopg connection and replays `schema/create_functions.sql`, `schema/create_database.sql`, `schema/create_indexes.sql`, `schema/create_track_indexes.sql` in pipeline order. CONCURRENTLY is stripped because the baseline only ever runs against an empty database (mirrors the `strip_concurrently=True` path in `scripts/run_pipeline.py`).
+
+Apply against an empty Postgres:
+
+```bash
+createdb discogs_cache_migrations_test
+DATABASE_URL_DISCOGS=postgresql://localhost:5433/discogs_cache_migrations_test \
+  alembic upgrade head
+```
+
+Add a new migration:
+
+```bash
+alembic revision -m "<short-name>"
+# edit alembic/versions/<rev>_<short-name>.py and write upgrade()/downgrade()
+```
+
+Prefer hand-written `op.execute()` migrations -- `--autogenerate` is intentionally off (no SQLAlchemy ORM models exist in this repo). When the change is simple SQL, it's fine to embed the DDL directly in `upgrade()`. When it's a large refactor, drop a new file under `schema/` and have `upgrade()` `op.execute(open(...).read())` it, the same pattern as `0001_initial`.
+
+**Not yet wired into deploy.** `alembic upgrade head` is *not* called by `scripts/run_pipeline.py`, the GitHub Actions cache-rebuild workflow, or the Docker entrypoint. The pipeline still applies `schema/*.sql` directly via `run_sql_file`. Switching the runtime path to drive everything through alembic is tracked in [WXYC/wxyc-etl#56](https://github.com/WXYC/wxyc-etl/issues/56). On first post-#56 deploy, existing production databases will be `alembic stamp head` stamped so they don't try to re-apply the baseline.
+
+Alembic is a `[project.optional-dependencies] dev` dep -- install via `pip install -e .[dev]` and use `.venv/bin/alembic`.
+
 ### Docker Compose
 
 `docker-compose.yml` provides a self-contained environment:

--- a/alembic.ini
+++ b/alembic.ini
@@ -1,0 +1,155 @@
+# A generic, single database configuration.
+
+[alembic]
+# path to migration scripts.
+# this is typically a path given in POSIX (e.g. forward slashes)
+# format, relative to the token %(here)s which refers to the location of this
+# ini file
+script_location = %(here)s/alembic
+
+# template used to generate migration file names; The default value is %%(rev)s_%%(slug)s
+# Uncomment the line below if you want the files to be prepended with date and time
+# see https://alembic.sqlalchemy.org/en/latest/tutorial.html#editing-the-ini-file
+# for all available tokens
+# file_template = %%(year)d_%%(month).2d_%%(day).2d_%%(hour).2d%%(minute).2d-%%(rev)s_%%(slug)s
+# Or organize into date-based subdirectories (requires recursive_version_locations = true)
+# file_template = %%(year)d/%%(month).2d/%%(day).2d_%%(hour).2d%%(minute).2d_%%(second).2d_%%(rev)s_%%(slug)s
+
+# sys.path path, will be prepended to sys.path if present.
+# defaults to the current working directory.  for multiple paths, the path separator
+# is defined by "path_separator" below.
+prepend_sys_path = .
+
+
+# timezone to use when rendering the date within the migration file
+# as well as the filename.
+# If specified, requires the tzdata library which can be installed by adding
+# `alembic[tz]` to the pip requirements.
+# string value is passed to ZoneInfo()
+# leave blank for localtime
+# timezone =
+
+# max length of characters to apply to the "slug" field
+# truncate_slug_length = 40
+
+# set to 'true' to run the environment during
+# the 'revision' command, regardless of autogenerate
+# revision_environment = false
+
+# set to 'true' to allow .pyc and .pyo files without
+# a source .py file to be detected as revisions in the
+# versions/ directory
+# sourceless = false
+
+# version location specification; This defaults
+# to <script_location>/versions.  When using multiple version
+# directories, initial revisions must be specified with --version-path.
+# The path separator used here should be the separator specified by "path_separator"
+# below.
+# version_locations = %(here)s/bar:%(here)s/bat:%(here)s/alembic/versions
+
+# path_separator; This indicates what character is used to split lists of file
+# paths, including version_locations and prepend_sys_path within configparser
+# files such as alembic.ini.
+# The default rendered in new alembic.ini files is "os", which uses os.pathsep
+# to provide os-dependent path splitting.
+#
+# Note that in order to support legacy alembic.ini files, this default does NOT
+# take place if path_separator is not present in alembic.ini.  If this
+# option is omitted entirely, fallback logic is as follows:
+#
+# 1. Parsing of the version_locations option falls back to using the legacy
+#    "version_path_separator" key, which if absent then falls back to the legacy
+#    behavior of splitting on spaces and/or commas.
+# 2. Parsing of the prepend_sys_path option falls back to the legacy
+#    behavior of splitting on spaces, commas, or colons.
+#
+# Valid values for path_separator are:
+#
+# path_separator = :
+# path_separator = ;
+# path_separator = space
+# path_separator = newline
+#
+# Use os.pathsep. Default configuration used for new projects.
+path_separator = os
+
+# set to 'true' to search source files recursively
+# in each "version_locations" directory
+# new in Alembic version 1.10
+# recursive_version_locations = false
+
+# the output encoding used when revision files
+# are written from script.py.mako
+# output_encoding = utf-8
+
+# database URL.  This is consumed by the user-maintained env.py script only.
+# other means of configuring database URLs may be customized within the env.py
+# file.
+#
+# discogs-etl reads the URL from the environment in alembic/env.py:
+#   1. DATABASE_URL_DISCOGS  (canonical)
+#   2. DATABASE_URL          (deprecated fallback)
+# This line is kept as a placeholder so alembic doesn't error on missing key;
+# env.py overrides it before any connection is opened.
+sqlalchemy.url = driver://user:pass@localhost/dbname
+
+
+[post_write_hooks]
+# post_write_hooks defines scripts or Python functions that are run
+# on newly generated revision scripts.  See the documentation for further
+# detail and examples
+
+# format using "black" - use the console_scripts runner, against the "black" entrypoint
+# hooks = black
+# black.type = console_scripts
+# black.entrypoint = black
+# black.options = -l 79 REVISION_SCRIPT_FILENAME
+
+# lint with attempts to fix using "ruff" - use the module runner, against the "ruff" module
+# hooks = ruff
+# ruff.type = module
+# ruff.module = ruff
+# ruff.options = check --fix REVISION_SCRIPT_FILENAME
+
+# Alternatively, use the exec runner to execute a binary found on your PATH
+# hooks = ruff
+# ruff.type = exec
+# ruff.executable = ruff
+# ruff.options = check --fix REVISION_SCRIPT_FILENAME
+
+# Logging configuration.  This is also consumed by the user-maintained
+# env.py script only.
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARNING
+handlers = console
+qualname =
+
+[logger_sqlalchemy]
+level = WARNING
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s
+datefmt = %H:%M:%S

--- a/alembic/README
+++ b/alembic/README
@@ -1,0 +1,1 @@
+Generic single-database configuration.

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -1,0 +1,106 @@
+import os
+import sys
+from logging.config import fileConfig
+
+from sqlalchemy import engine_from_config, pool
+
+from alembic import context
+
+# this is the Alembic Config object, which provides
+# access to the values within the .ini file in use.
+config = context.config
+
+# Interpret the config file for Python logging.
+# This line sets up loggers basically.
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+# Resolve the database URL from the environment, matching the cache-builder
+# CLI convention documented in CLAUDE.md:
+#   1. DATABASE_URL_DISCOGS  (canonical)
+#   2. DATABASE_URL          (deprecated fallback; emits a warning)
+_db_url = os.environ.get("DATABASE_URL_DISCOGS")
+if not _db_url:
+    _db_url = os.environ.get("DATABASE_URL")
+    if _db_url:
+        print(
+            "warning: DATABASE_URL is deprecated for discogs-etl; set DATABASE_URL_DISCOGS instead",
+            file=sys.stderr,
+        )
+if not _db_url:
+    raise RuntimeError(
+        "DATABASE_URL_DISCOGS (or DATABASE_URL) must be set to run alembic "
+        "migrations against the discogs cache."
+    )
+
+# discogs-etl uses psycopg (psycopg3); SQLAlchemy's default postgresql:// URL
+# resolves to psycopg2, which isn't a runtime dep. Force the psycopg driver.
+if _db_url.startswith("postgresql://"):
+    _db_url = "postgresql+psycopg://" + _db_url[len("postgresql://") :]
+elif _db_url.startswith("postgres://"):
+    _db_url = "postgresql+psycopg://" + _db_url[len("postgres://") :]
+config.set_main_option("sqlalchemy.url", _db_url)
+
+# add your model's MetaData object here
+# for 'autogenerate' support
+# from myapp import mymodel
+# target_metadata = mymodel.Base.metadata
+#
+# discogs-etl uses hand-written migrations that op.execute() the
+# canonical schema/*.sql files; --autogenerate is intentionally not wired up.
+target_metadata = None
+
+# other values from the config, defined by the needs of env.py,
+# can be acquired:
+# my_important_option = config.get_main_option("my_important_option")
+# ... etc.
+
+
+def run_migrations_offline() -> None:
+    """Run migrations in 'offline' mode.
+
+    This configures the context with just a URL
+    and not an Engine, though an Engine is acceptable
+    here as well.  By skipping the Engine creation
+    we don't even need a DBAPI to be available.
+
+    Calls to context.execute() here emit the given string to the
+    script output.
+
+    """
+    url = config.get_main_option("sqlalchemy.url")
+    context.configure(
+        url=url,
+        target_metadata=target_metadata,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online() -> None:
+    """Run migrations in 'online' mode.
+
+    In this scenario we need to create an Engine
+    and associate a connection with the context.
+
+    """
+    connectable = engine_from_config(
+        config.get_section(config.config_ini_section, {}),
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+
+    with connectable.connect() as connection:
+        context.configure(connection=connection, target_metadata=target_metadata)
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/alembic/script.py.mako
+++ b/alembic/script.py.mako
@@ -1,0 +1,28 @@
+"""${message}
+
+Revision ID: ${up_revision}
+Revises: ${down_revision | comma,n}
+Create Date: ${create_date}
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+${imports if imports else ""}
+
+# revision identifiers, used by Alembic.
+revision: str = ${repr(up_revision)}
+down_revision: Union[str, Sequence[str], None] = ${repr(down_revision)}
+branch_labels: Union[str, Sequence[str], None] = ${repr(branch_labels)}
+depends_on: Union[str, Sequence[str], None] = ${repr(depends_on)}
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    ${downgrades if downgrades else "pass"}

--- a/alembic/versions/0001_initial.py
+++ b/alembic/versions/0001_initial.py
@@ -1,0 +1,68 @@
+"""initial baseline
+
+Reproduces the canonical schema in ``schema/*.sql`` as the alembic baseline.
+
+The SQL files remain the single source of truth — this revision just executes
+them in pipeline order so alembic has a recorded starting point. Existing
+production databases will be ``alembic stamp head``-ed on first post-migration
+deploy (see WXYC/wxyc-etl#56); the runtime path that drives the pipeline still
+applies the SQL files directly.
+
+Revision ID: 0001_initial
+Revises:
+Create Date: 2026-04-27
+
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Sequence
+from pathlib import Path
+
+import psycopg
+
+# revision identifiers, used by Alembic.
+revision: str = "0001_initial"
+down_revision: str | Sequence[str] | None = None
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+# alembic/versions/0001_initial.py -> repo root is two parents up
+_SCHEMA_DIR = Path(__file__).resolve().parents[2] / "schema"
+
+# Order matches scripts/run_pipeline.py: functions must precede create_database
+# because idx_master_title_trgm references f_unaccent (see issue #104).
+# Indexes follow once the tables exist.
+_SCHEMA_FILES: tuple[str, ...] = (
+    "create_functions.sql",
+    "create_database.sql",
+    "create_indexes.sql",
+    "create_track_indexes.sql",
+)
+
+
+def upgrade() -> None:
+    # Open a side-channel psycopg connection in autocommit mode and apply the
+    # canonical schema/*.sql files. We bypass alembic's wrapped transaction so
+    # the multi-statement files (some with DO $$ ... $$ blocks) execute the
+    # same way scripts/run_pipeline.py applies them.
+    #
+    # CREATE INDEX CONCURRENTLY is stripped: this baseline only ever applies
+    # to an empty database, so the online-DDL safety isn't relevant -- mirrors
+    # the ``strip_concurrently=True`` path in scripts/run_pipeline.py.
+    db_url = os.environ.get("DATABASE_URL_DISCOGS") or os.environ.get("DATABASE_URL")
+    if not db_url:
+        raise RuntimeError(
+            "DATABASE_URL_DISCOGS (or DATABASE_URL) must be set to apply 0001_initial."
+        )
+    with psycopg.connect(db_url, autocommit=True) as conn, conn.cursor() as cur:
+        for name in _SCHEMA_FILES:
+            sql = (_SCHEMA_DIR / name).read_text().replace(" CONCURRENTLY", "")
+            cur.execute(sql)
+
+
+def downgrade() -> None:
+    # Baseline migration; no downgrade path. Drop the database to start over.
+    raise NotImplementedError("0001_initial is the baseline migration; downgrade is not supported.")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dev = [
     "pytest>=7.0.0",
     "pytest-asyncio>=0.21.0",
     "ruff>=0.4.0",
+    "alembic>=1.13",
 ]
 
 [build-system]

--- a/tests/integration/test_alembic_baseline.py
+++ b/tests/integration/test_alembic_baseline.py
@@ -1,0 +1,61 @@
+"""Verify the alembic 0001_initial baseline applies cleanly to an empty Postgres.
+
+The baseline replays ``schema/*.sql`` in pipeline order, so the surface this
+guards is: CONCURRENTLY-stripping works, dollar-quoted DO blocks survive, and
+alembic stamps ``version_num = '0001_initial'`` on success.
+
+Marked ``pg`` because it needs a live Postgres; lives in ``tests/integration/``
+because the unit of work spans an actual migration tool + database round-trip.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import psycopg
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+@pytest.mark.pg
+def test_alembic_upgrade_head_against_empty_db(db_url: str) -> None:
+    env = {**os.environ, "DATABASE_URL_DISCOGS": db_url}
+    # Drop any inherited DATABASE_URL so we can't accidentally validate the
+    # deprecated-fallback path here.
+    env.pop("DATABASE_URL", None)
+
+    result = subprocess.run(
+        [sys.executable, "-m", "alembic", "upgrade", "head"],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, (
+        f"alembic upgrade head failed:\nstdout: {result.stdout}\nstderr: {result.stderr}"
+    )
+
+    with psycopg.connect(db_url) as conn, conn.cursor() as cur:
+        cur.execute("SELECT version_num FROM alembic_version")
+        row = cur.fetchone()
+        assert row == ("0001_initial",), f"unexpected alembic_version row: {row}"
+
+        # Spot-check the contract: the canonical tables and the trigram index
+        # whose creation expression depends on f_unaccent() (issue #104).
+        cur.execute(
+            "SELECT table_name FROM information_schema.tables "
+            "WHERE table_schema = 'public' ORDER BY table_name"
+        )
+        tables = {row[0] for row in cur.fetchall()}
+        for required in ("release", "release_artist", "release_track", "cache_metadata"):
+            assert required in tables, f"missing table {required} after baseline"
+
+        cur.execute(
+            "SELECT 1 FROM pg_indexes "
+            "WHERE schemaname = 'public' AND indexname = 'idx_release_artist_name_trgm'"
+        )
+        assert cur.fetchone() is not None, "trigram index missing after baseline"


### PR DESCRIPTION
## Summary

- Add `alembic` to the dev deps and scaffold `alembic/` + `alembic.ini`. `env.py` resolves the URL from `DATABASE_URL_DISCOGS` (canonical) or `DATABASE_URL` (deprecated, warns to stderr) and rewrites `postgresql://` → `postgresql+psycopg://` so SQLAlchemy uses psycopg3 instead of pulling in psycopg2.
- Add `alembic/versions/0001_initial.py` — a hand-written baseline whose `upgrade()` opens an autocommit psycopg connection and replays `schema/create_functions.sql`, `schema/create_database.sql`, `schema/create_indexes.sql`, `schema/create_track_indexes.sql` in pipeline order. CONCURRENTLY is stripped (mirrors `strip_concurrently=True` in `scripts/run_pipeline.py`) because the baseline only ever runs against an empty database.
- Add a CLAUDE.md "Migrations" section covering layout, how to add a revision, the apply command, and the explicit fact that `alembic upgrade head` is **not yet** wired into the deploy path. That switch + production stamping lands in WXYC/wxyc-etl#56.
- Add `tests/integration/test_alembic_baseline.py` (`pg`-marked) — runs `alembic upgrade head` against a fresh DB, asserts `alembic_version = '0001_initial'`, and spot-checks the canonical tables + the trigram index whose creation depended on `f_unaccent` ordering (regression target for #104).

The runtime / deploy path is unchanged: `scripts/run_pipeline.py` still applies `schema/*.sql` directly via `run_sql_file`. The pipeline doesn't import alembic.

## Test plan

- [x] `alembic.ini`, `alembic/env.py`, `alembic/versions/0001_initial.py` exist
- [x] `0001_initial.py` replays all four `schema/*.sql` files in pipeline order
- [x] `DATABASE_URL_DISCOGS=… alembic upgrade head` against an empty Postgres succeeds and stamps `0001_initial`
- [x] CLAUDE.md "Migrations" section landed
- [x] `ruff check .` and `ruff format --check .` pass
- [x] `pytest -m pg tests/integration/test_alembic_baseline.py` passes against `docker compose up db`
- [x] No changes to `scripts/run_pipeline.py` or any deploy/runtime code path

## Tracking

- Parent epic: WXYC/wxyc-etl#48
- Phase: D — Music Data Pipeline Hardening (https://github.com/orgs/WXYC/projects/19)
- Follow-up: WXYC/wxyc-etl#56 wires `alembic upgrade head` into deploy and stamps existing production DBs.

Closes #119