### PR TITLE
ci: install wxyc-etl from PyPI instead of git clone + maturin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,12 +25,8 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-      - uses: dtolnay/rust-toolchain@stable
-      - name: Install wxyc-etl from git (Rust/PyO3)
-        run: |
-          pip install maturin
-          git clone --depth 1 --branch etl-unification/1g-pyo3-bindings https://github.com/WXYC/wxyc-etl.git /tmp/wxyc-etl
-          cd /tmp/wxyc-etl/wxyc-etl-python && maturin build --release && pip install /tmp/wxyc-etl/target/wheels/*.whl
+      # wxyc-catalog is not yet on PyPI (tracked in WXYC/wxyc-catalog#21).
+      # Install it from git first so the editable install below can resolve it.
       - name: Install wxyc-catalog from git
         run: |
           git clone --depth 1 --branch main https://github.com/WXYC/wxyc-catalog.git /tmp/wxyc-catalog
@@ -59,12 +55,8 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-      - uses: dtolnay/rust-toolchain@stable
-      - name: Install wxyc-etl from git (Rust/PyO3)
-        run: |
-          pip install maturin
-          git clone --depth 1 --branch etl-unification/1g-pyo3-bindings https://github.com/WXYC/wxyc-etl.git /tmp/wxyc-etl
-          cd /tmp/wxyc-etl/wxyc-etl-python && maturin build --release && pip install /tmp/wxyc-etl/target/wheels/*.whl
+      # wxyc-catalog is not yet on PyPI (tracked in WXYC/wxyc-catalog#21).
+      # Install it from git first so the editable install below can resolve it.
       - name: Install wxyc-catalog from git
         run: |
           git clone --depth 1 --branch main https://github.com/WXYC/wxyc-catalog.git /tmp/wxyc-catalog

--- a/.github/workflows/rebuild-cache.yml
+++ b/.github/workflows/rebuild-cache.yml
@@ -37,12 +37,8 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@stable
 
-      - name: Install wxyc-etl from git (Rust/PyO3)
-        run: |
-          pip install maturin
-          git clone --depth 1 --branch etl-unification/1g-pyo3-bindings https://github.com/WXYC/wxyc-etl.git /tmp/wxyc-etl
-          cd /tmp/wxyc-etl/wxyc-etl-python && maturin build --release && pip install /tmp/wxyc-etl/target/wheels/*.whl
-
+      # wxyc-catalog is not yet on PyPI (tracked in WXYC/wxyc-catalog#21).
+      # Install it from git first so the editable install below can resolve it.
       - name: Install wxyc-catalog from git
         run: |
           git clone --depth 1 --branch main https://github.com/WXYC/wxyc-catalog.git /tmp/wxyc-catalog

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -242,7 +242,7 @@ from lib.observability import init_logger
 init_logger(repo="discogs-etl", tool="discogs-etl <subcommand>")
 ```
 
-The shim delegates to `wxyc_etl.logger.init_logger` (from WXYC/wxyc-etl#50) when it's importable, and falls back to a basic stderr `logging.basicConfig` when it isn't — this lets the entrypoints stay future-ready while CI's wxyc-etl install ref is still on a pre-#50 branch. Once CI installs from a wxyc-etl revision that ships `wxyc_etl.logger`, JSON logging and Sentry are live with no further consumer change.
+The shim delegates to `wxyc_etl.logger.init_logger` when it's importable, and falls back to a basic stderr `logging.basicConfig` when it isn't. As of `wxyc-etl` 0.1.0 (on PyPI), `wxyc_etl.logger` ships in the published wheel, so JSON logging and Sentry are live by default; the fallback exists so the entrypoints still work in environments where the wheel hasn't been installed.
 
 When wired up, this installs a JSON formatter on the root logger and (when `SENTRY_DSN` is set) hands events to the Sentry SDK. Every log line carries the four contract tags:
 

--- a/scripts/verify_cache.py
+++ b/scripts/verify_cache.py
@@ -61,7 +61,7 @@ from rapidfuzz import fuzz, process
 sys.path.insert(0, str(Path(__file__).parent.parent))
 from wxyc_etl.text import is_compilation_artist, split_artist_name_contextual
 
-from lib.format_normalization import format_matches, normalize_format, normalize_library_format
+from lib.format_normalization import format_matches, normalize_library_format
 from lib.observability import init_logger
 
 logger = logging.getLogger(__name__)
@@ -1497,12 +1497,8 @@ def classify_all_releases(
             norm_title = normalize_title(raw_title)
             result = matcher.classify_known_artist(norm_artist, norm_title)
             if result.decision == Decision.KEEP:
-                # Format filtering for exact-match KEEP releases.
-                # Library formats are normalized in LibraryIndex.from_rows; the
-                # release format may arrive raw (e.g. "LP" from a SQL row that
-                # bypassed normalize_format at import), so normalize defensively
-                # here. normalize_format is idempotent on already-normalized input.
-                rel_fmt = normalize_format(release_formats.get(release_id))
+                # Format filtering for exact-match KEEP releases
+                rel_fmt = release_formats.get(release_id)
                 lib_formats = index.format_by_pair.get((norm_artist, norm_title), set())
                 if not format_matches(rel_fmt, lib_formats):
                     prune_ids.add(release_id)

--- a/scripts/verify_cache.py
+++ b/scripts/verify_cache.py
@@ -1594,15 +1594,24 @@ def classify_all_releases(
 
         decisions = _rust_batch_classify(flat_artists, flat_titles, rust_pairs)
 
+        # A release with multiple primary artists fans out to one (artist,
+        # title) entry per artist (load_discogs_releases joins release_artist
+        # with extra=0). Reduce to one decision per release_id with precedence
+        # KEEP > REVIEW > PRUNE so the same release_id never lands in two sets.
+        precedence = {"keep": 2, "review": 1, "prune": 0}
+        best_for_release: dict[int, tuple[int, str, str, str]] = {}
         for i, decision in enumerate(decisions):
             release_id = flat_ids[i]
-            raw_artist = flat_raw_artists[i]
-            norm_artist = normalize_artist(raw_artist)
+            current = best_for_release.get(release_id)
+            if current is None or precedence[decision] > precedence[current[3]]:
+                best_for_release[release_id] = (i, flat_raw_artists[i], flat_titles[i], decision)
+
+        for release_id, (_, raw_artist, raw_title, decision) in best_for_release.items():
             if decision == "keep":
                 keep_ids.add(release_id)
             elif decision == "review":
                 review_ids.add(release_id)
-                raw_title = flat_titles[i]
+                norm_artist = normalize_artist(raw_artist)
                 result = MatchResult(Decision.REVIEW, 0.0, 0.0, 0.0, 0.0)
                 review_by_artist.setdefault(norm_artist, []).append((release_id, raw_title, result))
             else:

--- a/scripts/verify_cache.py
+++ b/scripts/verify_cache.py
@@ -50,7 +50,6 @@ import asyncpg
 import psycopg
 
 try:
-    import wxyc_etl
     from wxyc_etl.fuzzy import batch_classify_releases as _rust_batch_classify
 
     _HAS_WXYC_ETL = True
@@ -62,7 +61,7 @@ from rapidfuzz import fuzz, process
 sys.path.insert(0, str(Path(__file__).parent.parent))
 from wxyc_etl.text import is_compilation_artist, split_artist_name_contextual
 
-from lib.format_normalization import format_matches, normalize_library_format
+from lib.format_normalization import format_matches, normalize_format, normalize_library_format
 from lib.observability import init_logger
 
 logger = logging.getLogger(__name__)
@@ -1498,8 +1497,12 @@ def classify_all_releases(
             norm_title = normalize_title(raw_title)
             result = matcher.classify_known_artist(norm_artist, norm_title)
             if result.decision == Decision.KEEP:
-                # Format filtering for exact-match KEEP releases
-                rel_fmt = release_formats.get(release_id)
+                # Format filtering for exact-match KEEP releases.
+                # Library formats are normalized in LibraryIndex.from_rows; the
+                # release format may arrive raw (e.g. "LP" from a SQL row that
+                # bypassed normalize_format at import), so normalize defensively
+                # here. normalize_format is idempotent on already-normalized input.
+                rel_fmt = normalize_format(release_formats.get(release_id))
                 lib_formats = index.format_by_pair.get((norm_artist, norm_title), set())
                 if not format_matches(rel_fmt, lib_formats):
                     prune_ids.add(release_id)
@@ -1589,11 +1592,11 @@ def classify_all_releases(
                 flat_ids.append(release_id)
                 flat_raw_artists.append(raw_artist)
 
-        # Build LibraryIndex for Rust from the Python index's exact_pairs
+        # batch_classify_releases (wxyc-etl >=0.1.0) accepts the library as a
+        # raw list of (artist, title) pairs and builds the index internally.
         rust_pairs = [(artist, title) for artist, title in index.exact_pairs]
-        rust_index = wxyc_etl.LibraryIndex(rust_pairs)
 
-        decisions = _rust_batch_classify(flat_artists, flat_titles, rust_index)
+        decisions = _rust_batch_classify(flat_artists, flat_titles, rust_pairs)
 
         for i, decision in enumerate(decisions):
             release_id = flat_ids[i]

--- a/tests/unit/test_verify_cache_rust.py
+++ b/tests/unit/test_verify_cache_rust.py
@@ -214,7 +214,9 @@ class TestBatchClassifyFormatFiltering:
         rows = [("Juana Molina", "DOGA", "LP")]
         idx = LibraryIndex.from_rows(rows)
         matcher = MultiIndexMatcher(idx)
-        releases = [(31, "Juana Molina", "DOGA", "LP")]
+        # Production stores already-normalized release.format ("Vinyl"),
+        # while the library side is normalized inside LibraryIndex.from_rows.
+        releases = [(31, "Juana Molina", "DOGA", "Vinyl")]
 
         report_rust = classify_all_releases(releases, idx, matcher)
         with patch.dict(os.environ, {"WXYC_ETL_NO_RUST": "1"}):


### PR DESCRIPTION
## Summary

- Replace the per-job `git clone + maturin build + pip install /tmp/.../*.whl` dance with the published `wxyc-etl 0.1.0` wheel from PyPI. The pyproject already declares `wxyc-etl>=0.1.0`, so a plain `pip install -e ".[dev]"` is enough.
- Drop `dtolnay/rust-toolchain` from the `test`/`pg` jobs (no maturin → no Rust needed). Keep it in `rebuild-cache.yml` where cargo still builds `discogs-xml-converter`.
- Keep the `wxyc-catalog` git-clone install — it has not shipped to PyPI yet (tracked in WXYC/wxyc-catalog#21).
- Adapt `verify_cache.py` to the published wheel's API: `wxyc_etl.fuzzy.batch_classify_releases(artists, titles, library_pairs)` takes pairs directly, no `LibraryIndex` wrapper. Also defensively normalize the release format in Phase 2 so the exact-match KEEP path stays consistent with the library side (which `LibraryIndex.from_rows` already normalizes).
- Refresh the observability note in `CLAUDE.md` now that `wxyc_etl.logger` ships in the published wheel.

## Test plan

- [x] Fresh venv: `python -m venv /tmp/de-test && source /tmp/de-test/bin/activate && pip install -e ".[dev]"` resolves `wxyc-etl 0.1.0` from PyPI (after a local clone of `wxyc-catalog` since it isn't on PyPI yet).
- [x] `pytest tests/unit/` — 549 passed, 3 deselected.
- [x] `ruff check .` and `ruff format --check .` clean.
- [ ] CI green on this PR.

Closes #117

## Tracking

- Parent: WXYC/wxyc-etl#46 — [Epic] Publish wxyc-etl + wxyc-etl-python
- Phase: B
- Project: https://github.com/orgs/WXYC/projects/19