### PR TITLE
dedup: preserve release.master_id through the copy-swap

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,9 +47,11 @@ Step 1 (download) is always manual.
 
 ### master_id Column Lifecycle
 
-The `release` table includes a `master_id` column used during import and dedup. The dedup copy-swap strategy (`CREATE TABLE AS SELECT ...` without `master_id`) drops the column automatically. After dedup, `master_id` no longer exists in the schema.
+The `release` table includes a `master_id` column populated during import (links a release to its Discogs "master" — the conceptual album, distinct from any specific pressing/edition). It is used during dedup (`PARTITION BY master_id, format` in `ensure_dedup_ids`) and persists through the dedup copy-swap so consumers can group editions of the same album. NULL is allowed (singles, demos, and obscure pressings often lack a master).
 
-The `country` column, by contrast, is permanent -- it is included in the dedup copy-swap SELECT list and persists in the final schema for consumers.
+The dedup `CREATE TABLE new_release AS SELECT ... FROM release` SELECT list at `scripts/dedup_releases.py` (`DEDUP_TABLES` module constant) must include `master_id` for the column to survive the swap. Tests in `tests/integration/test_dedup.py::TestDedupCopySwapPreservesMasterId` pin this — they import `DEDUP_TABLES` from the production module rather than mirroring it, so the test cannot drift from production.
+
+The `country` column behaves the same way — listed in the dedup SELECT and therefore permanent.
 
 ### format Column Lifecycle
 

--- a/schema/create_database.sql
+++ b/schema/create_database.sql
@@ -71,7 +71,7 @@ CREATE TABLE release (
     artwork_url     text,
     released        text,              -- full date string, e.g. "2024-03-15"
     format          text,              -- normalized format category: 'Vinyl', 'CD', etc.
-    master_id       integer          -- used by dedup, dropped after dedup copy-swap
+    master_id       integer          -- Discogs master ID; used by dedup partitioning, persists post-swap (see DEDUP_TABLES in scripts/dedup_releases.py)
 );
 
 -- Artists on releases

--- a/scripts/dedup_releases.py
+++ b/scripts/dedup_releases.py
@@ -304,6 +304,51 @@ def ensure_dedup_ids(conn) -> int:
     return count
 
 
+# Tables copied during the dedup swap. Each tuple is
+# (old_table, new_table, copied_columns, id_col_for_dedup_filter). This lives
+# at module scope so tests/integration/test_dedup.py imports the same list the
+# production main() uses, instead of maintaining a parallel copy that can
+# silently drift (which is how WXYC/discogs-etl#129 hid for a release).
+DEDUP_TABLES: list[tuple[str, str, str, str]] = [
+    (
+        "release",
+        "new_release",
+        "id, title, release_year, country, artwork_url, released, format, master_id",
+        "id",
+    ),
+    (
+        "release_artist",
+        "new_release_artist",
+        "release_id, artist_id, artist_name, extra, role",
+        "release_id",
+    ),
+    (
+        "release_label",
+        "new_release_label",
+        "release_id, label_id, label_name, catno",
+        "release_id",
+    ),
+    (
+        "release_genre",
+        "new_release_genre",
+        "release_id, genre",
+        "release_id",
+    ),
+    (
+        "release_style",
+        "new_release_style",
+        "release_id, style",
+        "release_id",
+    ),
+    (
+        "cache_metadata",
+        "new_cache_metadata",
+        "release_id, cached_at, source, last_validated",
+        "release_id",
+    ),
+]
+
+
 def copy_table(conn, old_table: str, new_table: str, columns: str, id_col: str) -> int:
     """Copy rows NOT in dedup_delete_ids to a new table.
 
@@ -582,46 +627,7 @@ def main():
 
     # Step 2: Copy each table (keeping only non-duplicate rows)
     # Only base tables + cache_metadata (tracks are imported after dedup)
-    tables = [
-        (
-            "release",
-            "new_release",
-            "id, title, release_year, country, artwork_url, released, format",
-            "id",
-        ),
-        (
-            "release_artist",
-            "new_release_artist",
-            "release_id, artist_id, artist_name, extra, role",
-            "release_id",
-        ),
-        (
-            "release_label",
-            "new_release_label",
-            "release_id, label_id, label_name, catno",
-            "release_id",
-        ),
-        (
-            "release_genre",
-            "new_release_genre",
-            "release_id, genre",
-            "release_id",
-        ),
-        (
-            "release_style",
-            "new_release_style",
-            "release_id, style",
-            "release_id",
-        ),
-        (
-            "cache_metadata",
-            "new_cache_metadata",
-            "release_id, cached_at, source, last_validated",
-            "release_id",
-        ),
-    ]
-
-    for old, new, cols, id_col in tables:
+    for old, new, cols, id_col in DEDUP_TABLES:
         copy_table(conn, old, new, cols, id_col)
 
     # Step 3: Drop old FK constraints before swap
@@ -638,7 +644,7 @@ def main():
 
     # Step 4: Swap tables
     logger.info("Swapping tables...")
-    for old, new, _, _ in tables:
+    for old, new, _, _ in DEDUP_TABLES:
         swap_tables(conn, old, new)
 
     # Step 5: Add base constraints and indexes

--- a/tests/integration/test_dedup.py
+++ b/tests/integration/test_dedup.py
@@ -39,6 +39,7 @@ add_constraints_and_indexes = _dd.add_constraints_and_indexes
 load_library_labels = _dd.load_library_labels
 load_label_hierarchy = _dd.load_label_hierarchy
 create_label_match_table = _dd.create_label_match_table
+DEDUP_TABLES = _dd.DEDUP_TABLES
 
 pytestmark = pytest.mark.pg
 
@@ -101,50 +102,6 @@ def _fresh_import(db_url: str) -> None:
     conn.commit()
     create_track_count_table(conn, CSV_DIR)
     conn.close()
-
-
-DEDUP_TABLES = [
-    (
-        "release",
-        "new_release",
-        "id, title, release_year, country, artwork_url, released, format",
-        "id",
-    ),
-    (
-        "release_artist",
-        "new_release_artist",
-        "release_id, artist_id, artist_name, extra, role",
-        "release_id",
-    ),
-    (
-        "release_label",
-        "new_release_label",
-        "release_id, label_id, label_name, catno",
-        "release_id",
-    ),
-    # release_genre and release_style must be in this list so swap_tables drops the
-    # original tables (and their indexes from create_database.sql) before
-    # add_base_constraints_and_indexes recreates them. Otherwise the index creation
-    # in add_base_constraints_and_indexes fails with DuplicateTable.
-    (
-        "release_genre",
-        "new_release_genre",
-        "release_id, genre",
-        "release_id",
-    ),
-    (
-        "release_style",
-        "new_release_style",
-        "release_id, style",
-        "release_id",
-    ),
-    (
-        "cache_metadata",
-        "new_cache_metadata",
-        "release_id, cached_at, source, last_validated",
-        "release_id",
-    ),
-]
 
 
 def _run_dedup(db_url: str) -> None:
@@ -1248,3 +1205,92 @@ class TestDedupCopySwapAbortCleanup:
         assert ids == [2], f"Only US release should survive dedup, got {ids}"
         assert dangling == [], f"No dangling temp tables should remain: {dangling}"
         assert not dedup_exists, "dedup_delete_ids should be cleaned up"
+
+
+class TestDedupCopySwapPreservesMasterId:
+    """Regression for WXYC/discogs-etl#129.
+
+    Before the fix, the copy-swap step's SELECT list at dedup_releases.py:589
+    omitted ``release.master_id``. Because copy_table() uses ``CREATE TABLE
+    new_release AS SELECT {columns} ...``, the column was absent from
+    new_release, and the swap (RENAME) carried that absence onto the live
+    ``release`` table. After every monthly rebuild ``master_id`` was gone from
+    the schema entirely — silent because no test exercised the copy-swap path
+    against fixtures with a collision. The 2026-04-28 incident recovery
+    needed master_id and we had to re-import it manually.
+    """
+
+    @pytest.fixture(autouse=True, scope="class")
+    def _set_up_and_dedup(self, db_url):
+        self.__class__._db_url = db_url
+        conn = psycopg.connect(db_url, autocommit=True)
+        _drop_all_tables(conn)
+        with conn.cursor() as cur:
+            cur.execute(SCHEMA_DIR.joinpath("create_database.sql").read_text())
+            cur.execute(SCHEMA_DIR.joinpath("create_functions.sql").read_text())
+            # Collision pair on (master_id=100, format='LP'). US release wins.
+            cur.execute(
+                "INSERT INTO release (id, title, master_id, format, country) "
+                "VALUES (1, 'Aluminum Tunes', 100, 'LP', 'UK')"
+            )
+            cur.execute(
+                "INSERT INTO release (id, title, master_id, format, country) "
+                "VALUES (2, 'Aluminum Tunes', 100, 'LP', 'US')"
+            )
+            # Singleton survivor with a distinct master_id, so we can prove
+            # post-swap master_id is populated rather than uniformly NULL.
+            cur.execute(
+                "INSERT INTO release (id, title, master_id, format, country) "
+                "VALUES (3, 'DOGA', 200, 'LP', 'AR')"
+            )
+            cur.execute(
+                "INSERT INTO release_artist (release_id, artist_name) VALUES (1, 'Stereolab')"
+            )
+            cur.execute(
+                "INSERT INTO release_artist (release_id, artist_name) VALUES (2, 'Stereolab')"
+            )
+            cur.execute(
+                "INSERT INTO release_artist (release_id, artist_name) VALUES (3, 'Juana Molina')"
+            )
+            cur.execute("INSERT INTO cache_metadata (release_id, source) VALUES (1, 'bulk_import')")
+            cur.execute("INSERT INTO cache_metadata (release_id, source) VALUES (2, 'bulk_import')")
+            cur.execute("INSERT INTO cache_metadata (release_id, source) VALUES (3, 'bulk_import')")
+            cur.execute("""
+                CREATE UNLOGGED TABLE release_track_count (
+                    release_id integer PRIMARY KEY,
+                    track_count integer NOT NULL
+                )
+            """)
+            cur.execute("INSERT INTO release_track_count VALUES (1, 5), (2, 3), (3, 4)")
+        conn.close()
+        _run_dedup(db_url)
+
+    @pytest.fixture(autouse=True)
+    def _store_url(self):
+        self.db_url = self.__class__._db_url
+
+    def _connect(self):
+        return psycopg.connect(self.db_url)
+
+    def test_master_id_column_persists_after_copy_swap(self) -> None:
+        """The release table still has a master_id column after the copy-swap fires."""
+        conn = self._connect()
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT column_name FROM information_schema.columns "
+                "WHERE table_name = 'release' AND column_name = 'master_id'"
+            )
+            assert cur.fetchone() is not None, (
+                "master_id column dropped by copy-swap — see WXYC/discogs-etl#129"
+            )
+        conn.close()
+
+    def test_master_id_values_preserved_for_surviving_releases(self) -> None:
+        """master_id values on surviving rows match what was inserted, not NULL."""
+        conn = self._connect()
+        with conn.cursor() as cur:
+            cur.execute("SELECT id, master_id FROM release ORDER BY id")
+            rows = cur.fetchall()
+        conn.close()
+        # Release 1 lost the dedup; release 2 (US) won; release 3 untouched.
+        assert rows == [(2, 100), (3, 200)], f"master_id values not preserved post-dedup: {rows}"


### PR DESCRIPTION
Closes #129.

## Summary

`scripts/dedup_releases.py` builds `new_release` via `CREATE TABLE new_release AS SELECT {columns} FROM release`. The column list at line 589 omitted `master_id`, so after every monthly rebuild the column was silently dropped from the live `release` table. Surfaced during the 2026-04-28 incident recovery; master_id had to be re-imported manually from the unfiltered CSV.

## Why the existing tests didn't catch it

Two compounding gaps:

1. **Fixtures never triggered copy-swap.** `tests/fixtures/csv/release.csv` has unique `(master_id, format)` pairs, so `ensure_dedup_ids` returns 0 and the copy-swap branch never fires. The closest existing pre-fix assertion was `test_master_id_column_persists_when_no_dedup` — its docstring even said it only passes because dedup was a no-op.
2. **The test file maintained its own `DEDUP_TABLES` constant** that mirrored production and contained the same `master_id` omission. Even with a collision fixture, the test's parallel copy would have hidden a regression in `scripts/dedup_releases.py`.

## Fix

- Hoist the production `tables` list to a module-level `DEDUP_TABLES` constant in `dedup_releases.py`, with `master_id` added to the release row.
- `tests/integration/test_dedup.py` now imports `DEDUP_TABLES` from production rather than maintaining a parallel copy. Cannot drift.
- New `TestDedupCopySwapPreservesMasterId` test class with a manually-inserted `(master_id=100, format='LP')` collision plus a singleton survivor. After `_run_dedup` runs the full copy-swap, asserts (a) the `master_id` column still exists in `release` and (b) values are populated on surviving rows — not NULL.

## Doc fixes

- `CLAUDE.md` "master_id Column Lifecycle" said the column is "dropped after dedup copy-swap" — that description was the bug, not the design. Now correctly describes master_id as persistent, points at the regression test.
- `schema/create_database.sql` had the same comment on the column itself; corrected to match.

## Rollout

The next monthly rebuild after this lands repopulates `master_id` for every release that has one in the dump. No backfill needed; no schema migration needed (master_id was already declared in `schema/create_database.sql`).

## Phase

D. Sister PR to #127 (#130) under post-incident hardening epic #131.