### PR TITLE
filter: pair-wise (artist, title) filter to fit small destination DBs

### DIFF
--- a/.github/workflows/rebuild-cache.yml
+++ b/.github/workflows/rebuild-cache.yml
@@ -5,6 +5,12 @@ name: Rebuild Discogs Cache
 # settle and to stagger against sister cache-builder repos (e.g. wikidata-cache,
 # musicbrainz-cache).
 #
+# The pipeline runs `--pair-filter`, which narrows the converter's
+# artist-only output (~4M release rows) to releases whose (artist, title)
+# pair matches the WXYC library (~50K) before the import step. Without
+# this, the import overflows small destination DBs (Railway-sized) at
+# `COPY release_artist` — see #128.
+#
 # TODO: the Discogs releases dump is ~63 GB compressed XML; expanding +
 # converting it can exceed the GitHub Actions free-runner disk (~14 GB) and
 # 6-hour wall-clock budget. The skeleton here lets operators kick the rebuild
@@ -118,4 +124,5 @@ jobs:
             --xml data/releases.xml.gz \
             --generate-library-db \
             --catalog-source tubafrenzy \
-            --catalog-db-url "${{ secrets.LIBRARY_CATALOG_DB_URL }}"
+            --catalog-db-url "${{ secrets.LIBRARY_CATALOG_DB_URL }}" \
+            --pair-filter

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,7 @@ ETL pipeline for building and maintaining a PostgreSQL cache of Discogs release 
 1. **Download** Discogs monthly data dumps (XML) from https://discogs-data-dumps.s3.us-west-2.amazonaws.com/index.html
 2. **Enrich** `library_artists.txt` with WXYC cross-references (via `wxyc-enrich-library-artists` CLI from wxyc-catalog, optional)
 3. **Convert and filter** XML to CSV using [discogs-xml-converter](https://github.com/WXYC/discogs-xml-converter) (Rust binary), with optional artist filtering via `--library-artists`. Accepts a single XML file or a directory containing releases.xml, artists.xml, and labels.xml. When artists.xml is present, alias-enhanced filtering is enabled automatically. When labels.xml is present, `label_hierarchy.csv` is produced for sublabel-aware dedup.
+3a. **(Optional) Pair-wise filter** with `--pair-filter` (requires `--library-db`). Narrows the converter's artist-filtered CSVs (~4M releases) to releases whose `(artist, title)` matches a library entry (~50K). Used by the monthly rebuild workflow so the import step fits on Railway-sized destination DBs without overflowing the volume during `COPY release_artist` (#128). Diacritic-normalised on both sides; known false negatives are compound-artist library entries like "Duke Ellington & John Coltrane" whose Discogs releases split into separate `release_artist` rows.
 4. **Create schema** (`schema/create_database.sql`) and **functions** (`schema/create_functions.sql`), then **SET UNLOGGED** on all tables to skip WAL writes during bulk import
 5. **Import** filtered CSVs into PostgreSQL (`scripts/import_csv.py`)
 6. **Create indexes** including accent-insensitive trigram GIN indexes (`schema/create_indexes.sql`)
@@ -118,7 +119,7 @@ docker compose up db -d     # just the database (for tests)
 ### Key Files
 
 - `scripts/run_pipeline.py` -- Pipeline orchestrator (--xml for steps 2-9, --csv-dir for steps 4-9)
-- `scripts/filter_csv.py` -- Filter Discogs CSVs to library artists (standalone, used outside the pipeline)
+- `scripts/filter_csv.py` -- Filter Discogs CSVs against the WXYC library. Two modes: (default) artist-only, takes `library_artists.txt`; (`--library-db`) pair-wise on `(artist, title)` against a SQLite library.db. Pair-wise mode is what the monthly rebuild workflow runs via `--pair-filter`; standalone use is also supported.
 - `scripts/import_csv.py` -- Import CSVs into PostgreSQL (psycopg COPY). Child tables are imported in parallel via ThreadPoolExecutor after parent tables. Artist detail tables (artist_alias, artist_member) are filtered to known artist IDs to prevent FK violations, since the converter's CSVs contain all Discogs artists. Tables with `unique_key` configs are deduped in-memory during COPY.
 - `scripts/dedup_releases.py` -- Deduplicate releases by master_id, preferring label match + sublabel resolution, US releases (copy-swap with `DROP CASCADE`). Index/constraint creation is parallelized via ThreadPoolExecutor.
 - `scripts/verify_cache.py` -- Multi-index fuzzy matching for KEEP/PRUNE classification; `--copy-to` streams matches to a target DB. Phase 4 (fuzzy matching) has two paths: when `wxyc-etl` is installed, `batch_classify_releases()` runs all scoring in Rust with rayon parallelism; otherwise, falls back to ProcessPoolExecutor with rapidfuzz. Set `WXYC_ETL_NO_RUST=1` to force the Python fallback. Large prune sets (>10K IDs) use copy-and-swap instead of CASCADE DELETE.
@@ -202,6 +203,8 @@ This pipeline runs monthly (or when Discogs publishes new data dumps). It has a 
 A GitHub Actions cron workflow runs `scripts/run_pipeline.py --xml ...` on the 4th of each month at 06:00 UTC, staggered a few days after Discogs publishes the new dump. It can also be triggered manually with an optional `dump_url` input: `gh workflow run rebuild-cache.yml`.
 
 The job downloads `releases.xml.gz` for the current month from `discogs-data-dumps.s3.us-west-2.amazonaws.com`, builds `discogs-xml-converter` from source, and runs the full XML-mode pipeline (steps 2-10) against `DATABASE_URL_DISCOGS`. Library catalog is generated inline via `--generate-library-db --catalog-source tubafrenzy`.
+
+The workflow runs `--pair-filter` so the import payload to `DATABASE_URL_DISCOGS` is ~50K release rows instead of the converter's ~4M, which is what makes a Railway-sized destination DB feasible (the unfiltered import overflows the volume at `COPY release_artist`; see #128).
 
 **Caveat — runner capacity**: the Discogs releases dump is ~63 GB compressed XML and the conversion + Postgres bulk load can exceed the GitHub Actions free hosted runner's ~14 GB disk and 6-hour wall-clock budget. The workflow file is the deliverable; provisioning a self-hosted or larger hosted runner is a follow-up operator task. Until then, expect the scheduled tick to fail loudly rather than silently produce a half-built cache.
 

--- a/scripts/filter_csv.py
+++ b/scripts/filter_csv.py
@@ -10,8 +10,10 @@ Usage:
 
 from __future__ import annotations
 
+import argparse
 import csv
 import logging
+import sqlite3
 import sys
 import unicodedata
 from pathlib import Path
@@ -40,6 +42,17 @@ def normalize_artist(name: str) -> str:
     Strips diacritics so that Discogs "Björk" matches library "Bjork".
     """
     nfkd = unicodedata.normalize("NFKD", name)
+    stripped = "".join(c for c in nfkd if not unicodedata.combining(c))
+    return stripped.lower().strip()
+
+
+def normalize_title(title: str) -> str:
+    """Normalize release title for matching.
+
+    Same shape as ``normalize_artist`` so a Discogs title with diacritics
+    matches a library title without them (and vice versa).
+    """
+    nfkd = unicodedata.normalize("NFKD", title)
     stripped = "".join(c for c in nfkd if not unicodedata.combining(c))
     return stripped.lower().strip()
 
@@ -151,34 +164,291 @@ def filter_csv_file(
     return input_count, output_count
 
 
-def main():
-    init_logger(repo="discogs-etl", tool="discogs-etl filter_csv")
+def load_library_pairs(library_db: Path) -> dict[str, set[str]]:
+    """Load (artist, title) pairs from a SQLite ``library.db`` file.
 
-    if len(sys.argv) != 4:
-        print(__doc__)
-        sys.exit(1)
+    Returns an inverted index ``{normalized_title: set of normalized_artists}``.
+    Built this way so the pair-wise scan over release_artist.csv can do a
+    single dict lookup keyed by the candidate release's title.
+    """
+    logger.info("Loading library pairs from %s", library_db)
+    pairs: dict[str, set[str]] = {}
+    conn = sqlite3.connect(str(library_db))
+    try:
+        for artist, title in conn.execute("SELECT artist, title FROM library"):
+            if not artist or not title:
+                continue
+            n_title = normalize_title(title)
+            n_artist = normalize_artist(artist)
+            pairs.setdefault(n_title, set()).add(n_artist)
+    finally:
+        conn.close()
+    logger.info(
+        "Loaded %d distinct library titles spanning %d (artist, title) pairs",
+        len(pairs),
+        sum(len(v) for v in pairs.values()),
+    )
+    return pairs
 
-    library_artists_path = Path(sys.argv[1])
-    csv_input_dir = Path(sys.argv[2])
-    csv_output_dir = Path(sys.argv[3])
 
-    if not library_artists_path.exists():
-        logger.error(f"Library artists file not found: {library_artists_path}")
-        sys.exit(1)
+def find_matching_release_ids_pairwise(
+    release_csv: Path,
+    release_artist_csv: Path,
+    library_pairs: dict[str, set[str]],
+) -> set[int]:
+    """Find release IDs whose (any artist, title) matches a library pair.
 
-    if not csv_input_dir.exists():
-        logger.error(f"CSV input directory not found: {csv_input_dir}")
-        sys.exit(1)
+    Two passes: pass 1 builds a ``{release_id: normalized_title}`` map for
+    only those releases whose title is in ``library_pairs`` (an inverted
+    index keyed by title). Pass 2 walks ``release_artist.csv`` and for each
+    candidate release checks whether the artist is in the library's set
+    for that title. Memory bounded by the size of the title intersection,
+    which is small even on a 4M-release dump (~200 K candidates worst case).
+    """
+    logger.info("Pair-wise pass 1: indexing release titles in %s", release_csv)
+    candidate_titles: dict[int, str] = {}
+    title_normalize_cache: dict[str, str] = {}
+
+    with open(release_csv, encoding="utf-8", errors="replace") as f:
+        reader = csv.reader(f)
+        header = next(reader)
+        try:
+            id_idx = header.index("id")
+            title_idx = header.index("title")
+        except ValueError as exc:
+            raise ValueError(f"release.csv missing expected columns. Header: {header}") from exc
+        total_rows = 0
+        for row in reader:
+            total_rows += 1
+            try:
+                raw_title = row[title_idx]
+                raw_id = row[id_idx]
+            except IndexError:
+                continue
+            n_title = title_normalize_cache.get(raw_title)
+            if n_title is None:
+                n_title = normalize_title(raw_title)
+                title_normalize_cache[raw_title] = n_title
+            if n_title not in library_pairs:
+                continue
+            try:
+                rid = int(raw_id)
+            except ValueError:
+                continue
+            candidate_titles[rid] = n_title
+
+            if total_rows % 1000000 == 0:
+                logger.info(
+                    "  Pass 1: scanned %d release rows, %d title candidates so far",
+                    total_rows,
+                    len(candidate_titles),
+                )
+
+    logger.info(
+        "Pair-wise pass 1: %d candidate release titles match the library", len(candidate_titles)
+    )
+
+    logger.info("Pair-wise pass 2: scanning %s for matching artists", release_artist_csv)
+    matching: set[int] = set()
+    artist_normalize_cache: dict[str, str] = {}
+
+    with open(release_artist_csv, encoding="utf-8", errors="replace") as f:
+        reader = csv.reader(f)
+        header = next(reader)
+        try:
+            rid_idx = header.index("release_id")
+            artist_idx = header.index("artist_name")
+        except ValueError as exc:
+            raise ValueError(
+                f"release_artist.csv missing expected columns. Header: {header}"
+            ) from exc
+        total_rows = 0
+        for row in reader:
+            total_rows += 1
+            try:
+                raw_rid = row[rid_idx]
+                raw_artist = row[artist_idx]
+            except IndexError:
+                continue
+            try:
+                rid = int(raw_rid)
+            except ValueError:
+                continue
+            n_title = candidate_titles.get(rid)
+            if n_title is None:
+                continue
+            n_artist = artist_normalize_cache.get(raw_artist)
+            if n_artist is None:
+                n_artist = normalize_artist(raw_artist)
+                artist_normalize_cache[raw_artist] = n_artist
+            if n_artist in library_pairs[n_title]:
+                matching.add(rid)
+
+            if total_rows % 1000000 == 0:
+                logger.info(
+                    "  Pass 2: scanned %d release_artist rows, %d matching releases so far",
+                    total_rows,
+                    len(matching),
+                )
+
+    logger.info(
+        "Pair-wise filter kept %d releases (down from %d candidate titles)",
+        len(matching),
+        len(candidate_titles),
+    )
+    return matching
+
+
+def filter_csvs_by_pairs(
+    library_db: Path,
+    csv_input_dir: Path,
+    csv_output_dir: Path,
+) -> dict[str, tuple[int, int]]:
+    """Filter every release-id-keyed CSV in ``csv_input_dir`` to only the
+    releases whose (artist, title) pair matches the WXYC library.
+
+    Designed to run between the converter's artist-only filter (~4 M releases)
+    and the import step. The pair-wise narrowing brings it down to ~50 K, which
+    fits on a small Postgres host (Railway-sized) where the artist-only output
+    overflows the volume during ``COPY release_artist`` (#128).
+
+    ``csv_input_dir`` and ``csv_output_dir`` may point at the same path; in
+    that case the original CSVs are overwritten in place. The CI workflow
+    uses this to keep runner disk small.
+
+    Returns ``{filename: (input_count, output_count)}``.
+    """
+    library_pairs = load_library_pairs(library_db)
+
+    release_csv = csv_input_dir / "release.csv"
+    release_artist_csv = csv_input_dir / "release_artist.csv"
+    if not release_csv.exists() or not release_artist_csv.exists():
+        raise FileNotFoundError(
+            f"release.csv and release_artist.csv must both exist in {csv_input_dir}"
+        )
+
+    matching_ids = find_matching_release_ids_pairwise(
+        release_csv, release_artist_csv, library_pairs
+    )
 
     csv_output_dir.mkdir(parents=True, exist_ok=True)
 
-    # Step 1: Load library artists
-    library_artists = load_library_artists(library_artists_path)
+    # When input and output dirs match, write each filtered CSV to a sibling
+    # ``.tmp`` first and atomically replace, so a partial failure leaves the
+    # original intact.
+    in_place = csv_input_dir.resolve() == csv_output_dir.resolve()
+    stats: dict[str, tuple[int, int]] = {}
 
-    # Step 2: Find matching release IDs
-    release_artist_path = csv_input_dir / "release_artist.csv"
+    for filename in RELEASE_ID_FILES:
+        input_path = csv_input_dir / filename
+        if not input_path.exists():
+            continue
+        output_path = csv_output_dir / filename
+        id_column = get_release_id_column(filename)
+        if in_place:
+            tmp_path = output_path.with_suffix(output_path.suffix + ".tmp")
+            input_count, output_count = filter_csv_file(
+                input_path, tmp_path, matching_ids, id_column
+            )
+            tmp_path.replace(output_path)
+        else:
+            input_count, output_count = filter_csv_file(
+                input_path, output_path, matching_ids, id_column
+            )
+        stats[filename] = (input_count, output_count)
+        reduction = (1 - output_count / input_count) * 100 if input_count > 0 else 0.0
+        logger.info(
+            "  %s: %d → %d rows (%.1f%% reduction)",
+            filename,
+            input_count,
+            output_count,
+            reduction,
+        )
+
+    return stats
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Filter Discogs CSVs to a smaller subset. Two modes:\n"
+            "  1. Artist-only (default): pass library_artists.txt; keep releases\n"
+            "     with at least one matching artist.\n"
+            "  2. Pair-wise: pass --library-db; keep releases whose (artist, title)\n"
+            "     matches a library entry. Used to narrow the converter's\n"
+            "     ~4M-release output to ~50K so import doesn't OOM small\n"
+            "     destination DBs (#128)."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--library-db",
+        type=Path,
+        help="SQLite library.db for pair-wise (artist, title) filtering.",
+    )
+    parser.add_argument(
+        "--library-artists",
+        type=Path,
+        help="library_artists.txt for artist-only filtering (default mode).",
+    )
+    parser.add_argument(
+        "csv_input_dir", type=Path, help="Directory containing the converter's CSVs."
+    )
+    parser.add_argument(
+        "csv_output_dir",
+        type=Path,
+        help="Output directory for filtered CSVs. May equal csv_input_dir for in-place rewrite.",
+    )
+    args = parser.parse_args(argv)
+    if not args.library_db and not args.library_artists:
+        parser.error("one of --library-db or --library-artists is required")
+    if args.library_db and args.library_artists:
+        parser.error("--library-db and --library-artists are mutually exclusive")
+    return args
+
+
+def main(argv: list[str] | None = None) -> None:
+    init_logger(repo="discogs-etl", tool="discogs-etl filter_csv")
+
+    # Backwards-compat: the original positional CLI was
+    #   filter_csv.py <library_artists> <csv_in> <csv_out>
+    # Detect that shape and rewrite into the argparse-friendly form so
+    # existing callers (scripts, docs) keep working.
+    raw_argv = list(sys.argv[1:]) if argv is None else list(argv)
+    if len(raw_argv) == 3 and not any(a.startswith("--") for a in raw_argv):
+        raw_argv = ["--library-artists", raw_argv[0], raw_argv[1], raw_argv[2]]
+
+    args = _parse_args(raw_argv)
+
+    if args.library_db:
+        if not args.library_db.exists():
+            logger.error("library.db not found: %s", args.library_db)
+            sys.exit(1)
+        if not args.csv_input_dir.exists():
+            logger.error("CSV input directory not found: %s", args.csv_input_dir)
+            sys.exit(1)
+        stats = filter_csvs_by_pairs(args.library_db, args.csv_input_dir, args.csv_output_dir)
+        logger.info("=== Pair-wise filter summary ===")
+        for filename, (inp, out) in stats.items():
+            pct = (1 - out / inp) * 100 if inp > 0 else 0.0
+            logger.info("  %s: %d → %d (%.1f%% reduction)", filename, inp, out, pct)
+        return
+
+    # Artist-only mode (legacy default).
+    if not args.library_artists.exists():
+        logger.error("Library artists file not found: %s", args.library_artists)
+        sys.exit(1)
+    if not args.csv_input_dir.exists():
+        logger.error("CSV input directory not found: %s", args.csv_input_dir)
+        sys.exit(1)
+
+    args.csv_output_dir.mkdir(parents=True, exist_ok=True)
+
+    library_artists = load_library_artists(args.library_artists)
+
+    release_artist_path = args.csv_input_dir / "release_artist.csv"
     if not release_artist_path.exists():
-        logger.error(f"release_artist.csv not found in {csv_input_dir}")
+        logger.error("release_artist.csv not found in %s", args.csv_input_dir)
         sys.exit(1)
 
     matching_ids = find_matching_release_ids(release_artist_path, library_artists)
@@ -187,34 +457,32 @@ def main():
         logger.warning("No matching releases found! Check artist name normalization.")
         sys.exit(1)
 
-    logger.info(f"Found {len(matching_ids):,} releases to keep")
+    logger.info("Found %d releases to keep", len(matching_ids))
 
-    # Step 3: Filter each CSV file
-    stats = {}
+    stats: dict[str, tuple[int, int, float]] = {}
     for filename in RELEASE_ID_FILES:
-        input_path = csv_input_dir / filename
+        input_path = args.csv_input_dir / filename
         if not input_path.exists():
-            logger.warning(f"Skipping {filename} (not found)")
+            logger.warning("Skipping %s (not found)", filename)
             continue
 
-        output_path = csv_output_dir / filename
+        output_path = args.csv_output_dir / filename
         id_column = get_release_id_column(filename)
 
-        logger.info(f"Filtering {filename}...")
+        logger.info("Filtering %s...", filename)
         input_count, output_count = filter_csv_file(
             input_path, output_path, matching_ids, id_column
         )
 
         reduction_pct = (1 - output_count / input_count) * 100 if input_count > 0 else 0
         stats[filename] = (input_count, output_count, reduction_pct)
-        logger.info(f"  {input_count:,} → {output_count:,} rows ({reduction_pct:.1f}% reduction)")
+        logger.info("  %d → %d rows (%.1f%% reduction)", input_count, output_count, reduction_pct)
 
-    # Summary
-    logger.info("\n=== Summary ===")
-    logger.info(f"Library artists: {len(library_artists):,}")
-    logger.info(f"Matching releases: {len(matching_ids):,}")
+    logger.info("=== Summary ===")
+    logger.info("Library artists: %d", len(library_artists))
+    logger.info("Matching releases: %d", len(matching_ids))
     for filename, (inp, out, pct) in stats.items():
-        logger.info(f"  {filename}: {inp:,} → {out:,} ({pct:.1f}% reduction)")
+        logger.info("  %s: %d → %d (%.1f%% reduction)", filename, inp, out, pct)
 
 
 if __name__ == "__main__":

--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -247,6 +247,17 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "still written to the output directory.",
     )
     parser.add_argument(
+        "--pair-filter",
+        action="store_true",
+        default=False,
+        help="After the converter's artist-only filter, narrow the CSVs further "
+        "to releases whose (artist, title) pair matches a library entry. Cuts "
+        "the import payload from ~4M release rows to ~50K, which is what makes "
+        "the rebuild workflow fit on small destination DBs (Railway-sized; "
+        "see #128). Requires --library-db (or --generate-library-db). "
+        "Incompatible with --direct-pg (which bypasses CSVs entirely).",
+    )
+    parser.add_argument(
         "--resume",
         action="store_true",
         default=False,
@@ -310,6 +321,18 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 
     if args.target_db_url and not args.library_db and not args.generate_library_db:
         parser.error("--library-db or --generate-library-db is required when using --target-db-url")
+
+    if args.pair_filter:
+        if args.direct_pg:
+            parser.error(
+                "--pair-filter cannot be combined with --direct-pg "
+                "(--direct-pg bypasses the CSV staging that --pair-filter operates on)"
+            )
+        if not args.library_db and not args.generate_library_db:
+            parser.error(
+                "--pair-filter requires --library-db or --generate-library-db so the "
+                "(artist, title) pairs have a source to match against"
+            )
 
     return args
 
@@ -524,6 +547,27 @@ def convert_and_filter(
         "Convert and import XML to PostgreSQL" if database_url else "Convert and filter XML to CSV"
     )
     run_step(description, cmd)
+
+
+def pair_filter_csvs(library_db: Path, csv_dir: Path, python: str) -> None:
+    """Step 2.7: narrow the converter's artist-filtered CSVs to releases whose
+    (artist, title) pair matches a library entry.
+
+    Runs filter_csv.py --library-db in-place. Cuts release.csv from ~4M rows
+    (the converter's artist-only output) to ~50K — small enough for a
+    Railway-sized destination DB to import without overflowing the volume
+    (#128). The release_artist/label/track/etc. CSVs are filtered to the
+    same release_id set by the same call.
+    """
+    cmd = [
+        python,
+        str(SCRIPT_DIR / "filter_csv.py"),
+        "--library-db",
+        str(library_db),
+        str(csv_dir),
+        str(csv_dir),
+    ]
+    run_step("Pair-wise (artist, title) filter", cmd)
 
 
 def enrich_library_artists(
@@ -759,6 +803,13 @@ def _run_xml_pipeline(
         else:
             # Standard CSV mode
             convert_and_filter(args.xml, csv_out, args.converter, library_artists_path)
+
+            # Pair-wise filter narrows ~4M release rows to ~50K so the
+            # downstream import fits on a small destination DB. In-place
+            # rewrite over csv_out keeps runner disk small. Validated up
+            # front in parse_args() to require --library-db.
+            if args.pair_filter:
+                pair_filter_csvs(args.library_db, csv_out, python)
 
             # Auto-detect label_hierarchy.csv
             hierarchy_csv = args.label_hierarchy

--- a/tests/unit/test_filter_csv.py
+++ b/tests/unit/test_filter_csv.py
@@ -21,6 +21,10 @@ find_matching_release_ids = _fc.find_matching_release_ids
 filter_csv_file = _fc.filter_csv_file
 get_release_id_column = _fc.get_release_id_column
 main = _fc.main
+normalize_title = _fc.normalize_title
+load_library_pairs = _fc.load_library_pairs
+find_matching_release_ids_pairwise = _fc.find_matching_release_ids_pairwise
+filter_csvs_by_pairs = _fc.filter_csvs_by_pairs
 
 FIXTURES_DIR = Path(__file__).parent.parent / "fixtures"
 
@@ -314,7 +318,9 @@ class TestMain:
         monkeypatch.setattr("sys.argv", ["filter_csv.py"])
         with pytest.raises(SystemExit) as exc_info:
             main()
-        assert exc_info.value.code == 1
+        # argparse uses exit code 2 for usage errors; the legacy 3-positional
+        # CLI used exit 1. The exit-on-bad-input contract still holds.
+        assert exc_info.value.code in (1, 2)
 
     def test_missing_library_artists_exits(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -435,3 +441,258 @@ class TestMain:
             rows = list(reader)
         assert len(rows) == 1
         assert rows[0]["id"] == "5001"
+
+
+# ---------------------------------------------------------------------------
+# Pair-wise (artist, title) filter — closes the OOM gap on Railway-sized DBs
+# (#128). The artist-only filter passes ~4.2M releases through; pair-wise
+# narrows to ~58K so import doesn't overflow the destination volume.
+# ---------------------------------------------------------------------------
+
+
+import sqlite3  # noqa: E402
+
+
+class TestNormalizeTitle:
+    """Release-title normalization for pair matching."""
+
+    @pytest.mark.parametrize(
+        "raw, expected",
+        [
+            ("Confield", "confield"),
+            ("  Confield  ", "confield"),
+            ("CONFIELD", "confield"),
+            ("On Your Own Love Again", "on your own love again"),
+            ("", ""),
+            # Diacritic regressions: the title's normalization must be the
+            # same shape as artist normalization so a Discogs "PAINLESS"
+            # against library "PAINLESS" matches even after the canonical
+            # diacritic-bearing artist (Nilüfer Yanya) routes them together.
+            ("Pequeña Vertigem de Amor", "pequena vertigem de amor"),
+            ("Père Ubu's Métal Box", "pere ubu's metal box"),
+        ],
+    )
+    def test_normalize_title(self, raw: str, expected: str) -> None:
+        assert normalize_title(raw) == expected
+
+
+class TestLoadLibraryPairs:
+    """Loading (artist, title) pairs from the library.db SQLite file."""
+
+    def _make_library_db(self, tmp_path: Path, rows: list[tuple[str, str]]) -> Path:
+        path = tmp_path / "library.db"
+        conn = sqlite3.connect(str(path))
+        conn.execute(
+            "CREATE TABLE library (id INTEGER PRIMARY KEY AUTOINCREMENT, "
+            "artist TEXT NOT NULL, title TEXT NOT NULL, format TEXT)"
+        )
+        conn.executemany("INSERT INTO library (artist, title) VALUES (?, ?)", rows)
+        conn.commit()
+        conn.close()
+        return path
+
+    def test_returns_inverted_index_keyed_by_title(self, tmp_path: Path) -> None:
+        db = self._make_library_db(
+            tmp_path,
+            [
+                ("Autechre", "Confield"),
+                ("Autechre", "Amber"),
+                ("Stereolab", "Aluminum Tunes"),
+            ],
+        )
+        pairs = load_library_pairs(db)
+        assert pairs == {
+            "confield": {"autechre"},
+            "amber": {"autechre"},
+            "aluminum tunes": {"stereolab"},
+        }
+
+    def test_collapses_duplicate_rows(self, tmp_path: Path) -> None:
+        # The fixture library.db has duplicate (artist, title) rows from
+        # multiple library copies of the same album. The set-valued index
+        # collapses these.
+        db = self._make_library_db(
+            tmp_path,
+            [
+                ("Stereolab", "Aluminum Tunes"),
+                ("Stereolab", "Aluminum Tunes"),
+                ("Stereolab", "Aluminum Tunes"),
+            ],
+        )
+        pairs = load_library_pairs(db)
+        assert pairs == {"aluminum tunes": {"stereolab"}}
+
+    def test_groups_multiple_artists_under_same_title(self, tmp_path: Path) -> None:
+        db = self._make_library_db(
+            tmp_path,
+            [
+                ("Various Artists", "Compilation"),
+                ("Stereolab", "Compilation"),
+            ],
+        )
+        pairs = load_library_pairs(db)
+        assert pairs == {"compilation": {"various artists", "stereolab"}}
+
+    def test_normalizes_diacritics_on_load(self, tmp_path: Path) -> None:
+        db = self._make_library_db(
+            tmp_path,
+            [("Nilüfer Yanya", "PAINLESS")],
+        )
+        pairs = load_library_pairs(db)
+        assert pairs == {"painless": {"nilufer yanya"}}
+
+
+class TestFindMatchingReleaseIdsPairwise:
+    """Two-pass pair-wise scan: keep only release_ids whose (artist, title)
+    matches a library pair."""
+
+    def _write_csv(self, path: Path, header: list[str], rows: list[list[str]]) -> None:
+        with open(path, "w", encoding="utf-8", newline="") as f:
+            w = csv.writer(f)
+            w.writerow(header)
+            w.writerows(rows)
+
+    def test_exact_pair_match(self, tmp_path: Path) -> None:
+        release = tmp_path / "release.csv"
+        release_artist = tmp_path / "release_artist.csv"
+        self._write_csv(release, ["id", "title"], [["1001", "Confield"]])
+        self._write_csv(release_artist, ["release_id", "artist_name"], [["1001", "Autechre"]])
+        pairs = {"confield": {"autechre"}}
+        ids = find_matching_release_ids_pairwise(release, release_artist, pairs)
+        assert ids == {1001}
+
+    def test_title_in_library_but_artist_isnt_excluded(self, tmp_path: Path) -> None:
+        release = tmp_path / "release.csv"
+        release_artist = tmp_path / "release_artist.csv"
+        self._write_csv(release, ["id", "title"], [["1001", "Confield"]])
+        # release_artist has the right title-keyed candidate but artist is wrong
+        self._write_csv(
+            release_artist, ["release_id", "artist_name"], [["1001", "Some Other Band"]]
+        )
+        pairs = {"confield": {"autechre"}}
+        ids = find_matching_release_ids_pairwise(release, release_artist, pairs)
+        assert ids == set()
+
+    def test_title_not_in_library_excludes_release(self, tmp_path: Path) -> None:
+        release = tmp_path / "release.csv"
+        release_artist = tmp_path / "release_artist.csv"
+        self._write_csv(release, ["id", "title"], [["1001", "Some Other Album"]])
+        self._write_csv(release_artist, ["release_id", "artist_name"], [["1001", "Autechre"]])
+        pairs = {"confield": {"autechre"}}
+        ids = find_matching_release_ids_pairwise(release, release_artist, pairs)
+        assert ids == set()
+
+    def test_multi_artist_release_kept_when_one_matches(self, tmp_path: Path) -> None:
+        # A release with several featured artists is kept if ANY one of them
+        # forms a library pair with the release's title.
+        release = tmp_path / "release.csv"
+        release_artist = tmp_path / "release_artist.csv"
+        self._write_csv(release, ["id", "title"], [["9001", "From Here We Go Sublime"]])
+        self._write_csv(
+            release_artist,
+            ["release_id", "artist_name"],
+            [
+                ["9001", "Some Producer"],
+                ["9001", "Field, The"],
+            ],
+        )
+        pairs = {"from here we go sublime": {"field, the"}}
+        ids = find_matching_release_ids_pairwise(release, release_artist, pairs)
+        assert ids == {9001}
+
+    def test_diacritics_normalized_on_both_sides(self, tmp_path: Path) -> None:
+        release = tmp_path / "release.csv"
+        release_artist = tmp_path / "release_artist.csv"
+        self._write_csv(release, ["id", "title"], [["6001", "PAINLESS"]])
+        self._write_csv(release_artist, ["release_id", "artist_name"], [["6001", "Nilüfer Yanya"]])
+        # Library entries are pre-normalized by load_library_pairs, but we
+        # build the pairs-set the same way here to keep the test honest.
+        pairs = {"painless": {"nilufer yanya"}}
+        ids = find_matching_release_ids_pairwise(release, release_artist, pairs)
+        assert ids == {6001}
+
+    def test_handles_malformed_rows(self, tmp_path: Path) -> None:
+        # Defensive: short rows / non-numeric IDs should be skipped without
+        # taking the whole pass down.
+        release = tmp_path / "release.csv"
+        release_artist = tmp_path / "release_artist.csv"
+        self._write_csv(
+            release,
+            ["id", "title"],
+            [
+                ["not-an-int", "Confield"],
+                ["1001", "Confield"],
+            ],
+        )
+        self._write_csv(
+            release_artist,
+            ["release_id", "artist_name"],
+            [
+                ["1001", "Autechre"],
+                ["bad-row"],  # short row
+            ],
+        )
+        pairs = {"confield": {"autechre"}}
+        ids = find_matching_release_ids_pairwise(release, release_artist, pairs)
+        assert ids == {1001}
+
+
+class TestFilterCsvsByPairs:
+    """End-to-end orchestrator: library.db + CSV input dir → filtered CSVs."""
+
+    def test_filters_against_real_fixtures(self, tmp_path: Path) -> None:
+        # Reuses tests/fixtures/library.db + tests/fixtures/csv/. Combined,
+        # they contain six (artist, title) pairs that match the fixture
+        # release rows: (Autechre, Confield) covers 1001/1002/1003;
+        # (Autechre, Amber) → 3001; (Autechre, Tri Repetae) → 4001;
+        # (Stereolab, Aluminum Tunes) → 2001/2002; (Field, The, From Here
+        # We Go Sublime) → 9001; (Nilüfer Yanya, PAINLESS) → 6001 via
+        # diacritic normalization. Compound-artist release 9002 (Duke
+        # Ellington & John Coltrane) is a known false negative — the
+        # split artist rows don't match the combined library string.
+        out_dir = tmp_path / "filtered"
+        stats = filter_csvs_by_pairs(
+            FIXTURES_DIR / "library.db",
+            FIXTURES_DIR / "csv",
+            out_dir,
+        )
+
+        with open(out_dir / "release.csv") as f:
+            kept_ids = {int(row["id"]) for row in csv.DictReader(f)}
+
+        assert kept_ids == {1001, 1002, 1003, 2001, 2002, 3001, 4001, 6001, 9001}
+
+        # Sanity: the filtered CSV is a strict subset of the fixture, and
+        # release_artist.csv has been narrowed to the surviving release_ids.
+        with open(out_dir / "release_artist.csv") as f:
+            ra_release_ids = {int(row["release_id"]) for row in csv.DictReader(f)}
+        assert ra_release_ids <= kept_ids
+        assert ra_release_ids == kept_ids  # every survivor still has its artists
+
+        # Stats are populated for each file actually present in the input dir.
+        assert "release.csv" in stats
+        assert "release_artist.csv" in stats
+        in_count, out_count = stats["release.csv"]
+        assert out_count == len(kept_ids)
+        assert in_count > out_count  # some releases were dropped
+
+    def test_overwrites_input_when_input_and_output_dir_match(self, tmp_path: Path) -> None:
+        # Deployment pattern: rebuild-cache.yml runs the pair-wise filter
+        # in-place over the converter's output dir to keep runner disk small.
+        # Copy the fixture CSVs into a writable scratch dir first.
+        scratch = tmp_path / "scratch"
+        scratch.mkdir()
+        for src in (FIXTURES_DIR / "csv").iterdir():
+            if src.is_file():
+                (scratch / src.name).write_bytes(src.read_bytes())
+
+        filter_csvs_by_pairs(
+            FIXTURES_DIR / "library.db",
+            scratch,
+            scratch,
+        )
+
+        with open(scratch / "release.csv") as f:
+            kept_ids = {int(row["id"]) for row in csv.DictReader(f)}
+        # Same result as the separate-output case.
+        assert 1001 in kept_ids and 9002 not in kept_ids

--- a/tests/unit/test_run_pipeline.py
+++ b/tests/unit/test_run_pipeline.py
@@ -1078,3 +1078,83 @@ class TestParseArgsValidation:
                     "--generate-library-db",
                 ]
             )
+
+    def test_pair_filter_without_library_db_exits(self) -> None:
+        """--pair-filter needs a library source to derive (artist, title) pairs from."""
+        with pytest.raises(SystemExit):
+            run_pipeline.parse_args(["--csv-dir", "/tmp/csv", "--pair-filter"])
+
+    def test_pair_filter_with_direct_pg_exits(self) -> None:
+        """--pair-filter operates on the CSV staging that --direct-pg bypasses."""
+        with pytest.raises(SystemExit):
+            run_pipeline.parse_args(
+                [
+                    "--xml",
+                    "/tmp/dump.xml.gz",
+                    "--direct-pg",
+                    "--pair-filter",
+                    "--library-db",
+                    "/tmp/library.db",
+                ]
+            )
+
+    def test_pair_filter_with_library_db_accepted(self) -> None:
+        """--pair-filter + --library-db is the supported combination."""
+        args = run_pipeline.parse_args(
+            [
+                "--xml",
+                "/tmp/dump.xml.gz",
+                "--pair-filter",
+                "--library-db",
+                "/tmp/library.db",
+            ]
+        )
+        assert args.pair_filter is True
+        assert args.library_db == Path("/tmp/library.db")
+
+    def test_pair_filter_with_generate_library_db_accepted(self) -> None:
+        """--pair-filter + --generate-library-db (the rebuild-cache.yml shape)."""
+        args = run_pipeline.parse_args(
+            [
+                "--xml",
+                "/tmp/dump.xml.gz",
+                "--pair-filter",
+                "--generate-library-db",
+                "--catalog-source",
+                "tubafrenzy",
+                "--catalog-db-url",
+                "mysql://example/test",
+            ]
+        )
+        assert args.pair_filter is True
+        assert args.generate_library_db is True
+
+
+class TestPairFilterCsvs:
+    """The pair_filter_csvs helper invokes filter_csv.py with --library-db
+    and an in-place csv_dir."""
+
+    def test_invokes_filter_csv_in_place(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        recorded: dict[str, object] = {}
+
+        def fake_run_step(description: str, cmd: list[str], **kwargs) -> None:
+            recorded["description"] = description
+            recorded["cmd"] = cmd
+
+        monkeypatch.setattr(run_pipeline, "run_step", fake_run_step)
+
+        run_pipeline.pair_filter_csvs(
+            Path("/tmp/library.db"),
+            Path("/tmp/csv_out"),
+            "/usr/bin/python3",
+        )
+
+        cmd = recorded["cmd"]
+        assert cmd[0] == "/usr/bin/python3"
+        assert cmd[1].endswith("filter_csv.py")
+        assert "--library-db" in cmd
+        assert str(Path("/tmp/library.db")) in cmd
+        # Last two positional args are the input and output directories,
+        # which point at the same path so the rewrite is in-place.
+        assert cmd[-2] == str(Path("/tmp/csv_out"))
+        assert cmd[-1] == str(Path("/tmp/csv_out"))


### PR DESCRIPTION
Closes #128.

## Summary

Adds a second filter step between the converter's artist-only output and the import to PostgreSQL. Narrows from ~4M release rows / ~27M release_artist rows down to ~50K / ~250K, which fits inside a Railway-sized destination volume. Without this, the monthly rebuild fails at `COPY release_artist` with `psycopg.errors.DiskFull` — exactly what bit recovery on 2026-04-28.

This is **Approach A** from the issue body: stream-filter on the runner before COPY. No infrastructure changes.

## What lands

- **`scripts/filter_csv.py`** gains pair-wise mode alongside the existing artist-only one.
  - `normalize_title()` mirrors the shape of `normalize_artist()` so a Discogs title with diacritics matches a library title without them.
  - `load_library_pairs(library.db)` reads the SQLite library table and returns an inverted `{normalized_title: set of normalized_artists}` index.
  - `find_matching_release_ids_pairwise(release_csv, release_artist_csv, library_pairs)` does two passes — pass 1 builds `{release_id → normalized_title}` for only the title-intersected candidates, pass 2 walks `release_artist.csv` and checks the artist set keyed by that title. Memory bounded by the title intersection (~200K worst case on a 4M-release dump).
  - `filter_csvs_by_pairs(library_db, csv_in, csv_out)` orchestrates. When `csv_in == csv_out` (the workflow's in-place pattern) each filtered file is written to a sibling `.tmp` and atomically replaced so a partial failure leaves the input intact.
  - `main()` was rewritten on argparse with `--library-db` for pair-wise mode and `--library-artists` for the legacy artist-only path. The original 3-positional invocation is detected and rewritten so existing callers still work.

- **`scripts/run_pipeline.py`** gains `--pair-filter`, which shells out to `filter_csv.py --library-db` in-place over `csv_out` after the converter step. Validated up front: incompatible with `--direct-pg` (bypasses the CSV staging) and requires `--library-db` or `--generate-library-db`.

- **`.github/workflows/rebuild-cache.yml`** passes `--pair-filter`. No new secrets — the library.db is already generated inline via `--generate-library-db --catalog-source tubafrenzy`.

- **`CLAUDE.md`** documents the new step (3a in the pipeline order, with a known-false-negative note for compound-artist library entries like "Duke Ellington & John Coltrane" whose Discogs releases split into separate `release_artist` rows).

## Tests

- 14 new unit tests in `tests/unit/test_filter_csv.py`: `normalize_title`, `load_library_pairs` (diacritics + duplicate rows + multi-artist), `find_matching_release_ids_pairwise` (exact match / title-only or artist-only mismatch / multi-artist / diacritics / malformed rows), `filter_csvs_by_pairs` (real fixture end-to-end + in-place rewrite). The fixture-end-to-end test pins the 9-release expected output and explicitly notes the compound-artist false negative.
- 5 new unit tests in `tests/unit/test_run_pipeline.py`: `--pair-filter` parse_args validation and `pair_filter_csvs` command shape.
- Local run: 829 passed, 22 skipped against `pg or not slow`. ruff clean.

## Rollout

The 2026-05-04 06:00 UTC cron tick will be the first time this fires in production. To smoke-test before then, `gh workflow run rebuild-cache.yml` triggers a manual run. The pre-flight `Verify alembic baseline is stamped` step + `--pair-filter`'s parse_args validation both fail loudly before the multi-GB dump download if anything is misconfigured.

## Phase

D. Final child issue under post-incident hardening epic #131.