### PR TITLE
ci: drop git-clone wxyc-catalog step now that 0.1.0 is on PyPI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,12 +25,6 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-      # wxyc-catalog is not yet on PyPI (tracked in WXYC/wxyc-catalog#21).
-      # Install it from git first so the editable install below can resolve it.
-      - name: Install wxyc-catalog from git
-        run: |
-          git clone --depth 1 --branch main https://github.com/WXYC/wxyc-catalog.git /tmp/wxyc-catalog
-          cd /tmp/wxyc-catalog && sed -i 's|setuptools.backends._legacy:_Backend|setuptools.build_meta|' pyproject.toml && pip install -e .
       - run: pip install -e ".[dev]"
       - run: pytest tests/unit/ -v
 
@@ -55,12 +49,6 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-      # wxyc-catalog is not yet on PyPI (tracked in WXYC/wxyc-catalog#21).
-      # Install it from git first so the editable install below can resolve it.
-      - name: Install wxyc-catalog from git
-        run: |
-          git clone --depth 1 --branch main https://github.com/WXYC/wxyc-catalog.git /tmp/wxyc-catalog
-          cd /tmp/wxyc-catalog && sed -i 's|setuptools.backends._legacy:_Backend|setuptools.build_meta|' pyproject.toml && pip install -e .
       - run: pip install -e ".[dev]" pytest-cov
       - name: Enable pg_trgm extension
         run: |

--- a/.github/workflows/rebuild-cache.yml
+++ b/.github/workflows/rebuild-cache.yml
@@ -43,13 +43,6 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@stable
 
-      # wxyc-catalog is not yet on PyPI (tracked in WXYC/wxyc-catalog#21).
-      # Install it from git first so the editable install below can resolve it.
-      - name: Install wxyc-catalog from git
-        run: |
-          git clone --depth 1 --branch main https://github.com/WXYC/wxyc-catalog.git /tmp/wxyc-catalog
-          cd /tmp/wxyc-catalog && sed -i 's|setuptools.backends._legacy:_Backend|setuptools.build_meta|' pyproject.toml && pip install -e .
-
       - name: Install discogs-etl
         run: pip install -e ".[dev]"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dependencies = [
     "asyncpg>=0.29.0",
     "rapidfuzz>=3.0.0",
     "wxyc-etl>=0.1.0",
-    "wxyc-catalog>=0.1.0",
+    "wxyc-catalog[mysql]>=0.1.0",
     "sentry-sdk>=2.0",
 ]
 


### PR DESCRIPTION
Closes #134.

## Summary

`wxyc-catalog 0.1.0` shipped to PyPI on 2026-04-29 ([WXYC/wxyc-catalog#25](https://github.com/WXYC/wxyc-catalog/pull/25)). The `git clone https://github.com/WXYC/wxyc-catalog.git` step that's been sitting in three of our workflow jobs is now dead code — `wxyc-catalog>=0.1.0` is declared in `pyproject.toml`, so `pip install -e ".[dev]"` resolves it from PyPI.

Removed the step from:
- `ci.yml/test`
- `ci.yml/pg`
- `rebuild-cache.yml/rebuild`

## Latent issue caught

`wxyc_catalog/__init__.py` re-exports through `catalog_source` → `db`, which does an unconditional `import pymysql` at module top level. The old git-clone step ran `pip install -e .` (no extras), which didn't install pymysql — but discogs-etl's unit tests never `import wxyc_catalog` directly (only the entry-point CLIs `wxyc-export-to-sqlite` etc. trigger the chain at production runtime in `rebuild-cache.yml`). #128 was about the cron OOMing earlier in the pipeline so this latent ImportError never fired in practice.

This PR bumps the dep to `wxyc-catalog[mysql]>=0.1.0`, which pulls `pymysql>=1.0` along transitively and makes the import chain resolve. The proper fix is in `wxyc-catalog` itself (lazy-import pymysql inside `connect_mysql`); separate PR.

## Local verification

- `pip install -e ".[dev]"` in a fresh venv: resolves `wxyc-catalog 0.1.0` from PyPI (no git clone), pulls `pymysql 1.1.x` transitively.
- `python -c "import wxyc_catalog"` succeeds.
- Full suite: **829 passed, 22 skipped** against `pg or not slow` — same baseline as before this PR.
- `ruff check .` clean.

## Why now

The 2026-05-04 06:00 UTC cron tick will be the first end-to-end test of the new `--pair-filter` against Railway prod. Landing this cleanup before then keeps the rebuild workflow honest — no implicit dependency on whatever happens to be on `wxyc-catalog` `main` at clone time.