### PR TITLE
ci: propagate SENTRY_DSN through sync-library; drop stale TODO

### DIFF
--- a/.github/workflows/rebuild-cache.yml
+++ b/.github/workflows/rebuild-cache.yml
@@ -109,8 +109,9 @@ jobs:
         env:
           DATABASE_URL_DISCOGS: ${{ secrets.DATABASE_URL_DISCOGS }}
           DISCOGS_TOKEN: ${{ secrets.DISCOGS_TOKEN }}
-          # TODO: provision SENTRY_DSN as a separate operator task. Until then
-          # JSON logging still emits to stderr and Sentry stays inactive.
+          # When SENTRY_DSN is set as a repo secret, wxyc_etl.logger.init_logger
+          # hands exception events to the Sentry SDK. Unset → Sentry stays
+          # inactive, JSON logging still emits to stderr.
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
         run: |
           python scripts/run_pipeline.py \

--- a/.github/workflows/sync-library.yml
+++ b/.github/workflows/sync-library.yml
@@ -51,6 +51,11 @@ jobs:
           ADMIN_TOKEN: ${{ secrets.ADMIN_TOKEN }}
           STAGING_URL: ${{ secrets.STAGING_URL }}
           PRODUCTION_URL: ${{ secrets.PRODUCTION_URL }}
+          # Optional: when SENTRY_DSN is set, scripts/tsv_to_sqlite.py and the
+          # other Python entrypoints invoked by sync-library.sh hand exception
+          # events to Sentry via wxyc_etl.logger. Unset → Sentry stays inactive,
+          # JSON logging still emits to stderr.
+          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
 
       - name: Update library.db in LML release
         if: success()

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -264,7 +264,7 @@ When wired up, this installs a JSON formatter on the root logger and (when `SENT
 | `step` | per-event, supplied via `logger.info("...", extra={"step": "import"})` |
 | `run_id` | UUIDv4 generated at `init_logger` time (one per process) |
 
-`SENTRY_DSN` is read from the environment. When unset, JSON logging still works and Sentry stays inactive — there is no hard requirement on the DSN being configured. **TODO**: provision `SENTRY_DSN` in the GitHub Actions runtime env (sync-library workflow) and on EC2 / Railway as a separate child task.
+`SENTRY_DSN` is read from the environment. When unset, JSON logging still works and Sentry stays inactive — there is no hard requirement on the DSN being configured. Both the `rebuild-cache.yml` and `sync-library.yml` workflows propagate `secrets.SENTRY_DSN` into their pipeline-running steps, so adding the secret to the repo is enough to activate Sentry across both. EC2 / Railway runtime envs are separate operator tasks and not yet wired.
 
 Scripts that initialize the logger (subprocesses each get their own run_id, since they are independent processes): `run_pipeline.py`, `import_csv.py`, `dedup_releases.py`, `verify_cache.py`, `filter_csv.py`, `resolve_collisions.py`, `tsv_to_sqlite.py`. The shim itself lives in `lib/observability.py`.
 


### PR DESCRIPTION
## Summary

`rebuild-cache.yml` already had `SENTRY_DSN: \${{ secrets.SENTRY_DSN }}` wired into the "Run pipeline" step but with a stale TODO comment claiming it wasn't provisioned. The wiring is correct — the missing piece is the operator-side `SENTRY_DSN` repo secret. `sync-library.yml` was missing the propagation entirely. CLAUDE.md's Observability section had a TODO note that read like both workflows were unwired.

This PR:
- adds `SENTRY_DSN: \${{ secrets.SENTRY_DSN }}` to `sync-library.yml`'s "Run library sync" step (same shape as rebuild-cache.yml)
- drops the stale TODO from rebuild-cache.yml
- updates CLAUDE.md to match reality

When `SENTRY_DSN` is unset (today's state), `wxyc_etl.logger` runs with Sentry disabled and JSON logging still emits to stderr — same fall-back the workflows already had.

## Operator action required to actually activate Sentry

```sh
gh secret set SENTRY_DSN --repo WXYC/discogs-etl
# paste the DSN from the Sentry project's settings → client keys
```

EC2 / Railway runtime envs are separate operator tasks; not part of this PR.

## Why now

The 2026-05-04 cron tick is the first end-to-end test of `--pair-filter` against Railway prod. Without Sentry, a failure looks like a chunk of GH Actions stderr; with it, the same failure surfaces as a structured trace.

## Bigger finding (separate from this PR)

While checking, noticed that `DATABASE_URL_DISCOGS`, `LIBRARY_CATALOG_DB_URL`, and `DISCOGS_TOKEN` are also missing as repo secrets. These are required for the rebuild-cache.yml cron to run at all — the cron will fail at the first secret-using step on 5/4 unless they're added. Tracking as operator action separate from the code-side wiring in this PR.