### PR TITLE
ci: cache-drift watchdog + Slack failure alert for rebuild-cache

### DIFF
--- a/.github/workflows/rebuild-cache.yml
+++ b/.github/workflows/rebuild-cache.yml
@@ -120,3 +120,48 @@ jobs:
             --catalog-source tubafrenzy \
             --catalog-db-url "${{ secrets.LIBRARY_CATALOG_DB_URL }}" \
             --pair-filter
+
+      # Watchdog: cache_distinct_artists / library_distinct_artists ratio
+      # exposes drift between the just-rebuilt cache and the WXYC library
+      # catalog. A ratio below --min-ratio fails this step (and the workflow),
+      # firing the Slack alert below as a separate signal from "the rebuild
+      # itself crashed". Issue #125, third acceptance criterion.
+      #
+      # The pipeline above generates library.db inside a tempdir that we
+      # don't have a handle to here, so we re-export it in this step using
+      # the same wxyc-catalog CLI. The export is cheap relative to the
+      # pipeline (≈seconds vs hours).
+      - name: Check cache drift vs. library
+        if: success()
+        env:
+          DATABASE_URL_DISCOGS: ${{ secrets.DATABASE_URL_DISCOGS }}
+          SLACK_MONITORING_WEBHOOK: ${{ secrets.SLACK_MONITORING_WEBHOOK }}
+          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+        run: |
+          set -euo pipefail
+          wxyc-export-to-sqlite \
+            --catalog-source tubafrenzy \
+            --catalog-db-url "${{ secrets.LIBRARY_CATALOG_DB_URL }}" \
+            --output /tmp/library-watchdog.db
+          python scripts/check_cache_drift.py \
+            --library-db /tmp/library-watchdog.db \
+            --min-ratio 0.7
+
+      # Slack alert on any failure in this workflow (rebuild or watchdog).
+      # Mirrors the --notify pattern in scripts/sync-library.sh; posts only
+      # when SLACK_MONITORING_WEBHOOK is set as a repo secret. Issue #125,
+      # second acceptance criterion.
+      - name: Notify Slack on failure
+        if: failure()
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_MONITORING_WEBHOOK }}
+          RUN_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+        run: |
+          if [ -z "${SLACK_WEBHOOK_URL:-}" ]; then
+            echo "SLACK_MONITORING_WEBHOOK unset; skipping Slack post."
+            exit 0
+          fi
+          curl -s -X POST "$SLACK_WEBHOOK_URL" \
+            -H "Content-Type: application/json" \
+            -d "{\"text\":\":warning: *Discogs cache rebuild failed*\nRun: $RUN_URL\"}" \
+            || true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,6 +128,7 @@ docker compose up db -d     # just the database (for tests)
 - `lib/format_normalization.py` -- Normalize raw Discogs/library format strings to broad categories (Vinyl, CD, Cassette, 7", Digital)
 - `scripts/sync-library.sh` -- Daily library sync orchestrator: MySQL query (via MariaDB `mysql` CLI for MySQL 4.1 compat) → `tsv_to_sqlite.py` → streaming links enrichment → upload to LML. Automated by `.github/workflows/sync-library.yml` (daily at noon UTC).
 - `scripts/tsv_to_sqlite.py` -- Converts MySQL TSV output to SQLite with FTS5 index. Called by sync-library.sh.
+- `scripts/check_cache_drift.py` -- Drift watchdog: compares `COUNT(DISTINCT artist) FROM library` (sqlite) to `COUNT(DISTINCT artist_name) FROM release_artist` (cache). Exits non-zero (and posts to `SLACK_MONITORING_WEBHOOK` when set) if the ratio falls below `--min-ratio` (default 0.7). Run as the final step of `rebuild-cache.yml` so coverage regressions surface as workflow failures.
 - `docs/discogs-etl-technical-overview.md` -- Design rationale, benchmarks, and pipeline architecture details
 
 ### Shared Package Dependencies
@@ -206,6 +207,8 @@ The job downloads `releases.xml.gz` for the current month from `discogs-data-dum
 
 The workflow runs `--pair-filter` so the import payload to `DATABASE_URL_DISCOGS` is ~50K release rows instead of the converter's ~4M, which is what makes a Railway-sized destination DB feasible (the unfiltered import overflows the volume at `COPY release_artist`; see #128).
 
+After the pipeline succeeds, the workflow runs `scripts/check_cache_drift.py` against the just-rebuilt cache. It compares `COUNT(DISTINCT artist) FROM library` (sqlite) to `COUNT(DISTINCT artist_name) FROM release_artist` (cache); if the ratio falls below `0.7`, the step exits non-zero, the workflow's `failure()` Slack notifier fires, and the watchdog itself posts a more specific drift message via `SLACK_MONITORING_WEBHOOK`. This is the third acceptance criterion of [#125](https://github.com/WXYC/discogs-etl/issues/125): drift between rebuilds must be visible without a human looking. A pipeline-level failure (the rebuild itself crashing) also fires the same Slack notifier through the workflow's final `if: failure()` step, mirroring the `--notify` pattern in `scripts/sync-library.sh`.
+
 **Caveat — runner capacity**: the Discogs releases dump is ~63 GB compressed XML and the conversion + Postgres bulk load can exceed the GitHub Actions free hosted runner's ~14 GB disk and 6-hour wall-clock budget. The workflow file is the deliverable; provisioning a self-hosted or larger hosted runner is a follow-up operator task. Until then, expect the scheduled tick to fail loudly rather than silently produce a half-built cache.
 
 **Required GitHub secrets:**
@@ -213,9 +216,10 @@ The workflow runs `--pair-filter` so the import payload to `DATABASE_URL_DISCOGS
 | Secret | Description |
 |--------|-------------|
 | `DATABASE_URL_DISCOGS` | PostgreSQL URL for the destination cache database |
-| `LIBRARY_CATALOG_DB_URL` | MySQL URL for the tubafrenzy catalog (used by `--generate-library-db`) |
+| `LIBRARY_CATALOG_DB_URL` | MySQL URL for the tubafrenzy catalog (used by `--generate-library-db` and the watchdog's library.db re-export) |
 | `DISCOGS_TOKEN` | Discogs API token (optional; only matters if rate limits are hit) |
 | `SENTRY_DSN` | Sentry DSN for error reporting (optional; JSON logging still works without it) |
+| `SLACK_MONITORING_WEBHOOK` | Slack incoming webhook for failure + drift alerts (optional; without it failures still fail the workflow but only Sentry sees them) |
 
 ### Library Sync (`sync-library.yml`)
 
@@ -266,7 +270,7 @@ When wired up, this installs a JSON formatter on the root logger and (when `SENT
 
 `SENTRY_DSN` is read from the environment. When unset, JSON logging still works and Sentry stays inactive — there is no hard requirement on the DSN being configured. Both the `rebuild-cache.yml` and `sync-library.yml` workflows propagate `secrets.SENTRY_DSN` into their pipeline-running steps, so adding the secret to the repo is enough to activate Sentry across both. EC2 / Railway runtime envs are separate operator tasks and not yet wired.
 
-Scripts that initialize the logger (subprocesses each get their own run_id, since they are independent processes): `run_pipeline.py`, `import_csv.py`, `dedup_releases.py`, `verify_cache.py`, `filter_csv.py`, `resolve_collisions.py`, `tsv_to_sqlite.py`. The shim itself lives in `lib/observability.py`.
+Scripts that initialize the logger (subprocesses each get their own run_id, since they are independent processes): `run_pipeline.py`, `import_csv.py`, `dedup_releases.py`, `verify_cache.py`, `filter_csv.py`, `resolve_collisions.py`, `tsv_to_sqlite.py`, `check_cache_drift.py`. The shim itself lives in `lib/observability.py`.
 
 ## Development Practices
 

--- a/scripts/check_cache_drift.py
+++ b/scripts/check_cache_drift.py
@@ -1,0 +1,250 @@
+"""Watchdog: alert when the discogs-cache has drifted from the WXYC library.
+
+The discogs-cache (Postgres) is rebuilt from a Discogs XML dump on a monthly
+cadence (``rebuild-cache.yml``). Between rebuilds, new artists added to the
+WXYC library catalog have no Discogs metadata in the cache. This script
+quantifies that drift by comparing two distinct-artist counts:
+
+* ``library`` -- ``SELECT COUNT(DISTINCT artist) FROM library`` against
+  the SQLite library.db produced by ``scripts/sync-library.sh``.
+* ``cache``   -- ``SELECT COUNT(DISTINCT artist_name) FROM release_artist``
+  against the Postgres discogs-cache.
+
+If the ratio ``cache / library`` falls below ``--min-ratio`` (default
+``0.7``), the script emits a structured warning, optionally posts a Slack
+notification (when ``--slack-webhook`` is provided), and exits non-zero so
+the calling CI workflow surfaces the drift as a job failure.
+
+Usage::
+
+    python scripts/check_cache_drift.py \\
+        --library-db /tmp/library.db \\
+        --database-url $DATABASE_URL_DISCOGS \\
+        --min-ratio 0.7 \\
+        --slack-webhook "$SLACK_MONITORING_WEBHOOK"
+
+The pure decision logic (``count_library_artists``, ``evaluate_drift``,
+``post_slack_alert``, ``run``) is unit-tested in
+``tests/unit/test_check_cache_drift.py``. The Postgres path
+(``count_cache_artists``) is exercised end-to-end inside the rebuild
+workflow itself.
+
+The watchdog covers issue WXYC/discogs-etl#125's third acceptance criterion:
+"a watchdog query exposes drift between rebuilds and fires a separate alert
+when the ratio drops below a threshold."
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import sqlite3
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from urllib.request import Request, urlopen
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+from lib.observability import init_logger  # noqa: E402
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_MIN_RATIO = 0.7
+
+
+@dataclass(frozen=True)
+class DriftResult:
+    """Outcome of a drift comparison.
+
+    Attributes:
+        ok: True when coverage meets or exceeds ``min_ratio``.
+        ratio: ``cache_count / library_count``, or ``None`` when undefined
+            (e.g. ``library_count == 0``).
+        reason: Short human-readable explanation; populated when ``ok`` is
+            False, empty string otherwise.
+    """
+
+    ok: bool
+    ratio: float | None
+    reason: str = ""
+
+
+def count_library_artists(library_db_path: str) -> int:
+    """Return the count of distinct artists in the SQLite library.db."""
+    conn = sqlite3.connect(library_db_path)
+    try:
+        cur = conn.cursor()
+        cur.execute("SELECT COUNT(DISTINCT artist) FROM library")
+        row = cur.fetchone()
+        return int(row[0]) if row and row[0] is not None else 0
+    finally:
+        conn.close()
+
+
+def count_cache_artists(database_url: str) -> int:
+    """Return the count of distinct artist_name values in release_artist.
+
+    Imported lazily so unit tests that patch this function never need to
+    import psycopg.
+    """
+    import psycopg  # local import: keeps the test module psycopg-free
+
+    with psycopg.connect(database_url) as conn:
+        with conn.cursor() as cur:
+            cur.execute("SELECT COUNT(DISTINCT artist_name) FROM release_artist")
+            row = cur.fetchone()
+            return int(row[0]) if row and row[0] is not None else 0
+
+
+def evaluate_drift(*, library_count: int, cache_count: int, min_ratio: float) -> DriftResult:
+    """Decide whether the cache covers enough of the library.
+
+    Args:
+        library_count: distinct artists in the WXYC library catalog.
+        cache_count: distinct artist_name rows in the discogs-cache.
+        min_ratio: the minimum acceptable ``cache_count / library_count``.
+
+    Returns:
+        A ``DriftResult``. ``ok`` is True when the ratio is defined and
+        at or above ``min_ratio``.
+    """
+    if library_count <= 0:
+        return DriftResult(
+            ok=False,
+            ratio=None,
+            reason="library count is 0; cannot compute drift ratio.",
+        )
+    ratio = cache_count / library_count
+    if ratio < min_ratio:
+        return DriftResult(
+            ok=False,
+            ratio=ratio,
+            reason=(
+                f"cache/library coverage ratio {ratio:.3f} is below threshold"
+                f" {min_ratio:.3f} (cache={cache_count}, library={library_count})."
+            ),
+        )
+    return DriftResult(ok=True, ratio=ratio, reason="")
+
+
+def post_slack_alert(*, webhook_url: str | None, message: str) -> bool:
+    """Best-effort Slack notification.
+
+    Returns True when a request was made and accepted, False on no-op
+    (no webhook configured) or on transport error. Never raises.
+    """
+    if not webhook_url:
+        return False
+    payload = json.dumps({"text": f":warning: *Discogs cache drift*\n{message}"}).encode("utf-8")
+    req = Request(
+        webhook_url,
+        data=payload,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with urlopen(req, timeout=10):
+            return True
+    except Exception as exc:  # pragma: no cover - logged for operators
+        logger.warning("slack notify failed: %s", exc, extra={"step": "drift_check"})
+        return False
+
+
+def run(
+    *,
+    library_db: str,
+    database_url: str,
+    min_ratio: float,
+    slack_webhook: str | None,
+) -> int:
+    """Compute drift and return a process exit code.
+
+    Returns 0 when coverage is healthy, 1 when drift is detected (or the
+    library count is unusable). Slack is notified only on the unhealthy
+    branch.
+    """
+    library_count = count_library_artists(library_db)
+    cache_count = count_cache_artists(database_url)
+    logger.info(
+        "drift counts: library=%d cache=%d",
+        library_count,
+        cache_count,
+        extra={"step": "drift_check"},
+    )
+    result = evaluate_drift(
+        library_count=library_count, cache_count=cache_count, min_ratio=min_ratio
+    )
+    if result.ok:
+        logger.info(
+            "cache coverage healthy (ratio=%.3f >= %.3f)",
+            result.ratio if result.ratio is not None else float("nan"),
+            min_ratio,
+            extra={"step": "drift_check"},
+        )
+        return 0
+
+    logger.warning(result.reason, extra={"step": "drift_check"})
+    post_slack_alert(webhook_url=slack_webhook, message=result.reason)
+    return 1
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n\n", 1)[0])
+    parser.add_argument(
+        "--library-db",
+        required=True,
+        help="Path to the SQLite library.db produced by sync-library.sh.",
+    )
+    parser.add_argument(
+        "--database-url",
+        default=None,
+        help=(
+            "PostgreSQL URL for the discogs-cache. Falls back to "
+            "DATABASE_URL_DISCOGS, then DATABASE_URL."
+        ),
+    )
+    parser.add_argument(
+        "--min-ratio",
+        type=float,
+        default=DEFAULT_MIN_RATIO,
+        help=(f"Minimum acceptable cache/library coverage ratio. Default: {DEFAULT_MIN_RATIO}."),
+    )
+    parser.add_argument(
+        "--slack-webhook",
+        default=None,
+        help=(
+            "Slack incoming webhook URL. If unset, falls back to "
+            "SLACK_MONITORING_WEBHOOK env. When neither is set, drift is "
+            "logged but not posted."
+        ),
+    )
+    args = parser.parse_args(argv)
+
+    init_logger(repo="discogs-etl", tool="discogs-etl check_cache_drift")
+
+    database_url = (
+        args.database_url
+        or os.environ.get("DATABASE_URL_DISCOGS")
+        or os.environ.get("DATABASE_URL")
+    )
+    if not database_url:
+        print(
+            "error: --database-url not provided and DATABASE_URL_DISCOGS/DATABASE_URL not set.",
+            file=sys.stderr,
+        )
+        return 2
+
+    slack_webhook = args.slack_webhook or os.environ.get("SLACK_MONITORING_WEBHOOK")
+
+    return run(
+        library_db=args.library_db,
+        database_url=database_url,
+        min_ratio=args.min_ratio,
+        slack_webhook=slack_webhook,
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/test_check_cache_drift.py
+++ b/tests/unit/test_check_cache_drift.py
@@ -1,0 +1,251 @@
+"""Unit tests for ``scripts/check_cache_drift.py``.
+
+The drift watchdog compares the count of distinct artists in the WXYC
+library catalog (sqlite ``library.db``) to the count of distinct artists
+in the discogs-cache (Postgres ``release_artist``). When the ratio of
+covered artists drops below a configurable threshold, the script logs a
+warning, optionally posts a Slack notification, and exits non-zero so
+the calling CI workflow fires its failure alert.
+
+These tests cover the pure logic only: counting distinct artists from a
+sqlite library.db, computing the ratio, and the decision function. The
+Postgres path is exercised in the ``pg``-marked integration tests and
+end-to-end inside the ``rebuild-cache.yml`` workflow.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sqlite3
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "check_cache_drift.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("check_cache_drift", SCRIPT_PATH)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["check_cache_drift"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _make_library_db(path: Path, artists: list[str]) -> None:
+    conn = sqlite3.connect(path)
+    cur = conn.cursor()
+    cur.execute(
+        "CREATE TABLE library (id INTEGER PRIMARY KEY, title TEXT, artist TEXT, format TEXT)"
+    )
+    for i, artist in enumerate(artists, start=1):
+        cur.execute(
+            "INSERT INTO library (id, title, artist, format) VALUES (?, ?, ?, ?)",
+            (i, f"title-{i}", artist, "LP"),
+        )
+    conn.commit()
+    conn.close()
+
+
+class TestCountLibraryArtists:
+    def test_returns_distinct_artist_count(self, tmp_path: Path) -> None:
+        db = tmp_path / "library.db"
+        _make_library_db(
+            db,
+            [
+                "Juana Molina",
+                "Stereolab",
+                "Cat Power",
+                "Stereolab",  # duplicate
+                "Jessica Pratt",
+            ],
+        )
+        mod = _load_module()
+        assert mod.count_library_artists(str(db)) == 4
+
+    def test_empty_library_returns_zero(self, tmp_path: Path) -> None:
+        db = tmp_path / "library.db"
+        _make_library_db(db, [])
+        mod = _load_module()
+        assert mod.count_library_artists(str(db)) == 0
+
+
+class TestEvaluateDrift:
+    """Pure decision function: given the two counts and a threshold, classify."""
+
+    def test_zero_library_count_is_an_error(self) -> None:
+        mod = _load_module()
+        result = mod.evaluate_drift(library_count=0, cache_count=100, min_ratio=0.7)
+        assert result.ok is False
+        assert result.ratio is None
+        assert "library count is 0" in result.reason.lower()
+
+    def test_ratio_at_or_above_threshold_is_ok(self) -> None:
+        mod = _load_module()
+        result = mod.evaluate_drift(library_count=1000, cache_count=800, min_ratio=0.7)
+        assert result.ok is True
+        assert result.ratio == pytest.approx(0.8)
+
+    def test_ratio_below_threshold_is_drift(self) -> None:
+        mod = _load_module()
+        result = mod.evaluate_drift(library_count=1000, cache_count=500, min_ratio=0.7)
+        assert result.ok is False
+        assert result.ratio == pytest.approx(0.5)
+        assert "below threshold" in result.reason.lower()
+
+    def test_threshold_boundary_is_inclusive(self) -> None:
+        """ratio == min_ratio passes (>=, not >)."""
+        mod = _load_module()
+        result = mod.evaluate_drift(library_count=1000, cache_count=700, min_ratio=0.7)
+        assert result.ok is True
+
+    def test_cache_larger_than_library_is_ok(self) -> None:
+        """Cache covers more artists than library is fine -- ratio caps semantically."""
+        mod = _load_module()
+        result = mod.evaluate_drift(library_count=100, cache_count=500, min_ratio=0.7)
+        assert result.ok is True
+        assert result.ratio == pytest.approx(5.0)
+
+
+class TestPostSlackAlert:
+    """Slack webhook notification is best-effort and never raises."""
+
+    def test_no_webhook_is_a_noop(self) -> None:
+        mod = _load_module()
+        # Should return False (no post attempted) without raising.
+        assert mod.post_slack_alert(webhook_url=None, message="hi") is False
+        assert mod.post_slack_alert(webhook_url="", message="hi") is False
+
+    def test_webhook_post_serializes_text_field(self) -> None:
+        mod = _load_module()
+        captured: dict = {}
+
+        def fake_urlopen(req, timeout=None):  # noqa: ARG001
+            captured["url"] = req.full_url
+            captured["data"] = req.data
+            captured["headers"] = dict(req.headers)
+
+            class _Resp:
+                def __enter__(self):
+                    return self
+
+                def __exit__(self, *exc):
+                    return False
+
+                def read(self):
+                    return b""
+
+            return _Resp()
+
+        with patch.object(mod, "urlopen", fake_urlopen):
+            ok = mod.post_slack_alert(
+                webhook_url="https://hooks.slack.com/services/XXX",
+                message="drift detected: ratio=0.42 < 0.7",
+            )
+
+        assert ok is True
+        assert captured["url"] == "https://hooks.slack.com/services/XXX"
+        payload = json.loads(captured["data"].decode("utf-8"))
+        assert "drift detected" in payload["text"]
+
+    def test_webhook_post_failure_is_swallowed(self) -> None:
+        mod = _load_module()
+
+        def fake_urlopen(req, timeout=None):  # noqa: ARG001
+            raise OSError("network down")
+
+        with patch.object(mod, "urlopen", fake_urlopen):
+            ok = mod.post_slack_alert(
+                webhook_url="https://hooks.slack.com/services/XXX",
+                message="hi",
+            )
+        assert ok is False
+
+
+class TestRunWatchdogCli:
+    """CLI integration: build args, invoke run, check exit code."""
+
+    def test_run_returns_zero_when_ratio_meets_threshold(self, tmp_path: Path) -> None:
+        mod = _load_module()
+        db = tmp_path / "library.db"
+        _make_library_db(db, ["A", "B", "C", "D"])  # 4 distinct
+
+        # Stub the PG count so we don't need a live database.
+        with patch.object(mod, "count_cache_artists", return_value=4):
+            exit_code = mod.run(
+                library_db=str(db),
+                database_url="postgresql://stub",
+                min_ratio=0.5,
+                slack_webhook=None,
+            )
+        assert exit_code == 0
+
+    def test_run_returns_nonzero_when_drift_exceeds_threshold(self, tmp_path: Path) -> None:
+        mod = _load_module()
+        db = tmp_path / "library.db"
+        _make_library_db(db, ["A", "B", "C", "D"])  # 4 distinct
+
+        with patch.object(mod, "count_cache_artists", return_value=1):
+            exit_code = mod.run(
+                library_db=str(db),
+                database_url="postgresql://stub",
+                min_ratio=0.5,
+                slack_webhook=None,
+            )
+        assert exit_code != 0
+
+    def test_run_posts_slack_when_drifting_and_webhook_set(self, tmp_path: Path) -> None:
+        mod = _load_module()
+        db = tmp_path / "library.db"
+        _make_library_db(db, ["A", "B", "C", "D"])
+
+        posted: list[str] = []
+
+        def fake_post(webhook_url, message):
+            posted.append(message)
+            return True
+
+        with (
+            patch.object(mod, "count_cache_artists", return_value=1),
+            patch.object(mod, "post_slack_alert", side_effect=fake_post),
+        ):
+            exit_code = mod.run(
+                library_db=str(db),
+                database_url="postgresql://stub",
+                min_ratio=0.5,
+                slack_webhook="https://hooks.slack.com/services/XXX",
+            )
+
+        assert exit_code != 0
+        assert len(posted) == 1
+        assert "drift" in posted[0].lower() or "below" in posted[0].lower()
+
+    def test_run_does_not_post_slack_when_healthy(self, tmp_path: Path) -> None:
+        mod = _load_module()
+        db = tmp_path / "library.db"
+        _make_library_db(db, ["A", "B"])
+
+        called = {"n": 0}
+
+        def fake_post(webhook_url, message):
+            called["n"] += 1
+            return True
+
+        with (
+            patch.object(mod, "count_cache_artists", return_value=10),
+            patch.object(mod, "post_slack_alert", side_effect=fake_post),
+        ):
+            exit_code = mod.run(
+                library_db=str(db),
+                database_url="postgresql://stub",
+                min_ratio=0.5,
+                slack_webhook="https://hooks.slack.com/services/XXX",
+            )
+
+        assert exit_code == 0
+        assert called["n"] == 0

--- a/tests/unit/test_logger_init.py
+++ b/tests/unit/test_logger_init.py
@@ -101,6 +101,7 @@ def test_init_logger_emits_json_with_repo_tag(capfd, monkeypatch):
         "filter_csv.py",
         "resolve_collisions.py",
         "tsv_to_sqlite.py",
+        "check_cache_drift.py",
     ],
 )
 def test_script_compiles(script):


### PR DESCRIPTION
## Summary

Closes the remaining two acceptance criteria of #125 (the first -- a fixed monthly schedule -- shipped earlier in 9e003de):

- Adds `scripts/check_cache_drift.py`, a watchdog that compares `COUNT(DISTINCT artist) FROM library` (sqlite library.db) to `COUNT(DISTINCT artist_name) FROM release_artist` (Postgres cache) and exits non-zero (with an optional Slack post) when the ratio falls below `--min-ratio` (default 0.7).
- `rebuild-cache.yml` now runs the watchdog as a post-pipeline step (using a freshly re-exported library.db so the cache and the catalog are compared at the same moment), and posts a generic failure alert to `SLACK_MONITORING_WEBHOOK` on any step's failure -- the same `--notify` pattern already used in `scripts/sync-library.sh`.
- `CLAUDE.md` documents the new script, the watchdog/alert wiring inside `rebuild-cache.yml`, and the `SLACK_MONITORING_WEBHOOK` secret.

This change adds no new runtime dependencies (sqlite3 and urllib are stdlib; psycopg is already a project dependency).

## Test plan

- [x] 14 new unit tests in tests/unit/test_check_cache_drift.py cover count_library_artists, evaluate_drift (zero-library guard, threshold-inclusive boundary, drift-detected, cache-larger-than-library), post_slack_alert (no-op, payload shape, error-swallowing), and the run() integration (with count_cache_artists patched).
- [x] check_cache_drift.py added to the parametrized compile-smoke list in tests/unit/test_logger_init.py.
- [x] ruff check . and ruff format --check . clean.
- [x] YAML workflow parses.
- [ ] First scheduled tick on the 4th of next month is the production smoke test; until a beefier runner is provisioned, expect the rebuild itself to fail loudly (existing caveat in CLAUDE.md), at which point the new Slack alert path is what surfaces it.

## Related

- Issue #125 (this PR closes it).
- 9e003de -- prior commit that introduced rebuild-cache.yml and covered the first acceptance criterion.
- #128 -- pair-filter mitigation for Railway-sized destination DBs (already merged).
- LML PR #203 -- matching-symmetry fix that motivated the urgency on cache-staleness.

Closes #125