### PR TITLE
ci(rebuild-cache): use sync-library's library.db artifact

### DIFF
--- a/.github/workflows/rebuild-cache.yml
+++ b/.github/workflows/rebuild-cache.yml
@@ -11,6 +11,14 @@ name: Rebuild Discogs Cache
 # this, the import overflows small destination DBs (Railway-sized) at
 # `COPY release_artist` — see #128.
 #
+# Library catalog: this workflow consumes the `library.db` produced daily by
+# `sync-library.yml` (uploaded as an asset on the `streaming-data-v1` release
+# in WXYC/library-metadata-lookup). Earlier iterations called
+# `--generate-library-db --catalog-source tubafrenzy` here, but Kattare's
+# MySQL is not directly internet-reachable — the daily sync workflow tunnels
+# in over SSH. Reusing its output asset keeps that connectivity story in one
+# place and avoids duplicating SSH credentials across workflows.
+#
 # TODO: the Discogs releases dump is ~63 GB compressed XML; expanding +
 # converting it can exceed the GitHub Actions free-runner disk (~14 GB) and
 # 6-hour wall-clock budget. The skeleton here lets operators kick the rebuild
@@ -100,6 +108,29 @@ jobs:
             echo "url=https://discogs-data-dumps.s3.us-west-2.amazonaws.com/data/${year}/discogs_${stamp}_releases.xml.gz" >> "$GITHUB_OUTPUT"
           fi
 
+      # Pull the daily-fresh library.db from sync-library.yml's release artifact
+      # rather than regenerating it here from MySQL. Kattare's MySQL is reachable
+      # only through an SSH tunnel; sync-library.yml owns that tunnel + handles
+      # MySQL 4.1 quirks via the MariaDB CLI. By the time this monthly cron tick
+      # fires (06:00 UTC on the 4th), the previous day's sync upload (12:00 UTC
+      # on the 3rd) is the freshest available snapshot.
+      #
+      # `gh release download --pattern` filters to the single asset we need, so
+      # we don't pull the much-larger streaming_availability.db that ships in
+      # the same release. ${{ github.token }} has read scope on public repos
+      # (LML is public); the upstream upload step uses LML_RELEASE_TOKEN.
+      - name: Download library.db from LML release artifact
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          mkdir -p data
+          gh release download streaming-data-v1 \
+            --repo WXYC/library-metadata-lookup \
+            --pattern library.db \
+            --output data/library.db
+          echo "library.db size: $(du -h data/library.db | cut -f1)"
+
       - name: Download Discogs releases dump
         run: |
           mkdir -p data
@@ -116,9 +147,7 @@ jobs:
         run: |
           python scripts/run_pipeline.py \
             --xml data/releases.xml.gz \
-            --generate-library-db \
-            --catalog-source tubafrenzy \
-            --catalog-db-url "${{ secrets.LIBRARY_CATALOG_DB_URL }}" \
+            --library-db data/library.db \
             --pair-filter
 
       # Watchdog: cache_distinct_artists / library_distinct_artists ratio
@@ -127,10 +156,9 @@ jobs:
       # firing the Slack alert below as a separate signal from "the rebuild
       # itself crashed". Issue #125, third acceptance criterion.
       #
-      # The pipeline above generates library.db inside a tempdir that we
-      # don't have a handle to here, so we re-export it in this step using
-      # the same wxyc-catalog CLI. The export is cheap relative to the
-      # pipeline (≈seconds vs hours).
+      # Reuses data/library.db that the earlier "Download library.db from LML
+      # release artifact" step already pulled — same snapshot the pipeline
+      # filtered against, so the drift comparison is apples-to-apples.
       - name: Check cache drift vs. library
         if: success()
         env:
@@ -139,12 +167,8 @@ jobs:
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
         run: |
           set -euo pipefail
-          wxyc-export-to-sqlite \
-            --catalog-source tubafrenzy \
-            --catalog-db-url "${{ secrets.LIBRARY_CATALOG_DB_URL }}" \
-            --output /tmp/library-watchdog.db
           python scripts/check_cache_drift.py \
-            --library-db /tmp/library-watchdog.db \
+            --library-db data/library.db \
             --min-ratio 0.7
 
       # Slack alert on any failure in this workflow (rebuild or watchdog).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -203,11 +203,13 @@ This pipeline runs monthly (or when Discogs publishes new data dumps). It has a 
 
 A GitHub Actions cron workflow runs `scripts/run_pipeline.py --xml ...` on the 4th of each month at 06:00 UTC, staggered a few days after Discogs publishes the new dump. It can also be triggered manually with an optional `dump_url` input: `gh workflow run rebuild-cache.yml`.
 
-The job downloads `releases.xml.gz` for the current month from `discogs-data-dumps.s3.us-west-2.amazonaws.com`, builds `discogs-xml-converter` from source, and runs the full XML-mode pipeline (steps 2-10) against `DATABASE_URL_DISCOGS`. Library catalog is generated inline via `--generate-library-db --catalog-source tubafrenzy`.
+The job downloads `releases.xml.gz` for the current month from `discogs-data-dumps.s3.us-west-2.amazonaws.com`, downloads the daily-fresh `library.db` from `WXYC/library-metadata-lookup`'s `streaming-data-v1` release (produced by `sync-library.yml`), builds `discogs-xml-converter` from source, and runs the full XML-mode pipeline (steps 2-10) against `DATABASE_URL_DISCOGS`.
 
 The workflow runs `--pair-filter` so the import payload to `DATABASE_URL_DISCOGS` is ~50K release rows instead of the converter's ~4M, which is what makes a Railway-sized destination DB feasible (the unfiltered import overflows the volume at `COPY release_artist`; see #128).
 
 After the pipeline succeeds, the workflow runs `scripts/check_cache_drift.py` against the just-rebuilt cache. It compares `COUNT(DISTINCT artist) FROM library` (sqlite) to `COUNT(DISTINCT artist_name) FROM release_artist` (cache); if the ratio falls below `0.7`, the step exits non-zero, the workflow's `failure()` Slack notifier fires, and the watchdog itself posts a more specific drift message via `SLACK_MONITORING_WEBHOOK`. This is the third acceptance criterion of [#125](https://github.com/WXYC/discogs-etl/issues/125): drift between rebuilds must be visible without a human looking. A pipeline-level failure (the rebuild itself crashing) also fires the same Slack notifier through the workflow's final `if: failure()` step, mirroring the `--notify` pattern in `scripts/sync-library.sh`.
+
+**Library catalog source**: the workflow used to call `--generate-library-db --catalog-source tubafrenzy --catalog-db-url ...` to build `library.db` inline. That path required direct MySQL connectivity to Kattare, which is impossible from a GitHub-hosted runner (Kattare's MySQL only resolves from inside Kattare's network — the daily `sync-library.yml` workflow tunnels in over SSH). Reusing sync-library's pre-built artifact keeps the SSH credentials in one place. By 06:00 UTC on the 4th, the sync upload from 12:00 UTC on the 3rd is the freshest available snapshot. The watchdog reuses the same `data/library.db` for its drift comparison so the rebuild and the comparison are looking at the same library snapshot.
 
 **Caveat — runner capacity**: the Discogs releases dump is ~63 GB compressed XML and the conversion + Postgres bulk load can exceed the GitHub Actions free hosted runner's ~14 GB disk and 6-hour wall-clock budget. The workflow file is the deliverable; provisioning a self-hosted or larger hosted runner is a follow-up operator task. Until then, expect the scheduled tick to fail loudly rather than silently produce a half-built cache.
 
@@ -216,10 +218,11 @@ After the pipeline succeeds, the workflow runs `scripts/check_cache_drift.py` ag
 | Secret | Description |
 |--------|-------------|
 | `DATABASE_URL_DISCOGS` | PostgreSQL URL for the destination cache database |
-| `LIBRARY_CATALOG_DB_URL` | MySQL URL for the tubafrenzy catalog (used by `--generate-library-db` and the watchdog's library.db re-export) |
 | `DISCOGS_TOKEN` | Discogs API token (optional; only matters if rate limits are hit) |
 | `SENTRY_DSN` | Sentry DSN for error reporting (optional; JSON logging still works without it) |
 | `SLACK_MONITORING_WEBHOOK` | Slack incoming webhook for failure + drift alerts (optional; without it failures still fail the workflow but only Sentry sees them) |
+
+**Upstream dependency**: a successful `sync-library.yml` run must have uploaded `library.db` to the `streaming-data-v1` release on `WXYC/library-metadata-lookup` before this workflow fires, or the `Download library.db from LML release artifact` step fails with `release asset not found`. The default `${{ github.token }}` has read scope on the public LML repo; no extra PAT required.
 
 ### Library Sync (`sync-library.yml`)
 


### PR DESCRIPTION
Closes #138.

## Summary

Replace `--generate-library-db --catalog-source tubafrenzy --catalog-db-url ...` in `rebuild-cache.yml` with a step that downloads the daily-fresh `library.db` from `WXYC/library-metadata-lookup`'s `streaming-data-v1` release, then passes it to the pipeline via `--library-db`.

Why: Kattare's MySQL only resolves from inside Kattare's network. The companion `sync-library.yml` workflow reaches it via SSH tunnel; the rebuild workflow had no tunnel, so the inline `--catalog-db-url mysql://...` path would have hung at the MySQL handshake. The rebuild-cache.yml workflow has therefore never run end-to-end. The 2026-05-04 cron tick was queued to be the first attempt; without this PR it would have failed at `--generate-library-db` even with all the other secrets in place.

## What lands

- New `Download library.db from LML release artifact` step before the Discogs dump download. Uses `gh release download streaming-data-v1 --pattern library.db` with `\${{ github.token }}` (LML is public, default token has read scope).
- Drop `--generate-library-db --catalog-source tubafrenzy --catalog-db-url ...`; replace with `--library-db data/library.db`. Pipeline + `--pair-filter` keep working unchanged — both `--library-db` and `--generate-library-db` satisfy the validator.
- Workflow file's top-level comment block explains the connectivity story so future maintainers don't try to revive the inline path without a tunnel.
- CLAUDE.md secrets table loses `LIBRARY_CATALOG_DB_URL`; new "Library catalog source" subsection covers the reasoning.

## Tradeoff

`library.db` snapshot is at most ~18h stale (sync at 12:00 UTC, rebuild at 06:00 UTC the next day). For monthly cache cadence this is fine — drift inside a 24h window only widens the keep-set (false negatives, never false positives).

## Operator action

`LIBRARY_CATALOG_DB_URL` is no longer used. If it was set as a repo secret, drop it. (Per the secret-presence audit during the Sentry-wiring PR, it wasn't actually set yet anyway.)

## Validation

`actionlint .github/workflows/*.yml` clean. The rebuild path is workflow-only — no Python code changes.

## Why now

5/4 cron is in 4 days. Without this, the run fails at the inline catalog generation regardless of which other secrets land.