### PR TITLE
deps: drop wxyc-catalog [mysql] extra, pin >=0.1.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dependencies = [
     "asyncpg>=0.29.0",
     "rapidfuzz>=3.0.0",
     "wxyc-etl>=0.1.0",
-    "wxyc-catalog[mysql]>=0.1.0",
+    "wxyc-catalog>=0.1.1",
     "sentry-sdk>=2.0",
 ]
 


### PR DESCRIPTION
## Summary

Now that `wxyc-catalog 0.1.1` lazy-imports `pymysql` ([WXYC/wxyc-catalog#27](https://github.com/WXYC/wxyc-catalog/pull/27)), discogs-etl can drop the `[mysql]` extra workaround. The cron rebuild workflow no longer calls `connect_mysql` (PR #139 switched it to consuming sync-library's pre-built `library.db` artifact instead of `--generate-library-db --catalog-source tubafrenzy`), so pymysql was strict deadweight on the dependency closure.

```diff
- "wxyc-catalog[mysql]>=0.1.0",
+ "wxyc-catalog>=0.1.1",
```

## Verification

Fresh venv, `pip install -e ".[dev]"`:

- `pip show wxyc-catalog` → 0.1.1
- `pip show pymysql` → not installed (the lazy-import path keeps it optional)
- `python -c "import wxyc_catalog"` → succeeds

956 pytest pass + ruff clean.

## If anyone ever needs MySQL connectivity again

`wxyc-catalog[mysql]` still exists as an extra; `pip install wxyc-catalog[mysql]` (or just `pip install pymysql`) will bring it back. The lazy-import's ImportError message tells the user exactly that when they hit it.