### PR TITLE
ci(rebuild-cache): fix dump URL (data.discogs.com) + stream via FIFO

### DIFF
--- a/.github/workflows/rebuild-cache.yml
+++ b/.github/workflows/rebuild-cache.yml
@@ -19,13 +19,17 @@ name: Rebuild Discogs Cache
 # in over SSH. Reusing its output asset keeps that connectivity story in one
 # place and avoids duplicating SSH credentials across workflows.
 #
-# TODO: the Discogs releases dump is ~63 GB compressed XML; expanding +
-# converting it can exceed the GitHub Actions free-runner disk (~14 GB) and
-# 6-hour wall-clock budget. The skeleton here lets operators kick the rebuild
-# manually via workflow_dispatch on a self-hosted runner or a beefier hosted
-# runner; converting the scheduled run to use the same once one is provisioned
-# is a follow-up. Until then, the cron tick will fail loudly rather than
-# silently producing a half-built cache, which is the desired signal.
+# Disk: the Discogs releases dump is multi-tens-of-GB compressed and
+# expands to ~80 GB raw XML, well beyond the GitHub Actions free-runner
+# disk budget (~14 GB). The dump is therefore *streamed* through a named
+# pipe straight into the converter rather than materialised on disk —
+# only the much smaller filtered CSV outputs land on the runner. See the
+# `Run pipeline (with streamed dump)` step.
+#
+# Wall-clock: a single-pass parse of the dump is still bounded by the
+# 6-hour free-runner budget. If a future month's dump pushes past that,
+# the next escalation is `runs-on: ubuntu-latest-large` (paid hosted) or
+# a self-hosted runner.
 
 on:
   schedule:
@@ -96,6 +100,11 @@ jobs:
         env:
           OVERRIDE_URL: ${{ inputs.dump_url }}
         run: |
+          # Direct S3 (discogs-data-dumps.s3.us-west-2.amazonaws.com) returns
+          # 403 to anonymous requests as of 2026-05; downloads are gated through
+          # data.discogs.com which signs/proxies the request. Use the public
+          # download endpoint with URL-encoded `data/<YYYY>/<file>` after the
+          # `?download=` query parameter.
           if [ -n "$OVERRIDE_URL" ]; then
             echo "Using operator-supplied dump URL"
             echo "url=$OVERRIDE_URL" >> "$GITHUB_OUTPUT"
@@ -105,7 +114,7 @@ jobs:
             # month. Resolve the most recent published month relative to today.
             year=$(date -u +%Y)
             stamp=$(date -u +%Y%m01)
-            echo "url=https://discogs-data-dumps.s3.us-west-2.amazonaws.com/data/${year}/discogs_${stamp}_releases.xml.gz" >> "$GITHUB_OUTPUT"
+            echo "url=https://data.discogs.com/?download=data%2F${year}%2Fdiscogs_${stamp}_releases.xml.gz" >> "$GITHUB_OUTPUT"
           fi
 
       # Pull the daily-fresh library.db from sync-library.yml's release artifact
@@ -131,12 +140,20 @@ jobs:
             --output data/library.db
           echo "library.db size: $(du -h data/library.db | cut -f1)"
 
-      - name: Download Discogs releases dump
-        run: |
-          mkdir -p data
-          curl -fL --retry 3 --retry-delay 30 -o data/releases.xml.gz "${{ steps.dump.outputs.url }}"
-
-      - name: Run pipeline
+      # Stream the dump through a named pipe instead of materializing it on
+      # disk. Compressed releases.xml.gz is multi-tens-of-GB and expanded XML
+      # exceeds the GitHub Actions free-runner disk (~14 GB) by an order of
+      # magnitude. The converter (discogs-xml-converter) detects gzip by the
+      # `.gz` extension and decodes via flate2's GzDecoder, which is a pure
+      # streaming reader — feeding it from a FIFO works the same as feeding
+      # it from a real file.
+      #
+      # Layout: curl runs in the background writing into the FIFO; the pipeline
+      # invocation runs the converter against that FIFO. Kernel pipe buffer
+      # backpressures curl when the converter falls behind. We `wait` on the
+      # curl PID afterwards so a network-side failure mid-stream doesn't get
+      # masked by the pipeline succeeding on partial input.
+      - name: Run pipeline (with streamed dump)
         env:
           DATABASE_URL_DISCOGS: ${{ secrets.DATABASE_URL_DISCOGS }}
           DISCOGS_TOKEN: ${{ secrets.DISCOGS_TOKEN }}
@@ -145,10 +162,22 @@ jobs:
           # inactive, JSON logging still emits to stderr.
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
         run: |
+          set -euo pipefail
+          mkdir -p data
+          mkfifo data/releases.xml.gz
+          curl -fL --retry 3 --retry-delay 30 \
+            -o data/releases.xml.gz \
+            "${{ steps.dump.outputs.url }}" &
+          CURL_PID=$!
+
           python scripts/run_pipeline.py \
             --xml data/releases.xml.gz \
             --library-db data/library.db \
             --pair-filter
+
+          # Curl should already be done by the time the pipeline returns;
+          # wait surfaces any non-zero exit so a streaming failure is visible.
+          wait "$CURL_PID"
 
       # Watchdog: cache_distinct_artists / library_distinct_artists ratio
       # exposes drift between the just-rebuilt cache and the WXYC library

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -203,7 +203,9 @@ This pipeline runs monthly (or when Discogs publishes new data dumps). It has a 
 
 A GitHub Actions cron workflow runs `scripts/run_pipeline.py --xml ...` on the 4th of each month at 06:00 UTC, staggered a few days after Discogs publishes the new dump. It can also be triggered manually with an optional `dump_url` input: `gh workflow run rebuild-cache.yml`.
 
-The job downloads `releases.xml.gz` for the current month from `discogs-data-dumps.s3.us-west-2.amazonaws.com`, downloads the daily-fresh `library.db` from `WXYC/library-metadata-lookup`'s `streaming-data-v1` release (produced by `sync-library.yml`), builds `discogs-xml-converter` from source, and runs the full XML-mode pipeline (steps 2-10) against `DATABASE_URL_DISCOGS`.
+The job streams `releases.xml.gz` for the current month from `data.discogs.com` (the public download endpoint — direct S3 access via `discogs-data-dumps.s3.us-west-2.amazonaws.com` returns 403), downloads the daily-fresh `library.db` from `WXYC/library-metadata-lookup`'s `streaming-data-v1` release (produced by `sync-library.yml`), builds `discogs-xml-converter` from source, and runs the full XML-mode pipeline (steps 2-10) against `DATABASE_URL_DISCOGS`.
+
+The dump is streamed through a named pipe (`mkfifo data/releases.xml.gz`) into the converter instead of being materialised on disk — the compressed dump is multi-tens-of-GB and expanded XML hits ~80 GB, far past the GitHub Actions free-runner disk budget (~14 GB). The converter detects gzip via the `.gz` filename extension and decodes via flate2's `GzDecoder`, which is a pure streaming reader that works the same against a FIFO as against a real file. Only the much smaller filtered CSV outputs land on disk.
 
 The workflow runs `--pair-filter` so the import payload to `DATABASE_URL_DISCOGS` is ~50K release rows instead of the converter's ~4M, which is what makes a Railway-sized destination DB feasible (the unfiltered import overflows the volume at `COPY release_artist`; see #128).
 
@@ -211,7 +213,7 @@ After the pipeline succeeds, the workflow runs `scripts/check_cache_drift.py` ag
 
 **Library catalog source**: the workflow used to call `--generate-library-db --catalog-source tubafrenzy --catalog-db-url ...` to build `library.db` inline. That path required direct MySQL connectivity to Kattare, which is impossible from a GitHub-hosted runner (Kattare's MySQL only resolves from inside Kattare's network — the daily `sync-library.yml` workflow tunnels in over SSH). Reusing sync-library's pre-built artifact keeps the SSH credentials in one place. By 06:00 UTC on the 4th, the sync upload from 12:00 UTC on the 3rd is the freshest available snapshot. The watchdog reuses the same `data/library.db` for its drift comparison so the rebuild and the comparison are looking at the same library snapshot.
 
-**Caveat — runner capacity**: the Discogs releases dump is ~63 GB compressed XML and the conversion + Postgres bulk load can exceed the GitHub Actions free hosted runner's ~14 GB disk and 6-hour wall-clock budget. The workflow file is the deliverable; provisioning a self-hosted or larger hosted runner is a follow-up operator task. Until then, expect the scheduled tick to fail loudly rather than silently produce a half-built cache.
+**Caveat — runner capacity**: streaming the dump cuts the disk concern out — only the filtered CSV outputs land on the runner, comfortably inside the 14 GB free-runner budget. The remaining concern is the 6-hour wall-clock budget for a single-pass parse of the dump; if a future month exceeds it, the escalation is `runs-on: ubuntu-latest-large` (paid hosted runner) or a self-hosted runner. The 2026-05-04 cron tick will be the empirical signal for whether the free runner is sized correctly.
 
 **Required GitHub secrets:**
 


### PR DESCRIPTION
## Summary

Two stacked problems surfaced when the cron rerun finally got past the secret-swap pre-flight today.

### Wrong dump host

`Resolve dump URL` pointed at `discogs-data-dumps.s3.us-west-2.amazonaws.com` directly. Anonymous requests now get `403 Forbidden` from there. Discogs gates downloads through `data.discogs.com/?download=data%2F...` — Cloudflare in front of S3, with proper content-disposition headers. Verified manually:

```
$ curl -sL -r 0-99 "https://data.discogs.com/?download=data%2F2026%2Fdiscogs_20260501_releases.xml.gz" | xxd | head
00000000: 1f8b 0808 d3fb f469 02ff 6469 7363 6f67  .......i..discog
00000010: 735f 3230 3236 3035 3031 5f72 656c 6561  s_20260501_relea
00000020: 7365 732e 786d 6c00 ...                  ses.xml...
```

(Gzip magic + expected filename in the original-name field.)

Fixed by switching the URL builder to the public download endpoint.

### Disk doesn't fit the dump

Compressed `releases.xml.gz` is multi-tens-of-GB; expanded XML is ~80 GB. Free runner is ~14 GB. Materialising the dump would never have worked even after the URL fix.

`discogs-xml-converter` already supports gzip natively (flate2's `GzDecoder` — pure streaming reader, no seek on the underlying handle) and detects it by the `.gz` filename extension. Those properties make a Unix FIFO indistinguishable from a real file as far as the converter is concerned. New step body:

```bash
mkfifo data/releases.xml.gz
curl ... -o data/releases.xml.gz &
python scripts/run_pipeline.py --xml data/releases.xml.gz ...
wait $CURL_PID
```

Kernel pipe buffer backpressures curl when the converter falls behind; only the (much smaller) filtered CSV outputs land on the runner's disk. The trailing `wait` surfaces curl's exit code so a streaming network failure can't be masked by the pipeline succeeding on partial input. Combined the previous separate `Download Discogs releases dump` and `Run pipeline` steps into one — their bodies are now coupled by the FIFO lifetime.

## Validation strategy

Both changes are workflow-only — no Python or schema. CI here only runs `lint`, `test`, `pg`, `marker-sync` (none of which exercise the rebuild). Real validation is empirical: rerun the rebuild and watch.

```bash
gh run rerun 25308842897 --repo WXYC/discogs-etl
```

Expected: gets past `Run pipeline (with streamed dump)` step (or fails for a new reason — wall-clock budget, runner network throughput, etc.).

## Documentation

Workflow file's top comment + CLAUDE.md `Caveat — runner capacity` section rewritten. Disk is no longer the constraint. The 6-hour wall-clock is the next constraint to test against; if it bites, the next escalation is `ubuntu-latest-large` or a self-hosted runner.