### PR TITLE
ci(rebuild-cache): disable cron — workload doesn't fit GH-hosted runners

### DIFF
--- a/.github/workflows/rebuild-cache.yml
+++ b/.github/workflows/rebuild-cache.yml
@@ -31,10 +31,15 @@ name: Rebuild Discogs Cache
 # the next escalation is `runs-on: ubuntu-latest-large` (paid hosted) or
 # a self-hosted runner.
 
+# 2026-05-05: cron disabled. Two cron-tick attempts demonstrated that the
+# rebuild doesn't fit a GitHub-hosted runner: the dump-host's Cloudflare
+# front blocks GH-runner egress IPs (the same `data.discogs.com/?download=`
+# URL serves 200 to residential IPs and 403 from a runner), and even past
+# that the workflow eats meaningful Actions minutes for a job that runs
+# fine in ~half an hour on hardware co-located with the destination DB.
+# Tracking the migration to a Railway cron service in WXYC/discogs-etl.
+# `workflow_dispatch` is kept as a manual escape hatch.
 on:
-  schedule:
-    # 06:00 UTC on the 4th of each month (staggered from sister rebuilds).
-    - cron: "0 6 4 * *"
   workflow_dispatch:
     inputs:
       dump_url:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -201,7 +201,9 @@ This pipeline runs monthly (or when Discogs publishes new data dumps). It has a 
 
 ### Monthly Cache Rebuild (`rebuild-cache.yml`)
 
-A GitHub Actions cron workflow runs `scripts/run_pipeline.py --xml ...` on the 4th of each month at 06:00 UTC, staggered a few days after Discogs publishes the new dump. It can also be triggered manually with an optional `dump_url` input: `gh workflow run rebuild-cache.yml`.
+**Status (2026-05-05)**: the cron schedule has been disabled. Two cron-tick attempts (2026-05-04, 2026-05-05) demonstrated that this rebuild doesn't fit a GitHub-hosted runner — Discogs's Cloudflare front blocks GH-runner egress IPs from `data.discogs.com/?download=` (residential IPs get 200, runner gets 403), and the job's compute envelope (~30+ min wall, multi-tens-of-GB stream) consumes meaningful Actions minutes for what should be a short job on hardware co-located with the destination DB. The migration to a Railway-side cron service is the planned replacement; the workflow file stays in the repo as a `workflow_dispatch`-only manual escape hatch until that lands.
+
+The (now-disabled) cron used to fire `scripts/run_pipeline.py --xml ...` on the 4th of each month at 06:00 UTC. The workflow can still be triggered manually via `gh workflow run rebuild-cache.yml` with an optional `dump_url` input.
 
 The job streams `releases.xml.gz` for the current month from `data.discogs.com` (the public download endpoint — direct S3 access via `discogs-data-dumps.s3.us-west-2.amazonaws.com` returns 403), downloads the daily-fresh `library.db` from `WXYC/library-metadata-lookup`'s `streaming-data-v1` release (produced by `sync-library.yml`), builds `discogs-xml-converter` from source, and runs the full XML-mode pipeline (steps 2-10) against `DATABASE_URL_DISCOGS`.
 


### PR DESCRIPTION
## Summary

Two cron-tick attempts (2026-05-04, 2026-05-05) demonstrated this rebuild doesn't fit on a GitHub-hosted runner:

- **Cloudflare/origin filtering at `data.discogs.com`** blocks GH-runner egress IPs. The same `data.discogs.com/?download=data%2F...` URL that returns 200 + gzip bytes from a residential IP returns 403 from a GH runner. There's no obvious way to spoof past it without a residential proxy.
- **Compute envelope is wrong for CI.** The job downloads tens of GB of compressed XML, single-passes through it, and writes to a destination DB co-located on Railway. Doing that from a GitHub-hosted runner means egressing the DB writes to Railway over the public internet and burning Actions minutes for what should be a short colocated job.

Pulling the schedule trigger now. `workflow_dispatch` stays as a manual escape hatch (e.g. one-off rebuilds from a self-hosted residential runner). The migration target is a Railway-side cron service in the same project as the discogs-cache PG — colocated, no Cloudflare blocking, free internal-network DB writes.

CLAUDE.md gains a Status note explaining the situation so the next reader doesn't try to debug the cron.

## Why now

Two failed runs within 24 hours, both burning Actions minutes for nothing actionable. Stop the bleed.