### PR TITLE
ops: move monthly rebuild to EC2 cron + fix run_pipeline.py converter CLI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,7 +128,8 @@ docker compose up db -d     # just the database (for tests)
 - `lib/format_normalization.py` -- Normalize raw Discogs/library format strings to broad categories (Vinyl, CD, Cassette, 7", Digital)
 - `scripts/sync-library.sh` -- Daily library sync orchestrator: MySQL query (via MariaDB `mysql` CLI for MySQL 4.1 compat) → `tsv_to_sqlite.py` → streaming links enrichment → upload to LML. Automated by `.github/workflows/sync-library.yml` (daily at noon UTC).
 - `scripts/tsv_to_sqlite.py` -- Converts MySQL TSV output to SQLite with FTS5 index. Called by sync-library.sh.
-- `scripts/check_cache_drift.py` -- Drift watchdog: compares `COUNT(DISTINCT artist) FROM library` (sqlite) to `COUNT(DISTINCT artist_name) FROM release_artist` (cache). Exits non-zero (and posts to `SLACK_MONITORING_WEBHOOK` when set) if the ratio falls below `--min-ratio` (default 0.7). Run as the final step of `rebuild-cache.yml` so coverage regressions surface as workflow failures.
+- `scripts/check_cache_drift.py` -- Drift watchdog: compares `COUNT(DISTINCT artist) FROM library` (sqlite) to `COUNT(DISTINCT artist_name) FROM release_artist` (cache). Exits non-zero (and posts to `SLACK_MONITORING_WEBHOOK` when set) if the ratio falls below `--min-ratio` (default 0.7). Run as the final step of `rebuild-cache.sh` so coverage regressions surface as alerts.
+- `scripts/rebuild-cache.sh` -- EC2 cron wrapper: pulls latest discogs-etl + discogs-xml-converter, downloads library.db from LML release artifact, streams the Discogs dump from data.discogs.com through a FIFO into the converter, runs `run_pipeline.py --pair-filter`, then the drift watchdog. Setup runbook at `docs/ec2-rebuild-runbook.md`.
 - `docs/discogs-etl-technical-overview.md` -- Design rationale, benchmarks, and pipeline architecture details
 
 ### Shared Package Dependencies
@@ -201,9 +202,9 @@ This pipeline runs monthly (or when Discogs publishes new data dumps). It has a 
 
 ### Monthly Cache Rebuild (`rebuild-cache.yml`)
 
-**Status (2026-05-05)**: the cron schedule has been disabled. Two cron-tick attempts (2026-05-04, 2026-05-05) demonstrated that this rebuild doesn't fit a GitHub-hosted runner — Discogs's Cloudflare front blocks GH-runner egress IPs from `data.discogs.com/?download=` (residential IPs get 200, runner gets 403), and the job's compute envelope (~30+ min wall, multi-tens-of-GB stream) consumes meaningful Actions minutes for what should be a short job on hardware co-located with the destination DB. The migration to a Railway-side cron service is the planned replacement; the workflow file stays in the repo as a `workflow_dispatch`-only manual escape hatch until that lands.
+**Status (2026-05-05)**: the GH Actions cron is disabled. The rebuild now runs on the Backend-Service EC2 host as a cron-driven shell wrapper at `scripts/rebuild-cache.sh`. Setup + recurring-ops instructions in [`docs/ec2-rebuild-runbook.md`](docs/ec2-rebuild-runbook.md). The GH workflow file stays in the repo as a `workflow_dispatch`-only manual escape hatch (no scheduled trigger).
 
-The (now-disabled) cron used to fire `scripts/run_pipeline.py --xml ...` on the 4th of each month at 06:00 UTC. The workflow can still be triggered manually via `gh workflow run rebuild-cache.yml` with an optional `dump_url` input.
+**Why EC2**: GH-hosted runner egress IPs are 403'd by Discogs's Cloudflare front at `data.discogs.com/?download=`; residential and EC2 IPs aren't. Plus the job's compute envelope (multi-tens-of-GB stream + 60-90 min wall) is wrong for free Actions minutes. EC2 already hosts Backend-Service, so the marginal cost of adding this cron is effectively $0.
 
 The job streams `releases.xml.gz` for the current month from `data.discogs.com` (the public download endpoint — direct S3 access via `discogs-data-dumps.s3.us-west-2.amazonaws.com` returns 403), downloads the daily-fresh `library.db` from `WXYC/library-metadata-lookup`'s `streaming-data-v1` release (produced by `sync-library.yml`), builds `discogs-xml-converter` from source, and runs the full XML-mode pipeline (steps 2-10) against `DATABASE_URL_DISCOGS`.
 

--- a/docs/ec2-rebuild-runbook.md
+++ b/docs/ec2-rebuild-runbook.md
@@ -1,0 +1,181 @@
+# EC2 monthly cache rebuild — operator runbook
+
+The Discogs cache rebuild runs monthly via cron on the WXYC EC2 host. This
+runbook covers the one-time setup, the recurring operator concerns, and the
+troubleshooting playbook.
+
+## Why this lives on EC2
+
+We tried running the rebuild as a GitHub Actions cron and it doesn't fit
+([discogs-etl#138](https://github.com/WXYC/discogs-etl/issues/138) and
+the disable-cron PR follow-up). Specifically:
+
+- Discogs's Cloudflare front (`data.discogs.com`) returns 403 from
+  GitHub-hosted runner egress IPs. The same URL serves 200 from any
+  residential or AWS-EC2-style IP.
+- The job's compute envelope (~30+ min wall, multi-tens-of-GB stream)
+  burns Actions minutes for what should be a short job hosted close to
+  the destination DB.
+
+EC2 fixes both: residential-class IP + colocation with cheaper egress to
+Railway. Cost is effectively $0/month — runs against the existing
+Backend-Service EC2 (the same `ssh wxyc-ec2` host the API uses).
+
+## One-time setup
+
+All commands run on the EC2 host as `ec2-user` unless noted.
+
+### 1. Install runtimes
+
+```bash
+# Postgres client (psql) for the alembic stamp guard + smoke tests
+sudo dnf install -y postgresql15
+
+# Python 3.12 (or whatever's in `python_requires` in pyproject.toml)
+sudo dnf install -y python3.12 python3.12-pip python3.12-devel
+
+# Rust toolchain (stable) — needed to build discogs-xml-converter
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+    | sh -s -- -y --default-toolchain stable
+source "$HOME/.cargo/env"
+
+# GitHub CLI for `gh release download`
+sudo dnf install -y gh
+```
+
+### 2. Clone the repos
+
+```bash
+sudo mkdir -p /opt/discogs-etl /opt/discogs-xml-converter
+sudo chown ec2-user:ec2-user /opt/discogs-etl /opt/discogs-xml-converter
+
+git clone https://github.com/WXYC/discogs-etl.git /opt/discogs-etl
+git clone https://github.com/WXYC/discogs-xml-converter.git /opt/discogs-xml-converter
+
+# Bootstrap the Python venv used by the cron script.
+python3.12 -m venv /opt/discogs-etl/.venv
+source /opt/discogs-etl/.venv/bin/activate
+pip install -e "/opt/discogs-etl[dev]"
+
+# Pre-build the Rust binary so the first cron tick doesn't pay the cold-build cost.
+(cd /opt/discogs-xml-converter && cargo build --release)
+```
+
+### 3. Authenticate `gh` for the LML release-asset download
+
+`gh release download` against the public `WXYC/library-metadata-lookup` repo
+needs a token with at least `repo:read` (any classic PAT or fine-grained
+token scoped to the repo works).
+
+```bash
+gh auth login --with-token <<<"$YOUR_TOKEN"
+gh auth status
+```
+
+Or set `GH_TOKEN` in the env file (next step).
+
+### 4. Provision secrets
+
+Create `/etc/discogs-rebuild.env` (root-readable only) with:
+
+```ini
+DATABASE_URL_DISCOGS=postgresql://postgres:<pw>@<word>.proxy.rlwy.net:<port>/railway
+SLACK_MONITORING_WEBHOOK=https://hooks.slack.com/services/...   # optional
+SENTRY_DSN=https://<key>@<org>.ingest.sentry.io/<project>      # optional
+GH_TOKEN=...                                                   # if not using `gh auth login`
+```
+
+Lock it down so secrets don't leak via `world-readable`:
+
+```bash
+sudo chmod 600 /etc/discogs-rebuild.env
+sudo chown root:root /etc/discogs-rebuild.env
+```
+
+### 5. Set up logging directory
+
+```bash
+sudo mkdir -p /var/log/discogs-rebuild
+sudo chown ec2-user:ec2-user /var/log/discogs-rebuild
+```
+
+### 6. Test the script manually before scheduling
+
+```bash
+sudo --preserve-env=DATABASE_URL_DISCOGS,SLACK_MONITORING_WEBHOOK,SENTRY_DSN,GH_TOKEN \
+    bash -c 'set -a; source /etc/discogs-rebuild.env; set +a; \
+        bash /opt/discogs-etl/scripts/rebuild-cache.sh'
+```
+
+Expected: ~60-90 minute run, ends with `rebuild complete` in
+`/var/log/discogs-rebuild/<timestamp>.log` and (if configured) a
+`✅ Discogs cache rebuild: rebuilt successfully` Slack message.
+
+### 7. Add the cron entry
+
+Edit `ec2-user`'s crontab (`crontab -e`):
+
+```cron
+# Monthly Discogs cache rebuild — 06:00 UTC on the 4th of each month
+# (a few days after Discogs publishes the monthly dump).
+0 6 4 * * set -a; . /etc/discogs-rebuild.env; set +a; /opt/discogs-etl/scripts/rebuild-cache.sh
+```
+
+The `set -a; . /etc/discogs-rebuild.env; set +a` pattern sources the env
+file with auto-export so the script sees the secrets. (Cron does not by
+default source any shell rc, so `source` alone wouldn't propagate.)
+
+## Recurring operations
+
+### Watching a run
+
+```bash
+# follow the in-flight log
+ssh wxyc-ec2 'tail -f /var/log/discogs-rebuild/$(ls -1 /var/log/discogs-rebuild | tail -1)'
+```
+
+### Triggering a manual run
+
+```bash
+ssh wxyc-ec2
+sudo --preserve-env=DATABASE_URL_DISCOGS,SLACK_MONITORING_WEBHOOK,SENTRY_DSN,GH_TOKEN \
+    bash -c 'set -a; source /etc/discogs-rebuild.env; set +a; \
+        /opt/discogs-etl/scripts/rebuild-cache.sh'
+```
+
+The script's `flock` will refuse to start if another rebuild is already
+running (zero-exit no-op).
+
+## Troubleshooting
+
+### "another rebuild is already running"
+
+Lock file at `/var/run/discogs-rebuild.lock`. Either a previous run is
+genuinely still in flight (check `ps -ef | grep run_pipeline`) or it
+crashed without releasing the lock (which `flock` cleans up on next reboot
+or by `rm`-ing the file).
+
+### Slack alerts but no log file in `/var/log/discogs-rebuild/`
+
+The trap fires before the `tee` redirect could write anything. Run
+manually to see stderr.
+
+### `gh release download` fails with "release asset not found"
+
+Means `sync-library.yml` hasn't run successfully today/recently. Check
+[its workflow runs](https://github.com/WXYC/discogs-etl/actions/workflows/sync-library.yml)
+and trigger a fresh sync (`gh workflow run sync-library.yml`) before
+rerunning the rebuild.
+
+### Pipeline crashes with `psycopg.errors.DiskFull`
+
+The cache rebuild presumes `--pair-filter` is doing its job (~50K release
+rows, well inside Railway's volume). If a future change removes
+`--pair-filter` or the library expands meaningfully, the volume fills.
+Either restore the filter, expand the Railway volume, or move the cache
+off Railway.
+
+### Pipeline crashes with `relation "release" does not exist` early
+
+The destination DB hasn't been alembic-stamped. Apply the procedure in
+[`docs/migrations-runbook.md`](migrations-runbook.md) once.

--- a/scripts/rebuild-cache.sh
+++ b/scripts/rebuild-cache.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+# Monthly Discogs cache rebuild — invoked by EC2 cron at 06:00 UTC on the
+# 4th of each month. Streams the dump from data.discogs.com directly into
+# the converter via a FIFO, runs the pipeline against $DATABASE_URL_DISCOGS,
+# notifies Slack on outcome.
+#
+# Setup runbook: docs/ec2-rebuild-runbook.md
+#
+# Required env (from /etc/discogs-rebuild.env or equivalent):
+#   DATABASE_URL_DISCOGS         destination Postgres URL (Railway public proxy)
+#   REPO_DIR                     local clone of discogs-etl (default /opt/discogs-etl)
+#   CONVERTER_DIR                local clone of discogs-xml-converter
+#                                (default /opt/discogs-xml-converter)
+#   LOG_DIR                      where to write per-run logs (default /var/log/discogs-rebuild)
+#
+# Optional env:
+#   SENTRY_DSN                   forwarded to wxyc_etl.logger
+#   SLACK_MONITORING_WEBHOOK     posts a one-line status when set
+#   GH_TOKEN                     used by `gh release download` (any token with
+#                                read scope on WXYC/library-metadata-lookup)
+#   DRIFT_MIN_RATIO              watchdog threshold (default 0.7)
+
+set -euo pipefail
+
+REPO_DIR="${REPO_DIR:-/opt/discogs-etl}"
+CONVERTER_DIR="${CONVERTER_DIR:-/opt/discogs-xml-converter}"
+LOG_DIR="${LOG_DIR:-/var/log/discogs-rebuild}"
+DRIFT_MIN_RATIO="${DRIFT_MIN_RATIO:-0.7}"
+
+mkdir -p "$LOG_DIR"
+TS="$(date -u +%Y-%m-%dT%H%MZ)"
+LOG_FILE="$LOG_DIR/$TS.log"
+exec > >(tee -a "$LOG_FILE") 2>&1
+
+# Single-instance lock. Two cron ticks landing on a still-running rebuild
+# would clobber each other's COPY work.
+LOCK_FD=200
+LOCK_FILE="/var/run/discogs-rebuild.lock"
+exec 200>"$LOCK_FILE"
+if ! flock -n "$LOCK_FD"; then
+    echo "[$(date -u +%H:%M:%SZ)] another rebuild is already running; exiting"
+    exit 0
+fi
+
+notify_slack() {
+    local emoji="$1" message="$2"
+    if [ -z "${SLACK_MONITORING_WEBHOOK:-}" ]; then
+        return 0
+    fi
+    curl -sS -X POST "$SLACK_MONITORING_WEBHOOK" \
+        -H 'Content-Type: application/json' \
+        -d "{\"text\":\"${emoji} Discogs cache rebuild: ${message}\"}" \
+        --max-time 10 || true
+}
+
+# Trap surfaces unexpected exits to Slack with the failing line context.
+on_error() {
+    local exit_code=$?
+    local line=$1
+    notify_slack ":warning:" "failed at line ${line} (exit ${exit_code}). Log: ${LOG_FILE}"
+    exit "$exit_code"
+}
+trap 'on_error $LINENO' ERR
+
+echo "[$(date -u +%H:%M:%SZ)] starting rebuild — log: $LOG_FILE"
+
+# ---------------------------------------------------------------------------
+# 1. Refresh code (discogs-etl + discogs-xml-converter)
+# ---------------------------------------------------------------------------
+echo "[$(date -u +%H:%M:%SZ)] git fetch + reset --hard origin/main"
+git -C "$REPO_DIR" fetch --quiet origin main
+git -C "$REPO_DIR" reset --quiet --hard origin/main
+git -C "$CONVERTER_DIR" fetch --quiet origin main
+git -C "$CONVERTER_DIR" reset --quiet --hard origin/main
+
+# ---------------------------------------------------------------------------
+# 2. Refresh deps. Cheap when nothing changed — pip is no-op, cargo build
+#    only re-links if Cargo.lock or sources moved.
+# ---------------------------------------------------------------------------
+echo "[$(date -u +%H:%M:%SZ)] refresh Python venv + Rust converter binary"
+# shellcheck disable=SC1091
+source "$REPO_DIR/.venv/bin/activate"
+pip install --quiet -e "${REPO_DIR}[dev]"
+(cd "$CONVERTER_DIR" && cargo build --release --quiet)
+export PATH="$CONVERTER_DIR/target/release:$PATH"
+
+# ---------------------------------------------------------------------------
+# 3. Pull daily-fresh library.db produced by sync-library workflow
+# ---------------------------------------------------------------------------
+WORK_DIR="$(mktemp -d "$REPO_DIR/data-rebuild.XXXXXX")"
+trap 'rm -rf "$WORK_DIR"; on_error $LINENO' ERR
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+echo "[$(date -u +%H:%M:%SZ)] download library.db from LML release artifact"
+gh release download streaming-data-v1 \
+    --repo WXYC/library-metadata-lookup \
+    --pattern library.db \
+    --output "$WORK_DIR/library.db" \
+    --clobber
+echo "    library.db: $(du -h "$WORK_DIR/library.db" | cut -f1)"
+
+# ---------------------------------------------------------------------------
+# 4. Resolve dump URL — try current month, fall back to previous if 404/403
+# ---------------------------------------------------------------------------
+echo "[$(date -u +%H:%M:%SZ)] resolve Discogs dump URL"
+year=$(date -u +%Y)
+month=$(date -u +%m)
+url="https://data.discogs.com/?download=data%2F${year}%2Fdiscogs_${year}${month}01_releases.xml.gz"
+if ! curl -sIfL --max-time 15 -o /dev/null "$url"; then
+    prev=$(date -u -d "1 month ago" +%Y%m 2>/dev/null \
+        || date -u -v-1m +%Y%m)
+    prev_year=${prev:0:4}
+    url="https://data.discogs.com/?download=data%2F${prev_year}%2Fdiscogs_${prev}01_releases.xml.gz"
+    echo "    current-month dump not yet available; falling back to ${prev}"
+fi
+echo "    dump URL: $url"
+
+# ---------------------------------------------------------------------------
+# 5. Stream dump into converter via FIFO + run pipeline
+# ---------------------------------------------------------------------------
+mkfifo "$WORK_DIR/releases.xml.gz"
+echo "[$(date -u +%H:%M:%SZ)] start streaming download → pipeline"
+curl -fL --retry 3 --retry-delay 30 \
+    -o "$WORK_DIR/releases.xml.gz" \
+    "$url" &
+CURL_PID=$!
+
+python "$REPO_DIR/scripts/run_pipeline.py" \
+    --xml "$WORK_DIR/releases.xml.gz" \
+    --library-db "$WORK_DIR/library.db" \
+    --pair-filter
+
+# Curl is normally already done by here (the pipeline blocks reading the FIFO
+# until EOF, which only arrives when curl finishes). The wait surfaces a
+# non-zero curl exit so a streaming network failure isn't masked by the
+# pipeline succeeding on partial input.
+wait "$CURL_PID"
+
+# ---------------------------------------------------------------------------
+# 6. Drift watchdog — same library.db the pipeline just filtered against
+# ---------------------------------------------------------------------------
+echo "[$(date -u +%H:%M:%SZ)] cache-drift watchdog (min-ratio=$DRIFT_MIN_RATIO)"
+python "$REPO_DIR/scripts/check_cache_drift.py" \
+    --library-db "$WORK_DIR/library.db" \
+    --min-ratio "$DRIFT_MIN_RATIO"
+
+echo "[$(date -u +%H:%M:%SZ)] rebuild complete"
+notify_slack ":white_check_mark:" "rebuilt successfully (log: ${LOG_FILE})"
+
+# ---------------------------------------------------------------------------
+# 7. Trim old logs (keep ~6 months of tick history)
+# ---------------------------------------------------------------------------
+find "$LOG_DIR" -maxdepth 1 -name '*.log' -mtime +180 -delete 2>/dev/null || true

--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -534,11 +534,15 @@ def convert_and_filter(
     with a single call to the Rust binary.
 
     When database_url is provided, releases are streamed directly into
-    PostgreSQL via COPY instead of being written to CSV files. Supplementary
-    CSVs (artist_alias.csv, label_hierarchy.csv) are still written to
-    output_dir.
+    PostgreSQL via COPY (`import` subcommand) instead of being written to
+    CSV files (`build` subcommand). Supplementary CSVs (artist_alias.csv,
+    label_hierarchy.csv) are still written to output_dir in either mode.
     """
-    cmd = [converter, str(xml_file), "--output-dir", str(output_dir)]
+    # Converter CLI uses clap subcommands (`build` for CSV output, `import`
+    # for direct-to-PG). The old positional invocation surfaces as an
+    # `unrecognized subcommand` error against current main.
+    subcommand = "import" if database_url else "build"
+    cmd = [converter, subcommand, str(xml_file), "--data-dir", str(output_dir)]
     if library_artists:
         cmd.extend(["--library-artists", str(library_artists)])
     if database_url:

--- a/tests/unit/test_run_pipeline.py
+++ b/tests/unit/test_run_pipeline.py
@@ -783,8 +783,8 @@ class TestReportSizes:
 class TestConvertAndFilter:
     """convert_and_filter() constructs the converter command and delegates to run_step."""
 
-    def test_command_with_library_artists(self) -> None:
-        """Command includes --library-artists when provided."""
+    def test_build_subcommand_when_no_database_url(self) -> None:
+        """CSV mode dispatches to the converter's `build` subcommand."""
         with patch.object(run_pipeline, "run_step") as mock_run:
             run_pipeline.convert_and_filter(
                 Path("/data/releases.xml.gz"),
@@ -796,13 +796,18 @@ class TestConvertAndFilter:
         mock_run.assert_called_once()
         cmd = mock_run.call_args[0][1]
         assert cmd[0] == "discogs-xml-converter"
+        # Subcommand is the first positional arg after the binary, before any flags.
+        assert cmd[1] == "build"
         assert "/data/releases.xml.gz" in cmd
-        assert "--output-dir" in cmd
+        # New CLI uses --data-dir; --output-dir is the deprecated alias.
+        assert "--data-dir" in cmd
+        assert "--output-dir" not in cmd
         assert "--library-artists" in cmd
         assert "/data/library_artists.txt" in cmd
 
-    def test_command_with_database_url(self) -> None:
-        """Command includes --database-url for direct-PG mode."""
+    def test_import_subcommand_when_database_url_set(self) -> None:
+        """Direct-PG mode dispatches to the converter's `import` subcommand
+        and includes --database-url."""
         with patch.object(run_pipeline, "run_step") as mock_run:
             run_pipeline.convert_and_filter(
                 Path("/data/releases.xml.gz"),
@@ -812,6 +817,7 @@ class TestConvertAndFilter:
             )
 
         cmd = mock_run.call_args[0][1]
+        assert cmd[1] == "import"
         assert "--database-url" in cmd
         assert "postgresql:///discogs" in cmd
         # Description mentions PostgreSQL
@@ -828,6 +834,7 @@ class TestConvertAndFilter:
             )
 
         cmd = mock_run.call_args[0][1]
+        assert cmd[1] == "build"
         assert "--library-artists" not in cmd
         assert "--database-url" not in cmd
         description = mock_run.call_args[0][0]


### PR DESCRIPTION
## Summary

Two related changes:

1. **Fix `run_pipeline.py`'s converter invocation.** `discogs-xml-converter` switched to clap subcommands (`build` for CSV output, `import` for direct-PG) some weeks ago; `scripts/run_pipeline.py:541` was still calling it the old positional-only way. Today's GH Actions run that finally got past the pre-flight surfaced this as `error: unrecognized subcommand 'data/releases.xml.gz'`. Updated `convert_and_filter` to dispatch to the right subcommand and to use `--data-dir` instead of the now-deprecated `--output-dir` alias. Three tests in `TestConvertAndFilter` rewritten to pin the new shape.

2. **Move the monthly rebuild to EC2 cron.** Two GH Actions cron-tick attempts (5/4, 5/5) proved the workload doesn't fit there:
   - Discogs's Cloudflare front (`data.discogs.com/?download=...`) returns 403 to GH-runner egress IPs. The same URL serves 200 from residential and AWS-EC2 IPs.
   - The job's compute envelope (multi-tens-of-GB stream + 60-90 min wall) wastes Actions minutes for a job that should sit ~20 ms from the destination DB.

   The Backend-Service EC2 host (`ssh wxyc-ec2`) already has the right egress class and is colocated with the deploy pipeline. Marginal cost: ~$0/month.

## What lands

- **`scripts/rebuild-cache.sh`** — cron wrapper:
  - `flock` to prevent overlapping ticks
  - Per-run log at `/var/log/discogs-rebuild/<UTC-stamp>.log` with 6-month retention
  - ERR trap posts to `SLACK_MONITORING_WEBHOOK` with failing line + log path
  - `git fetch + reset --hard origin/main` for both discogs-etl and discogs-xml-converter, then refresh venv + Rust binary (cheap when nothing changed)
  - `gh release download streaming-data-v1 --pattern library.db` (same artifact as before)
  - Dump URL resolver tries current month, falls back to previous when 4xx
  - `mkfifo` + backgrounded curl + `python run_pipeline.py --xml <fifo> --library-db <db> --pair-filter`, with `wait $CURL_PID` so streaming network failures aren't masked
  - `check_cache_drift.py` runs against the same `library.db` the rebuild filtered against
- **`docs/ec2-rebuild-runbook.md`** — one-time setup, recurring ops, troubleshooting
- **`scripts/run_pipeline.py`** — `convert_and_filter` updated for new converter CLI
- **`tests/unit/test_run_pipeline.py`** — `TestConvertAndFilter` rewritten
- **`CLAUDE.md`** — Status note + Key Files entry

## Validation

- 956 pytest pass + ruff + shellcheck clean
- The script's syntax is bash-validated; the actual end-to-end will be the first cron tick on EC2 after one-time setup

## Operator action after merge

Follow `docs/ec2-rebuild-runbook.md` once. Steps:
1. Install runtimes (Python 3.12, Rust stable, postgresql client, gh CLI)
2. Clone discogs-etl + discogs-xml-converter under `/opt/`
3. Authenticate gh + create `/etc/discogs-rebuild.env` with secrets
4. Run the script manually once to validate
5. Add the cron entry

## Workflow file

`rebuild-cache.yml` stays as `workflow_dispatch`-only (the disabled-cron PR).