### PR TITLE
ops(rebuild-cache): REBUILD_SMOKE=1 mode for setup validation

### DIFF
--- a/docs/ec2-rebuild-runbook.md
+++ b/docs/ec2-rebuild-runbook.md
@@ -85,12 +85,14 @@ SENTRY_DSN=https://<key>@<org>.ingest.sentry.io/<project>      # optional
 GH_TOKEN=...                                                   # if not using `gh auth login`
 ```
 
-Lock it down so secrets don't leak via `world-readable`:
+Lock it down so the file isn't world-readable, but leave it readable to the cron user (`ec2-user` by default — root mode 600 means cron can't `source` it):
 
 ```bash
-sudo chmod 600 /etc/discogs-rebuild.env
-sudo chown root:root /etc/discogs-rebuild.env
+sudo chown root:ec2-user /etc/discogs-rebuild.env
+sudo chmod 640 /etc/discogs-rebuild.env
 ```
+
+If you'd rather run the cron as root, use `sudo crontab -e` in step 7 instead and tighten the file to `chown root:root` + `chmod 600`.
 
 ### 5. Set up logging directory
 
@@ -99,19 +101,42 @@ sudo mkdir -p /var/log/discogs-rebuild
 sudo chown ec2-user:ec2-user /var/log/discogs-rebuild
 ```
 
-### 6. Test the script manually before scheduling
+### 6. Validate the host setup with smoke mode (no DB write)
+
+`REBUILD_SMOKE=1` runs everything that can fail at host setup time —
+git pulls, venv refresh, cargo build, gh release download, dump URL
+resolution, FIFO + curl handshake — and exits 0 *before* writing anything
+to `$DATABASE_URL_DISCOGS`. Run this first so you can fix any host-side
+issue without touching prod:
 
 ```bash
-sudo --preserve-env=DATABASE_URL_DISCOGS,SLACK_MONITORING_WEBHOOK,SENTRY_DSN,GH_TOKEN \
-    bash -c 'set -a; source /etc/discogs-rebuild.env; set +a; \
-        bash /opt/discogs-etl/scripts/rebuild-cache.sh'
+sudo -u ec2-user bash -c '
+    set -a; . /etc/discogs-rebuild.env; set +a
+    REBUILD_SMOKE=1 /opt/discogs-etl/scripts/rebuild-cache.sh
+'
 ```
 
-Expected: ~60-90 minute run, ends with `rebuild complete` in
+Expected: ~3-5 min, ends with `smoke OK: read NNNNN bytes from the
+streamed dump` and (if configured) a `🔍 smoke test passed (no DB
+write performed)` Slack message.
+
+### 7. Test the full rebuild manually before scheduling
+
+Once smoke is green, run the real thing once before adding the cron
+entry — `~60-90 min`, writes to Railway prod:
+
+```bash
+sudo -u ec2-user bash -c '
+    set -a; . /etc/discogs-rebuild.env; set +a
+    /opt/discogs-etl/scripts/rebuild-cache.sh
+'
+```
+
+Expected: ends with `rebuild complete` in
 `/var/log/discogs-rebuild/<timestamp>.log` and (if configured) a
 `✅ Discogs cache rebuild: rebuilt successfully` Slack message.
 
-### 7. Add the cron entry
+### 8. Add the cron entry
 
 Edit `ec2-user`'s crontab (`crontab -e`):
 
@@ -138,13 +163,28 @@ ssh wxyc-ec2 'tail -f /var/log/discogs-rebuild/$(ls -1 /var/log/discogs-rebuild 
 
 ```bash
 ssh wxyc-ec2
-sudo --preserve-env=DATABASE_URL_DISCOGS,SLACK_MONITORING_WEBHOOK,SENTRY_DSN,GH_TOKEN \
-    bash -c 'set -a; source /etc/discogs-rebuild.env; set +a; \
-        /opt/discogs-etl/scripts/rebuild-cache.sh'
+sudo -u ec2-user bash -c '
+    set -a; . /etc/discogs-rebuild.env; set +a
+    /opt/discogs-etl/scripts/rebuild-cache.sh
+'
 ```
 
 The script's `flock` will refuse to start if another rebuild is already
 running (zero-exit no-op).
+
+### Smoke mode
+
+Same recipe with `REBUILD_SMOKE=1` exits before any DB write — useful to
+re-validate after upgrading the EC2 host (Python, Rust, system packages)
+or after rotating the Railway PG password without risking a partial
+rebuild against a broken connection:
+
+```bash
+sudo -u ec2-user bash -c '
+    set -a; . /etc/discogs-rebuild.env; set +a
+    REBUILD_SMOKE=1 /opt/discogs-etl/scripts/rebuild-cache.sh
+'
+```
 
 ## Troubleshooting
 

--- a/scripts/rebuild-cache.sh
+++ b/scripts/rebuild-cache.sh
@@ -19,6 +19,13 @@
 #   GH_TOKEN                     used by `gh release download` (any token with
 #                                read scope on WXYC/library-metadata-lookup)
 #   DRIFT_MIN_RATIO              watchdog threshold (default 0.7)
+#   REBUILD_SMOKE                when set to 1, exercise everything that can
+#                                fail at host setup (env, gh auth, git pulls,
+#                                cargo build, library.db download, dump URL,
+#                                FIFO + curl handshake) and exit 0 *before*
+#                                writing anything to $DATABASE_URL_DISCOGS.
+#                                Use to validate a fresh EC2 setup without
+#                                touching prod.
 
 set -euo pipefail
 
@@ -119,6 +126,29 @@ echo "    dump URL: $url"
 # 5. Stream dump into converter via FIFO + run pipeline
 # ---------------------------------------------------------------------------
 mkfifo "$WORK_DIR/releases.xml.gz"
+
+if [ "${REBUILD_SMOKE:-}" = "1" ]; then
+    # Smoke mode: prove that curl can write into the FIFO and a reader
+    # can pull bytes back, then bail out before any DB write. Reads only
+    # the first ~64 KB and SIGTERMs curl — enough to confirm the URL
+    # serves bytes, gzip magic is right, and the FIFO machinery works.
+    echo "[$(date -u +%H:%M:%SZ)] REBUILD_SMOKE=1 — validating curl→FIFO handshake"
+    curl -fL --max-time 30 \
+        -o "$WORK_DIR/releases.xml.gz" \
+        "$url" &
+    CURL_PID=$!
+    head_bytes=$(head -c 65536 "$WORK_DIR/releases.xml.gz" | wc -c)
+    # head closing its read end gives curl a SIGPIPE; reap.
+    wait "$CURL_PID" 2>/dev/null || true
+    if [ "$head_bytes" -lt 1024 ]; then
+        echo "::error:: smoke mode read only ${head_bytes} bytes from the FIFO" >&2
+        exit 1
+    fi
+    echo "    smoke OK: read ${head_bytes} bytes from the streamed dump"
+    notify_slack ":mag:" "smoke test passed (no DB write performed)"
+    exit 0
+fi
+
 echo "[$(date -u +%H:%M:%SZ)] start streaming download → pipeline"
 curl -fL --retry 3 --retry-delay 30 \
     -o "$WORK_DIR/releases.xml.gz" \


### PR DESCRIPTION
## Summary

`REBUILD_SMOKE=1 /opt/discogs-etl/scripts/rebuild-cache.sh` runs everything that can fail at host setup time and exits before any write to Railway prod. Useful for validating a fresh EC2 setup, or re-validating after a host upgrade / password rotation, without burning a real rebuild.

## What it exercises

- Env file readability + secret presence
- `gh` auth scope on `WXYC/library-metadata-lookup`
- `git fetch + reset --hard` for both discogs-etl and discogs-xml-converter
- venv refresh (`pip install -e ".[dev]"`)
- cargo build of the converter
- `gh release download streaming-data-v1 --pattern library.db`
- Dump URL resolution with the previous-month fallback
- FIFO + curl handshake — reads ~64 KB through the named pipe, asserts the byte count is plausible, then SIGPIPEs curl

Posts to Slack as `:mag: smoke test passed (no DB write performed)` on success. Total runtime ~3-5 min (most of it cargo + curl warm-up).

## Where it stops

Right before `python run_pipeline.py`. So the alembic stamp guard, the import to Railway, the dedup, the verify_cache, and the drift watchdog are all skipped.

## Runbook updates

- New step 6 in `docs/ec2-rebuild-runbook.md` walks through the smoke run before step 7 (the real manual rebuild).
- New "Smoke mode" entry in the Recurring Operations section for re-validating after host changes.
- Fixed the env file permission guidance: locking to `600 root:root` made cron (running as `ec2-user`) unable to source it. New recipe is `640 root:ec2-user`, with a note that running cron as root is the alternative.

## Validation

- `shellcheck scripts/rebuild-cache.sh` clean
- `bash -n scripts/rebuild-cache.sh` clean
- Real validation is operator-side — first time you run it on EC2 with `REBUILD_SMOKE=1` will exercise it