### PR TITLE
docs(runbook): gh CLI needs an extra repo on AL2023

### DIFF
--- a/docs/ec2-rebuild-runbook.md
+++ b/docs/ec2-rebuild-runbook.md
@@ -43,7 +43,10 @@ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
     | sh -s -- -y --default-toolchain stable
 source "$HOME/.cargo/env"
 
-# GitHub CLI for `gh release download`
+# GitHub CLI for `gh release download` — not in the AL2023 default repo,
+# so add the upstream cli.github.com repo first.
+sudo dnf install -y 'dnf-command(config-manager)'
+sudo dnf config-manager addrepo --from-repofile=https://cli.github.com/packages/rpm/gh-cli.repo
 sudo dnf install -y gh
 ```
 


### PR DESCRIPTION
Doc-only fix. `dnf install gh` finds nothing in the AL2023 default repo. Adds `dnf config-manager addrepo --from-repofile=https://cli.github.com/packages/rpm/gh-cli.repo` to step 1.