### PR TITLE
WX-2.3.3: Migrate to wxyc-etl 0.2.0 charter forms (test-only callsite)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ dependencies = [
     "psycopg[binary]>=3.1.0",
     "asyncpg>=0.29.0",
     "rapidfuzz>=3.0.0",
-    "wxyc-etl>=0.1.0",
+    "wxyc-etl>=0.2.0",
     "wxyc-catalog>=0.1.1",
     "sentry-sdk>=2.0",
 ]

--- a/tests/unit/test_wxyc_etl_parity.py
+++ b/tests/unit/test_wxyc_etl_parity.py
@@ -3,6 +3,16 @@
 These tests ensure behavioral parity between the deleted lib/matching.py,
 lib/artist_splitting.py, and lib/pipeline_state.py and their replacements in
 the wxyc-etl package (Rust/PyO3).
+
+Note: as of wxyc-etl 0.2.0 the legacy normalizer (`normalize_artist_name`,
+`strip_diacritics`, `normalize_title`, `batch_normalize`) is deprecated in favor
+of the WX-2 Normalizer Charter forms (`to_match_form`, `to_storage_form`,
+`to_ascii_form`). These tests intentionally exercise the legacy normalizer to
+verify parity with the old `lib/matching.py:normalize_artist()` until WX-4.1.1
+removes the legacy API. The DeprecationWarnings are silenced module-wide so the
+parity suite stays a regression net rather than turning CI yellow. The parallel
+charter-vs-legacy parity test below documents whether the new and old forms
+agree on the same input matrix.
 """
 
 from __future__ import annotations
@@ -16,7 +26,10 @@ from wxyc_etl.text import (
     normalize_artist_name,
     split_artist_name,
     split_artist_name_contextual,
+    to_match_form,
 )
+
+pytestmark = pytest.mark.filterwarnings("ignore::DeprecationWarning")
 
 # ---------------------------------------------------------------------------
 # is_compilation_artist (was lib/matching.py)
@@ -83,6 +96,52 @@ class TestNormalizeArtistNameParity:
 
     def test_none_returns_empty(self) -> None:
         assert normalize_artist_name(None) == ""
+
+
+# ---------------------------------------------------------------------------
+# Charter parity: to_match_form vs legacy normalize_artist_name
+# ---------------------------------------------------------------------------
+#
+# WX-2 Normalizer Charter migration. The legacy `normalize_artist_name` will be
+# removed by WX-4.1.1; this test surfaces any behavioral drift between the
+# legacy form and the charter `to_match_form` over the same input matrix the
+# old `lib/matching.py:normalize_artist()` was characterized against. As long
+# as both forms agree, downstream consumers that still call the legacy API can
+# be migrated mechanically. If they diverge, this test fails loudly and the
+# diff has to be triaged before bumping wxyc-etl.
+
+
+class TestToMatchFormParityWithLegacy:
+    """Charter `to_match_form` matches legacy `normalize_artist_name` on the
+    same input matrix as `TestNormalizeArtistNameParity`."""
+
+    @pytest.mark.parametrize(
+        "input_name, expected",
+        [
+            ("Duke Ellington", "duke ellington"),
+            ("STEREOLAB", "stereolab"),
+            ("Nilüfer Yanya", "nilufer yanya"),
+            ("  Cat Power  ", "cat power"),
+            ("Chuquimamani-Condori", "chuquimamani-condori"),
+        ],
+        ids=["lowercase", "all-caps", "diacritics", "whitespace", "hyphen"],
+    )
+    def test_to_match_form_matches_legacy(self, input_name: str, expected: str) -> None:
+        # Charter form produces the same output as legacy form...
+        assert to_match_form(input_name) == expected
+        # ...and they agree element-wise on this input matrix.
+        assert to_match_form(input_name) == normalize_artist_name(input_name)
+
+    def test_none_handling_diverges(self) -> None:
+        """Documented divergence: legacy returns '' for None, charter raises.
+
+        Callers migrating from the legacy API must guard `None` themselves
+        (e.g. `to_match_form(name or "")`) — the charter form treats `None` as
+        a programmer error rather than silently coercing to empty string.
+        """
+        assert normalize_artist_name(None) == ""
+        with pytest.raises(TypeError):
+            to_match_form(None)  # type: ignore[arg-type]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #152.

## Summary

Bumps `wxyc-etl` to `>=0.2.0` and adapts the lone deprecated callsite in this repo (`tests/unit/test_wxyc_etl_parity.py`).

## Strategy: silence + parallel parity

The deprecated functions (`normalize_artist_name`, `strip_diacritics`, `normalize_title`, `batch_normalize`) are exercised by exactly one file — the parity test suite that pins behavior of the legacy normalizer. The recommended approach (per the ticket) is to keep those tests as the regression net for the legacy path until WX-4.1.1 deletes the legacy API, while adding a parallel test that asserts the new charter form (`to_match_form`) matches the legacy form on the same input matrix. That way any future divergence between the two surfaces immediately rather than as a silent behavior change.

Concretely:

1. `pyproject.toml`: `wxyc-etl>=0.1.0` → `wxyc-etl>=0.2.0`.
2. `tests/unit/test_wxyc_etl_parity.py`:
   - Module-level `pytestmark = pytest.mark.filterwarnings(\"ignore::DeprecationWarning\")` so the legacy parity tests don't turn CI yellow. Added a docstring note explaining why the warning is silenced and when it will be removed (WX-4.1.1).
   - New `TestToMatchFormParityWithLegacy` class. For the same 5 input cases as the existing `TestNormalizeArtistNameParity`, asserts `to_match_form(input) == normalize_artist_name(input)` and that both equal the expected value. This catches future drift between charter and legacy forms.
   - One documented divergence: `normalize_artist_name(None)` returns `\"\"`; `to_match_form(None)` raises `TypeError`. Captured in `test_none_handling_diverges` so callers migrating off the legacy API know to guard `None` themselves.

## Acceptance criteria

- [x] `pyproject.toml` pins `wxyc-etl>=0.2.0`.
- [x] No production callsite of the deprecated functions (test files OK; verified via `grep -rE 'wxyc_etl(\\.text)?\\b.*(normalize_artist_name|strip_diacritics|normalize_title|batch_normalize)' --include='*.py'` — only `tests/unit/test_wxyc_etl_parity.py` matches).
- [x] `pytest tests/unit/ -v -W error::DeprecationWarning` passes (650 passed, 3 deselected, 1 xfailed). The pytestmark scopes the warning silence to just the parity file.
- [x] New-API parity test added covering the same input matrix as the legacy one.

## Test plan

- [x] `pytest tests/unit/ -v -W error::DeprecationWarning` (local, green)
- [x] `ruff check .` and `ruff format --check .` (local, green)
- [ ] CI: lint, test, pg, marker-sync