### PR TITLE
docs(ec2-rebuild-runbook): use AL2023 dnf config-manager syntax for gh repo

### DIFF
--- a/docs/ec2-rebuild-runbook.md
+++ b/docs/ec2-rebuild-runbook.md
@@ -46,7 +46,7 @@ source "$HOME/.cargo/env"
 # GitHub CLI for `gh release download` — not in the AL2023 default repo,
 # so add the upstream cli.github.com repo first.
 sudo dnf install -y 'dnf-command(config-manager)'
-sudo dnf config-manager addrepo --from-repofile=https://cli.github.com/packages/rpm/gh-cli.repo
+sudo dnf config-manager --add-repo https://cli.github.com/packages/rpm/gh-cli.repo
 sudo dnf install -y gh
 ```
 


### PR DESCRIPTION
## Summary
- The previous `dnf config-manager addrepo --from-repofile=...` invocation is the newer dnf5 syntax. Amazon Linux 2023 ships dnf4, where the equivalent flag is `--add-repo <URL>`. Operator hit \`unrecognized arguments: --from-repofile=...\` during fresh setup.
- One-line fix to the runbook so the next operator's gh CLI install works on first try.

## Test plan
- [x] Verified the corrected command on a fresh AL2023 host: `sudo dnf config-manager --add-repo https://cli.github.com/packages/rpm/gh-cli.repo` adds the repo, then `sudo dnf install -y gh` succeeds.