### PR TITLE
ops(rebuild-cache): default lock file under $LOG_DIR

### DIFF
--- a/scripts/rebuild-cache.sh
+++ b/scripts/rebuild-cache.sh
@@ -42,7 +42,7 @@ exec > >(tee -a "$LOG_FILE") 2>&1
 # Single-instance lock. Two cron ticks landing on a still-running rebuild
 # would clobber each other's COPY work.
 LOCK_FD=200
-LOCK_FILE="/var/run/discogs-rebuild.lock"
+LOCK_FILE="${LOCK_FILE:-$LOG_DIR/discogs-rebuild.lock}"
 exec 200>"$LOCK_FILE"
 if ! flock -n "$LOCK_FD"; then
     echo "[$(date -u +%H:%M:%SZ)] another rebuild is already running; exiting"


### PR DESCRIPTION
## Summary
- The script's flock lock at \`/var/run/discogs-rebuild.lock\` is only writable by root, but the runbook recommends running cron as \`ec2-user\`. First-time operator hit \`Permission denied\` running smoke mode.
- Default the lock under \`\$LOG_DIR\` (already owned by the cron user from setup step 5) and keep it overridable via \`LOCK_FILE\`. Root cron users can still set \`LOCK_FILE=/var/run/...\`.

## Test plan
- [x] Smoke test now reaches the actual setup steps instead of failing at the flock acquire.