### PR TITLE
ops(rebuild-cache): pre-build library_artists.txt outside FIFO timing window

### DIFF
--- a/scripts/rebuild-cache.sh
+++ b/scripts/rebuild-cache.sh
@@ -149,6 +149,17 @@ if [ "${REBUILD_SMOKE:-}" = "1" ]; then
     exit 0
 fi
 
+# Pre-build library_artists.txt OUTSIDE the FIFO timing window. The Linux
+# pipe buffer is ~64 KB; if the pipeline does any pre-converter work (the
+# enrich step takes ~3 minutes), curl fills the buffer in <1s, blocks waiting
+# for a reader, and Cloudflare drops the idle TCP connection. Running enrich
+# here means the converter opens the FIFO seconds after curl starts.
+echo "[$(date -u +%H:%M:%SZ)] pre-build library_artists.txt (skips in-pipeline enrich)"
+wxyc-enrich-library-artists \
+    --library-db "$WORK_DIR/library.db" \
+    --output "$WORK_DIR/library_artists.txt"
+echo "    library_artists: $(wc -l < "$WORK_DIR/library_artists.txt") names"
+
 echo "[$(date -u +%H:%M:%SZ)] start streaming download → pipeline"
 curl -fL --retry 3 --retry-delay 30 \
     -o "$WORK_DIR/releases.xml.gz" \
@@ -157,6 +168,7 @@ CURL_PID=$!
 
 python "$REPO_DIR/scripts/run_pipeline.py" \
     --xml "$WORK_DIR/releases.xml.gz" \
+    --library-artists "$WORK_DIR/library_artists.txt" \
     --library-db "$WORK_DIR/library.db" \
     --pair-filter
 

--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -742,7 +742,11 @@ def _run_xml_pipeline(
     def _run_with_dirs(tmp_dir: Path, csv_out: Path) -> None:
         # -- enrich_artists
         library_artists_path = args.library_artists
-        if args.library_db:
+        if args.library_db and not args.library_artists:
+            # Operator did not pre-supply library_artists.txt — derive it from
+            # library.db. Pre-supplying lets the EC2 wrapper run enrich outside
+            # the FIFO timing window so curl→FIFO has an immediate reader and
+            # Cloudflare doesn't drop the connection during a 3+ minute enrich.
             enriched_artists = tmp_dir / "library_artists.txt"
             enrich_library_artists(
                 args.library_db,

--- a/tests/unit/test_run_pipeline.py
+++ b/tests/unit/test_run_pipeline.py
@@ -614,6 +614,54 @@ class TestXmlModeEnrichment:
             "library_artists path should be passed to convert_and_filter"
         )
 
+    def test_enrich_skipped_when_library_artists_explicit(self, tmp_path) -> None:
+        """When --library-artists is provided alongside --library-db, the pipeline
+        must skip enrich_library_artists and pass the operator-supplied file straight
+        to the converter. This lets the EC2 wrapper pre-build library_artists.txt
+        outside the FIFO timing window so curl→FIFO has an immediate reader."""
+        xml_file = tmp_path / "releases.xml.gz"
+        xml_file.touch()
+        library_db = tmp_path / "library.db"
+        library_db.touch()
+        prebuilt_artists = tmp_path / "library_artists.txt"
+        prebuilt_artists.write_text("Juana Molina\nStereolab\n")
+
+        args = run_pipeline.parse_args(
+            [
+                "--xml",
+                str(xml_file),
+                "--library-db",
+                str(library_db),
+                "--library-artists",
+                str(prebuilt_artists),
+            ]
+        )
+
+        enrich_calls = []
+        convert_calls = []
+
+        def fake_enrich(lib_db, output, wxyc_db_url=None, catalog_source=None, catalog_db_url=None):
+            enrich_calls.append((lib_db, output))
+
+        def fake_convert(xml, output_dir, converter, library_artists=None):
+            convert_calls.append((xml, output_dir, converter, library_artists))
+
+        with (
+            patch.object(run_pipeline, "enrich_library_artists", side_effect=fake_enrich),
+            patch.object(run_pipeline, "convert_and_filter", side_effect=fake_convert),
+            patch.object(run_pipeline, "_run_database_build"),
+            patch.object(run_pipeline, "parse_args", return_value=args),
+        ):
+            run_pipeline.main()
+
+        assert enrich_calls == [], (
+            "enrich must be skipped when the operator pre-supplies library_artists.txt"
+        )
+        assert len(convert_calls) == 1
+        assert convert_calls[0][3] == prebuilt_artists, (
+            "the operator-supplied artist list must be passed through to the converter"
+        )
+
 
 # ---------------------------------------------------------------------------
 # wait_for_postgres


### PR DESCRIPTION
## Summary
- The first manual EC2 rebuild died at the curl/FIFO handoff: curl wrote 69756 bytes (one ~64 KB pipe buffer) in <1 second, then blocked for 3:39 while \`run_pipeline.py\`'s enrich step (~3 minutes) ran without ever reading the FIFO. Cloudflare dropped the idle TCP connection and curl exited with code 23. The converter then started, opened the FIFO, and got an EOF instead of a 10.2 GB stream.
- Fix in two parts:
  1. \`run_pipeline.py\`: when \`--library-artists\` is provided alongside \`--library-db\`, skip enrich and treat the operator-supplied file as authoritative. The combined-flag case was previously silently overridden by enrich; now it's a supported pre-built path.
  2. \`scripts/rebuild-cache.sh\`: invoke \`wxyc-enrich-library-artists\` directly before the curl/FIFO/pipeline starts, pass the result via \`--library-artists\`. Converter now opens the FIFO seconds (not minutes) after curl starts.

## Test plan
- [x] New unit test: \`test_enrich_skipped_when_library_artists_explicit\` — fails on main, passes with the fix.
- [x] Pre-existing test \`test_enrich_called_with_library_db_only\` still passes (default behavior unchanged when only \`--library-db\` is given).
- [x] \`shellcheck\` + \`bash -n\` clean on the wrapper.
- [ ] Real EC2 manual rebuild after merge.