### PR TITLE
ops(rebuild-cache): spool dump to disk instead of FIFO-streaming

### DIFF
--- a/docs/ec2-rebuild-runbook.md
+++ b/docs/ec2-rebuild-runbook.md
@@ -112,9 +112,10 @@ sudo chown ec2-user:ec2-user /var/log/discogs-rebuild
 
 `REBUILD_SMOKE=1` runs everything that can fail at host setup time —
 git pulls, venv refresh, cargo build, gh release download, dump URL
-resolution, FIFO + curl handshake — and exits 0 *before* writing anything
-to `$DATABASE_URL_DISCOGS`. Run this first so you can fix any host-side
-issue without touching prod:
+resolution, range-byte fetch, and disk-headroom check — and exits 0
+*before* writing anything to `$DATABASE_URL_DISCOGS` or downloading the
+full ~10 GB dump. Run this first so you can fix any host-side issue
+without touching prod:
 
 ```bash
 sudo -u ec2-user bash -c '
@@ -123,9 +124,9 @@ sudo -u ec2-user bash -c '
 '
 ```
 
-Expected: ~3-5 min, ends with `smoke OK: read NNNNN bytes from the
-streamed dump` and (if configured) a `🔍 smoke test passed (no DB
-write performed)` Slack message.
+Expected: ~30 seconds, ends with `smoke OK: read NNNNN bytes from URL;
+NN GB free at $WORK_DIR` and (if configured) a `🔍 smoke test passed
+(no DB write performed)` Slack message.
 
 ### 7. Test the full rebuild manually before scheduling
 

--- a/scripts/rebuild-cache.sh
+++ b/scripts/rebuild-cache.sh
@@ -123,60 +123,66 @@ fi
 echo "    dump URL: $url"
 
 # ---------------------------------------------------------------------------
-# 5. Stream dump into converter via FIFO + run pipeline
+# 5. Spool dump to disk, then run pipeline against the on-disk file
 # ---------------------------------------------------------------------------
-mkfifo "$WORK_DIR/releases.xml.gz"
+# History: an earlier version of this wrapper streamed the dump through a
+# named pipe (mkfifo + curl -o FIFO &). The intent was to avoid materialising
+# ~10 GB of compressed XML on disk. In practice that produced two distinct
+# failure modes on EC2 (2026-05-06):
+#   1. Pipeline pre-work blocked the FIFO for minutes while the 64 KB pipe
+#      buffer filled, Cloudflare timed out the idle TCP connection.
+#   2. Even with the pre-work moved out, curl would fail with `curl: (23)
+#      Failure writing output to destination` within seconds of the converter
+#      opening the FIFO — the converter's read pattern (multi-threaded rayon
+#      workers, gzip header probe before bulk read) interacted poorly with
+#      curl's buffered fwrite to the FIFO.
+# Spool-to-disk decouples network I/O from converter timing entirely. The
+# Backend-Service EC2 host has ~14 GB free; the dump is ~10.2 GB compressed.
+# After the converter consumes it the spooled file is removed via the EXIT
+# trap.
 
 if [ "${REBUILD_SMOKE:-}" = "1" ]; then
-    # Smoke mode: prove that curl can write into the FIFO and a reader
-    # can pull bytes back, then bail out before any DB write. Reads only
-    # the first ~64 KB and SIGTERMs curl — enough to confirm the URL
-    # serves bytes, gzip magic is right, and the FIFO machinery works.
-    echo "[$(date -u +%H:%M:%SZ)] REBUILD_SMOKE=1 — validating curl→FIFO handshake"
-    curl -fL --max-time 30 \
-        -o "$WORK_DIR/releases.xml.gz" \
-        "$url" &
-    CURL_PID=$!
-    head_bytes=$(head -c 65536 "$WORK_DIR/releases.xml.gz" | wc -c)
-    # head closing its read end gives curl a SIGPIPE; reap.
-    wait "$CURL_PID" 2>/dev/null || true
+    # Smoke mode: prove the URL serves bytes and the local disk has headroom
+    # for the dump, then bail out before any DB write or full download. The
+    # range-byte fetch is enough to confirm DNS, TLS, Cloudflare reachability,
+    # and the gzip magic on the first 64 KB of the resource.
+    echo "[$(date -u +%H:%M:%SZ)] REBUILD_SMOKE=1 — validating dump URL + disk headroom"
+    head_bytes=$(curl -fL --max-time 30 -r 0-65535 "$url" -o - | wc -c)
     if [ "$head_bytes" -lt 1024 ]; then
-        echo "::error:: smoke mode read only ${head_bytes} bytes from the FIFO" >&2
+        echo "::error:: smoke mode read only ${head_bytes} bytes from $url" >&2
         exit 1
     fi
-    echo "    smoke OK: read ${head_bytes} bytes from the streamed dump"
+    avail_kb=$(df --output=avail "$WORK_DIR" | tail -n1)
+    avail_gb=$(( avail_kb / 1024 / 1024 ))
+    if [ "$avail_gb" -lt 12 ]; then
+        echo "::error:: smoke mode: only ${avail_gb} GB free at $WORK_DIR (need ~12+ GB for the dump)" >&2
+        exit 1
+    fi
+    echo "    smoke OK: read ${head_bytes} bytes from URL; ${avail_gb} GB free at \$WORK_DIR"
     notify_slack ":mag:" "smoke test passed (no DB write performed)"
     exit 0
 fi
 
-# Pre-build library_artists.txt OUTSIDE the FIFO timing window. The Linux
-# pipe buffer is ~64 KB; if the pipeline does any pre-converter work (the
-# enrich step takes ~3 minutes), curl fills the buffer in <1s, blocks waiting
-# for a reader, and Cloudflare drops the idle TCP connection. Running enrich
-# here means the converter opens the FIFO seconds after curl starts.
+# Pre-build library_artists.txt before the long-running download so that
+# the converter doesn't have to wait on enrich after the dump arrives.
 echo "[$(date -u +%H:%M:%SZ)] pre-build library_artists.txt (skips in-pipeline enrich)"
 wxyc-enrich-library-artists \
     --library-db "$WORK_DIR/library.db" \
     --output "$WORK_DIR/library_artists.txt"
 echo "    library_artists: $(wc -l < "$WORK_DIR/library_artists.txt") names"
 
-echo "[$(date -u +%H:%M:%SZ)] start streaming download → pipeline"
+echo "[$(date -u +%H:%M:%SZ)] download Discogs dump to $WORK_DIR/releases.xml.gz"
 curl -fL --retry 3 --retry-delay 30 \
     -o "$WORK_DIR/releases.xml.gz" \
-    "$url" &
-CURL_PID=$!
+    "$url"
+echo "    dump size: $(du -h "$WORK_DIR/releases.xml.gz" | cut -f1)"
 
+echo "[$(date -u +%H:%M:%SZ)] run pipeline against on-disk dump"
 python "$REPO_DIR/scripts/run_pipeline.py" \
     --xml "$WORK_DIR/releases.xml.gz" \
     --library-artists "$WORK_DIR/library_artists.txt" \
     --library-db "$WORK_DIR/library.db" \
     --pair-filter
-
-# Curl is normally already done by here (the pipeline blocks reading the FIFO
-# until EOF, which only arrives when curl finishes). The wait surfaces a
-# non-zero curl exit so a streaming network failure isn't masked by the
-# pipeline succeeding on partial input.
-wait "$CURL_PID"
 
 # ---------------------------------------------------------------------------
 # 6. Drift watchdog — same library.db the pipeline just filtered against


### PR DESCRIPTION
## Summary
- The FIFO architecture failed twice on EC2 today (2026-05-06):
  1. With \`run_pipeline.py\` enrich running before the converter, curl was blocked by a full 64 KB pipe buffer for 3:39 — Cloudflare timed out the idle TCP connection.
  2. After moving enrich into the wrapper (PR #156), curl still failed with \`curl: (23) Failure writing output to destination\` within seconds of the converter opening the FIFO. The converter's multi-threaded rayon workers + gzip header probe interact poorly with curl's buffered fwrite to a named pipe.
- Pivot to spool-to-disk: curl writes ~10 GB to the work tempdir, then \`run_pipeline.py\` reads from the on-disk file. Decouples network I/O from converter timing entirely.
- Backend-Service EC2 has ~14 GB free; dump is ~10.2 GB compressed. Smoke mode now does a 64 KB range-byte fetch + disk-headroom assertion (\`avail_gb >= 12\`) instead of probing FIFO machinery.

## Test plan
- [x] \`shellcheck\` + \`bash -n\` clean.
- [ ] EC2 smoke run.
- [ ] EC2 full rebuild — the actual proof.