### PR TITLE
ops(rebuild-cache): restore FIFO architecture using converter --xml-type

### DIFF
--- a/scripts/rebuild-cache.sh
+++ b/scripts/rebuild-cache.sh
@@ -123,66 +123,72 @@ fi
 echo "    dump URL: $url"
 
 # ---------------------------------------------------------------------------
-# 5. Spool dump to disk, then run pipeline against the on-disk file
+# 5. Stream dump into converter via FIFO + run pipeline
 # ---------------------------------------------------------------------------
-# History: an earlier version of this wrapper streamed the dump through a
-# named pipe (mkfifo + curl -o FIFO &). The intent was to avoid materialising
-# ~10 GB of compressed XML on disk. In practice that produced two distinct
-# failure modes on EC2 (2026-05-06):
-#   1. Pipeline pre-work blocked the FIFO for minutes while the 64 KB pipe
-#      buffer filled, Cloudflare timed out the idle TCP connection.
-#   2. Even with the pre-work moved out, curl would fail with `curl: (23)
-#      Failure writing output to destination` within seconds of the converter
-#      opening the FIFO — the converter's read pattern (multi-threaded rayon
-#      workers, gzip header probe before bulk read) interacted poorly with
-#      curl's buffered fwrite to the FIFO.
-# Spool-to-disk decouples network I/O from converter timing entirely. The
-# Backend-Service EC2 host has ~14 GB free; the dump is ~10.2 GB compressed.
-# After the converter consumes it the spooled file is removed via the EXIT
-# trap.
+# Backend-Service EC2 only has ~14 GB free, so we cannot spool the ~10 GB
+# compressed dump to disk alongside the ~5–10 GB of intermediate filtered
+# CSVs the converter writes. Instead we stream curl through a named pipe
+# directly into the converter.
+#
+# Two prerequisites make this safe:
+#   1. library_artists.txt is pre-built BEFORE the curl-to-FIFO setup so
+#      enrich (~3 minutes) does not block the FIFO buffer and timeout
+#      Cloudflare's TCP idle.
+#   2. run_pipeline.py forwards --xml-type=releases to discogs-xml-converter,
+#      which skips the per-file root-element auto-detection that would
+#      otherwise open-and-close the FIFO once before the real scan,
+#      SIGPIPE-killing the upstream curl.
+# Both are required; either alone fails on EC2 (verified 2026-05-06).
 
 if [ "${REBUILD_SMOKE:-}" = "1" ]; then
-    # Smoke mode: prove the URL serves bytes and the local disk has headroom
-    # for the dump, then bail out before any DB write or full download. The
-    # range-byte fetch is enough to confirm DNS, TLS, Cloudflare reachability,
-    # and the gzip magic on the first 64 KB of the resource.
-    echo "[$(date -u +%H:%M:%SZ)] REBUILD_SMOKE=1 — validating dump URL + disk headroom"
-    head_bytes=$(curl -fL --max-time 30 -r 0-65535 "$url" -o - | wc -c)
+    # Smoke mode validates the URL is reachable and the FIFO machinery works.
+    # We read only ~64 KB from the FIFO, which is enough to confirm DNS, TLS,
+    # Cloudflare reachability, and the gzip magic in the first chunk. head
+    # closing its read end gives curl a SIGPIPE, which we silence.
+    echo "[$(date -u +%H:%M:%SZ)] REBUILD_SMOKE=1 — validating curl→FIFO handshake"
+    mkfifo "$WORK_DIR/releases.xml.gz"
+    curl -fL --max-time 30 \
+        -o "$WORK_DIR/releases.xml.gz" \
+        "$url" &
+    CURL_PID=$!
+    head_bytes=$(head -c 65536 "$WORK_DIR/releases.xml.gz" | wc -c)
+    wait "$CURL_PID" 2>/dev/null || true
     if [ "$head_bytes" -lt 1024 ]; then
-        echo "::error:: smoke mode read only ${head_bytes} bytes from $url" >&2
+        echo "::error:: smoke mode read only ${head_bytes} bytes from the FIFO" >&2
         exit 1
     fi
-    avail_kb=$(df --output=avail "$WORK_DIR" | tail -n1)
-    avail_gb=$(( avail_kb / 1024 / 1024 ))
-    if [ "$avail_gb" -lt 12 ]; then
-        echo "::error:: smoke mode: only ${avail_gb} GB free at $WORK_DIR (need ~12+ GB for the dump)" >&2
-        exit 1
-    fi
-    echo "    smoke OK: read ${head_bytes} bytes from URL; ${avail_gb} GB free at \$WORK_DIR"
+    echo "    smoke OK: read ${head_bytes} bytes from the streamed dump"
     notify_slack ":mag:" "smoke test passed (no DB write performed)"
     exit 0
 fi
 
-# Pre-build library_artists.txt before the long-running download so that
-# the converter doesn't have to wait on enrich after the dump arrives.
+# Pre-build library_artists.txt OUTSIDE the curl/FIFO timing window so the
+# converter has no slow pre-work to do once curl starts writing.
 echo "[$(date -u +%H:%M:%SZ)] pre-build library_artists.txt (skips in-pipeline enrich)"
 wxyc-enrich-library-artists \
     --library-db "$WORK_DIR/library.db" \
     --output "$WORK_DIR/library_artists.txt"
 echo "    library_artists: $(wc -l < "$WORK_DIR/library_artists.txt") names"
 
-echo "[$(date -u +%H:%M:%SZ)] download Discogs dump to $WORK_DIR/releases.xml.gz"
+mkfifo "$WORK_DIR/releases.xml.gz"
+
+echo "[$(date -u +%H:%M:%SZ)] start streaming download → pipeline"
 curl -fL --retry 3 --retry-delay 30 \
     -o "$WORK_DIR/releases.xml.gz" \
-    "$url"
-echo "    dump size: $(du -h "$WORK_DIR/releases.xml.gz" | cut -f1)"
+    "$url" &
+CURL_PID=$!
 
-echo "[$(date -u +%H:%M:%SZ)] run pipeline against on-disk dump"
 python "$REPO_DIR/scripts/run_pipeline.py" \
     --xml "$WORK_DIR/releases.xml.gz" \
+    --xml-type releases \
     --library-artists "$WORK_DIR/library_artists.txt" \
     --library-db "$WORK_DIR/library.db" \
     --pair-filter
+
+# Curl is normally already done by here. Wait surfaces any non-zero curl exit
+# so a streaming network failure isn't masked by the pipeline succeeding on
+# partial input.
+wait "$CURL_PID"
 
 # ---------------------------------------------------------------------------
 # 6. Drift watchdog — same library.db the pipeline just filtered against

--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -147,6 +147,15 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "Used with --xml to filter during conversion.",
     )
     parser.add_argument(
+        "--xml-type",
+        choices=["releases", "artists", "labels", "masters"],
+        default=None,
+        help="Forwarded to discogs-xml-converter --xml-type. Skips per-file "
+        "root-element auto-detection. Required when --xml points at a FIFO "
+        "(named pipe) — auto-detection's open/close cycle would SIGPIPE the "
+        "upstream writer before the real scan starts.",
+    )
+    parser.add_argument(
         "--library-db",
         type=Path,
         metavar="FILE",
@@ -527,6 +536,7 @@ def convert_and_filter(
     converter: str,
     library_artists: Path | None = None,
     database_url: str | None = None,
+    xml_type: str | None = None,
 ) -> None:
     """Convert Discogs XML to CSV using discogs-xml-converter.
 
@@ -537,16 +547,20 @@ def convert_and_filter(
     PostgreSQL via COPY (`import` subcommand) instead of being written to
     CSV files (`build` subcommand). Supplementary CSVs (artist_alias.csv,
     label_hierarchy.csv) are still written to output_dir in either mode.
+
+    xml_type, when set, skips the converter's per-file root-element
+    auto-detection. Required for FIFO inputs (the rebuild-cache.sh
+    monthly path) where the auto-detect open/close pattern would
+    SIGPIPE the upstream curl writer before the real scan opens the file.
     """
-    # Converter CLI uses clap subcommands (`build` for CSV output, `import`
-    # for direct-to-PG). The old positional invocation surfaces as an
-    # `unrecognized subcommand` error against current main.
     subcommand = "import" if database_url else "build"
     cmd = [converter, subcommand, str(xml_file), "--data-dir", str(output_dir)]
     if library_artists:
         cmd.extend(["--library-artists", str(library_artists)])
     if database_url:
         cmd.extend(["--database-url", database_url])
+    if xml_type:
+        cmd.extend(["--xml-type", xml_type])
     description = (
         "Convert and import XML to PostgreSQL" if database_url else "Convert and filter XML to CSV"
     )
@@ -786,6 +800,7 @@ def _run_xml_pipeline(
                 args.converter,
                 library_artists_path,
                 database_url=db_url,
+                xml_type=args.xml_type,
             )
 
             # Auto-detect label_hierarchy.csv
@@ -810,7 +825,13 @@ def _run_xml_pipeline(
             )
         else:
             # Standard CSV mode
-            convert_and_filter(args.xml, csv_out, args.converter, library_artists_path)
+            convert_and_filter(
+                args.xml,
+                csv_out,
+                args.converter,
+                library_artists_path,
+                xml_type=args.xml_type,
+            )
 
             # Pair-wise filter narrows ~4M release rows to ~50K so the
             # downstream import fits on a small destination DB. In-place

--- a/tests/unit/test_run_pipeline.py
+++ b/tests/unit/test_run_pipeline.py
@@ -543,7 +543,7 @@ class TestDirectPgUnloggedBeforeConverter:
         def track_set_unlogged(db_url):
             call_order.append("set_tables_unlogged")
 
-        def track_convert(xml, output_dir, converter, library_artists=None, database_url=None):
+        def track_convert(xml, output_dir, converter, library_artists=None, database_url=None, **kwargs):
             call_order.append("convert_and_filter")
 
         with (
@@ -596,7 +596,7 @@ class TestXmlModeEnrichment:
         def fake_enrich(lib_db, output, wxyc_db_url=None, catalog_source=None, catalog_db_url=None):
             enrich_calls.append((lib_db, output, catalog_source))
 
-        def fake_convert(xml, output_dir, converter, library_artists=None):
+        def fake_convert(xml, output_dir, converter, library_artists=None, **kwargs):
             convert_calls.append((xml, output_dir, converter, library_artists))
 
         with (
@@ -643,7 +643,7 @@ class TestXmlModeEnrichment:
         def fake_enrich(lib_db, output, wxyc_db_url=None, catalog_source=None, catalog_db_url=None):
             enrich_calls.append((lib_db, output))
 
-        def fake_convert(xml, output_dir, converter, library_artists=None):
+        def fake_convert(xml, output_dir, converter, library_artists=None, **kwargs):
             convert_calls.append((xml, output_dir, converter, library_artists))
 
         with (
@@ -887,6 +887,35 @@ class TestConvertAndFilter:
         assert "--database-url" not in cmd
         description = mock_run.call_args[0][0]
         assert "CSV" in description
+
+    def test_xml_type_forwarded_when_set(self) -> None:
+        """When xml_type is provided, --xml-type is forwarded to the converter
+        so it can skip per-file root-element auto-detection. Required for FIFO
+        inputs where the auto-detect open/close kills the upstream writer."""
+        with patch.object(run_pipeline, "run_step") as mock_run:
+            run_pipeline.convert_and_filter(
+                Path("/data/releases.xml.gz"),
+                Path("/tmp/csv"),
+                "discogs-xml-converter",
+                xml_type="releases",
+            )
+
+        cmd = mock_run.call_args[0][1]
+        assert "--xml-type" in cmd
+        assert "releases" in cmd
+
+    def test_xml_type_omitted_when_not_set(self) -> None:
+        """When xml_type is None, --xml-type is not forwarded; the converter
+        falls back to its default auto-detection."""
+        with patch.object(run_pipeline, "run_step") as mock_run:
+            run_pipeline.convert_and_filter(
+                Path("/data/releases.xml.gz"),
+                Path("/tmp/csv"),
+                "discogs-xml-converter",
+            )
+
+        cmd = mock_run.call_args[0][1]
+        assert "--xml-type" not in cmd
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_run_pipeline.py
+++ b/tests/unit/test_run_pipeline.py
@@ -543,7 +543,9 @@ class TestDirectPgUnloggedBeforeConverter:
         def track_set_unlogged(db_url):
             call_order.append("set_tables_unlogged")
 
-        def track_convert(xml, output_dir, converter, library_artists=None, database_url=None, **kwargs):
+        def track_convert(
+            xml, output_dir, converter, library_artists=None, database_url=None, **kwargs
+        ):
             call_order.append("convert_and_filter")
 
         with (


### PR DESCRIPTION
## Summary
- discogs-xml-converter [PR #44](https://github.com/WXYC/discogs-xml-converter/pull/44) added \`--xml-type\` to bypass per-file root-element auto-detection. That was the root cause of the \`curl: (23)\` failure on the FIFO path: \`detect_xml_type\` opened the FIFO, read the root element, closed, and the close SIGPIPEd the upstream curl before the real scan ever started.
- With \`--xml-type=releases\`, the input is opened exactly once. This PR wires the flag through \`run_pipeline.py\` and switches \`rebuild-cache.sh\` back to a \`mkfifo\` + \`curl -o FIFO &\` + \`python run_pipeline.py --xml FIFO\` pipeline.
- Spool-to-disk (PR #157) is reverted: Backend-Service EC2 only has ~14 GB free; the dump is ~10 GB; the converter's intermediate CSVs need ~5–10 GB; together that exceeds the disk and the previous attempt died with \"No space left on device\" at 2.3M of ~4M releases.

## Test plan
- [x] New unit tests \`test_xml_type_forwarded_when_set\` and \`test_xml_type_omitted_when_not_set\` cover \`convert_and_filter\`'s pass-through behaviour.
- [x] Full \`pytest tests/unit/test_run_pipeline.py\` (77 passed).
- [x] \`shellcheck\` + \`bash -n\` clean on the wrapper.
- [ ] EC2 smoke + real rebuild — the actual proof.