### PR TITLE
import_csv: strip U+0000 at PG TEXT boundary (WX-3.B)

### DIFF
--- a/lib/pg_text.py
+++ b/lib/pg_text.py
@@ -1,0 +1,25 @@
+"""PostgreSQL TEXT boundary helpers.
+
+PostgreSQL's TEXT type rejects U+0000 (psycopg surfaces it as
+``CharacterNotInRepertoireError``). Per the WXYC mojibake-prevention policy
+(WXYC/docs#18), we strip U+0000 at every TEXT write boundary rather than
+rejecting the row. U+0000 in metadata is always corruption, never intent;
+stripping is idempotent and cheap.
+"""
+
+from __future__ import annotations
+
+from typing import TypeVar
+
+T = TypeVar("T")
+
+
+def strip_pg_null_bytes(value: T) -> T:
+    """Return ``value`` with U+0000 removed if it is a string; pass through otherwise.
+
+    Non-string values (None, int, etc.) are returned unchanged so this can be
+    applied uniformly to heterogeneous CSV row tuples.
+    """
+    if isinstance(value, str):
+        return value.replace("\x00", "")  # type: ignore[return-value]
+    return value

--- a/scripts/import_csv.py
+++ b/scripts/import_csv.py
@@ -28,6 +28,7 @@ except ImportError:
 sys.path.insert(0, str(Path(__file__).parent.parent))
 from lib.format_normalization import normalize_format  # noqa: E402
 from lib.observability import init_logger  # noqa: E402
+from lib.pg_text import strip_pg_null_bytes  # noqa: E402
 
 logger = logging.getLogger(__name__)
 
@@ -327,6 +328,10 @@ def import_csv(
                             skip = True
                             break
 
+                        # Strip U+0000 at PG TEXT boundary (WXYC/docs#18 policy).
+                        # PostgreSQL TEXT rejects NUL bytes; stripping is idempotent.
+                        val = strip_pg_null_bytes(val)
+
                         values.append(val)
 
                     if skip:
@@ -492,7 +497,7 @@ def import_artwork(conn, csv_dir: Path) -> int:
 
         with cur.copy("COPY _artwork (release_id, artwork_url) FROM STDIN") as copy:
             for release_id, uri in artwork.items():
-                copy.write_row((release_id, uri))
+                copy.write_row((release_id, strip_pg_null_bytes(uri)))
 
         cur.execute("""
             UPDATE release r
@@ -664,7 +669,7 @@ def import_artist_details(conn, csv_dir: Path) -> int:
                     if artist_id and profile:
                         cur.execute(
                             "UPDATE artist SET profile = %s WHERE id = %s",
-                            (profile, int(artist_id)),
+                            (strip_pg_null_bytes(profile), int(artist_id)),
                         )
                         profile_count += cur.rowcount
         conn.commit()

--- a/tests/integration/test_charset_torture_pg_cache.py
+++ b/tests/integration/test_charset_torture_pg_cache.py
@@ -1,43 +1,41 @@
 """WX-1.2.6 detector: catches future regressions in the PG cache write path
-that would silently corrupt non-ASCII bytes flowing into the discogs-cache."""
+that would silently corrupt non-ASCII bytes flowing into the discogs-cache.
+
+Per WXYC/docs#18 the write path strips U+0000 at the boundary (idempotent;
+NUL in metadata is always corruption). This test mirrors that boundary by
+applying ``strip_pg_null_bytes`` before INSERT and asserting the round-trip
+matches the stripped form.
+"""
 
 from __future__ import annotations
 
 import pytest
 
+from lib.pg_text import strip_pg_null_bytes
 from tests.charset_torture import CharsetTortureEntry, entry_id, iter_entries
 
 CORPUS_ENTRIES = list(iter_entries())
 
-PG_TEXT_XFAIL_INPUTS: dict[tuple[str, str], str] = {
-    ("quoting", "null\x00byte"): (
-        "[dxe:pg-null-byte] PostgreSQL TEXT rejects U+0000 (SQL standard)"
-    ),
-}
-
 
 @pytest.mark.pg
 @pytest.mark.parametrize("entry", CORPUS_ENTRIES, ids=entry_id)
-def test_pg_text_roundtrip(
-    db_conn, entry: CharsetTortureEntry, request: pytest.FixtureRequest
-) -> None:
-    """INSERT into a TEXT column + SELECT must preserve every corpus entry."""
-    xfail_reason = PG_TEXT_XFAIL_INPUTS.get((entry["category"], entry["input"]))
-    if xfail_reason is not None:
-        request.applymarker(pytest.mark.xfail(reason=xfail_reason, strict=True, raises=Exception))
+def test_pg_text_roundtrip(db_conn, entry: CharsetTortureEntry) -> None:
+    """INSERT into a TEXT column + SELECT must preserve every corpus entry
+    after the boundary strip."""
+    boundary_value = strip_pg_null_bytes(entry["input"])
 
     with db_conn.cursor() as cur:
         # Defensive: TEMP TABLEs survive rollbacks; if a future db_conn fixture
         # widens its scope, the next test would fail with "relation already exists".
         cur.execute("DROP TABLE IF EXISTS charset_probe")
         cur.execute("CREATE TEMP TABLE charset_probe (id SERIAL PRIMARY KEY, value TEXT NOT NULL)")
-        cur.execute("INSERT INTO charset_probe (value) VALUES (%s) RETURNING id", (entry["input"],))
+        cur.execute("INSERT INTO charset_probe (value) VALUES (%s) RETURNING id", (boundary_value,))
         row_id = cur.fetchone()[0]
         cur.execute("SELECT value FROM charset_probe WHERE id = %s", (row_id,))
         result = cur.fetchone()
     db_conn.commit()
 
     assert result is not None, f"{entry['category']}: row not found"
-    assert result[0] == entry["input"], (
+    assert result[0] == boundary_value, (
         f"{entry['category']}: round-trip lost bytes ({entry['notes']})"
     )

--- a/tests/unit/test_pg_text.py
+++ b/tests/unit/test_pg_text.py
@@ -1,0 +1,34 @@
+"""Unit tests for lib/pg_text.py."""
+
+from __future__ import annotations
+
+import pytest
+
+from lib.pg_text import strip_pg_null_bytes
+
+
+class TestStripPgNullBytes:
+    """Strip U+0000 from strings; pass other types through unchanged."""
+
+    @pytest.mark.parametrize(
+        "value, expected",
+        [
+            ("null\x00byte", "nullbyte"),
+            ("\x00leading", "leading"),
+            ("trailing\x00", "trailing"),
+            ("\x00\x00both\x00\x00", "both"),
+            ("no nulls here", "no nulls here"),
+            ("", ""),
+        ],
+    )
+    def test_strips_nul_from_strings(self, value: str, expected: str) -> None:
+        assert strip_pg_null_bytes(value) == expected
+
+    @pytest.mark.parametrize("value", [None, 0, 42, 3.14, b"bytes\x00", ("a", "b"), [1, 2]])
+    def test_passes_non_strings_through(self, value: object) -> None:
+        assert strip_pg_null_bytes(value) is value
+
+    def test_idempotent(self) -> None:
+        once = strip_pg_null_bytes("a\x00b\x00c")
+        twice = strip_pg_null_bytes(once)
+        assert once == twice == "abc"


### PR DESCRIPTION
Implements WX-3.B per the [WXYC/docs#18](https://github.com/WXYC/docs/issues/18) ratified policy (option 1, strip at boundary). PostgreSQL TEXT rejects U+0000; psycopg surfaces it as `CharacterNotInRepertoireError`. The strip is idempotent and cheap, and U+0000 in metadata is always corruption never intent.

## Files / callsites changed

- `lib/pg_text.py` (new) — `strip_pg_null_bytes(value)` helper. Returns `value.replace('\x00', '')` for `str`; passes other types through unchanged so it can apply uniformly to heterogeneous CSV row tuples.
- `scripts/import_csv.py`:
  - `import_csv()` value-extraction loop — strips every TEXT-bound field after transforms, before `copy.write_row`.
  - `import_artwork()` — strips `uri` before `copy.write_row` into the `_artwork` temp table.
  - `import_artist_details()` — strips `profile` before the `UPDATE artist SET profile = %s ...`.
- `tests/integration/test_charset_torture_pg_cache.py` — applies `strip_pg_null_bytes` at the simulated write boundary; removed `PG_TEXT_XFAIL_INPUTS` and the xfail-application logic.
- `tests/unit/test_pg_text.py` (new) — 14-case parametrize covering NUL-strip, non-string passthrough, and idempotency.

## Behavior diff

- The `[dxe:pg-null-byte]` strict-xfail entry is removed from `PG_TEXT_XFAIL_INPUTS` (the dict itself is now unused and removed). The corpus's `quoting:null\x00byte` entry now passes the round-trip after the boundary strip — `null\x00byte` -> `nullbyte` round-trips cleanly.
- All 56 previously-passing parametrize cases still pass (57 total now PASS, 0 xfail).
- Default `pytest` run: 631 passed, 18 skipped, 1 xfailed, no regressions (the lone xfail is in an unrelated test file).
- Local pg suite passed cleanly modulo three pre-existing `tests/integration/test_alembic_baseline.py` failures caused by `alembic` missing from the local venv (CI installs `[dev]` and is unaffected).

## Acceptance checklist

- [x] `scripts/import_csv.py:import_csv()` drops U+0000 from every TEXT-bound field before COPY.
- [x] `[dxe:pg-null-byte]` removed from `tests/integration/test_charset_torture_pg_cache.py:PG_TEXT_XFAIL_INPUTS` in the same commit (the entire dict is removed since it had only that entry).
- [x] No regressions on the 56 currently-passing parametrize cases.
- [x] Same fix applied to the two other PG TEXT write boundaries in `import_csv.py` (`import_artwork`, `import_artist_details`).

Closes #144