### PR TITLE
tests: align to_match_form parity test with unified None handling

### DIFF
--- a/tests/unit/test_wxyc_etl_parity.py
+++ b/tests/unit/test_wxyc_etl_parity.py
@@ -132,16 +132,15 @@ class TestToMatchFormParityWithLegacy:
         # ...and they agree element-wise on this input matrix.
         assert to_match_form(input_name) == normalize_artist_name(input_name)
 
-    def test_none_handling_diverges(self) -> None:
-        """Documented divergence: legacy returns '' for None, charter raises.
+    def test_none_handling_agrees(self) -> None:
+        """Charter and legacy both return '' for None as of wxyc-etl 0.2.1.
 
-        Callers migrating from the legacy API must guard `None` themselves
-        (e.g. `to_match_form(name or "")`) — the charter form treats `None` as
-        a programmer error rather than silently coercing to empty string.
+        Earlier 0.2.0 charter forms raised TypeError on None while legacy returned
+        ''. The 0.2.1 PyO3 wrappers accept Option<&str> and return '' on None,
+        unifying the contract — this test guards against regression.
         """
         assert normalize_artist_name(None) == ""
-        with pytest.raises(TypeError):
-            to_match_form(None)  # type: ignore[arg-type]
+        assert to_match_form(None) == ""
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`tests/unit/test_wxyc_etl_parity.py::TestToMatchFormParityWithLegacy::test_none_handling_diverges` asserts that `to_match_form(None)` raises `TypeError`. As of `wxyc-etl 0.2.1` (tagged 2026-05-06), the PyO3 wrappers for the three charter forms accept `Option<&str>` and return `""` on `None`, unifying the contract with the legacy normalizers. The "divergence" the test documented no longer exists, and the test fails on `main`.

This PR renames the test to `test_none_handling_agrees`, asserts both legacy and charter return `""` on `None`, and updates the docstring to reflect the unified contract — the test now serves as a regression guard against either side drifting back.

Unblocks the WX-3.B PR (#159) which was rebased onto a red `main`.

## Test plan
- [ ] CI green (Default Tests + PG Tests + External API + Type Check + Lint + CI Marker Sync)