### PR TITLE
tsv_to_sqlite: FTS5 tokenizer override for emoji + ZWJ

### DIFF
--- a/scripts/tsv_to_sqlite.py
+++ b/scripts/tsv_to_sqlite.py
@@ -44,10 +44,27 @@ def tsv_to_sqlite(tsv_path: str, db_path: str) -> int:
         genre TEXT, format TEXT, alternate_artist_name TEXT,
         album_artist TEXT, label TEXT
     )""")
-    cur.execute("""CREATE VIRTUAL TABLE library_fts USING fts5(
-        title, artist, alternate_artist_name, album_artist,
-        content='library', content_rowid='id'
-    )""")
+    # FTS5 tokenizer extends unicode61 with the Symbol category and U+200D ZWJ so
+    # bare-emoji rows (waving-hand, musical-note) and ZWJ graphemes (family,
+    # flag, person-with-profession) get tokenized. The default unicode61
+    # categories ('L* N* Co') drop everything else, leaving the FTS index with
+    # no token to anchor a supplementary-plane row on.
+    # Cf is NOT included wholesale -- that would merge tokens around
+    # zero-width-space, BOM, soft-hyphen, etc. ZWJ is opted in explicitly via
+    # tokenchars; the U+200D codepoint is written as the explicit \\u200d escape
+    # below so the source stays unambiguous in editors and diffs that render
+    # zero-width characters invisibly.
+    # Must stay in sync with `library.db.LIBRARY_FTS_CREATE_SQL` in
+    # WXYC/library-metadata-lookup. See WXYC/discogs-etl#161 and
+    # WXYC/library-metadata-lookup#251.
+    fts_tokenizer = "unicode61 categories 'L* N* Co S*' tokenchars '\u200d'"
+    cur.execute(
+        "CREATE VIRTUAL TABLE library_fts USING fts5("
+        "title, artist, alternate_artist_name, album_artist, "
+        f'tokenize="{fts_tokenizer}", '
+        "content='library', content_rowid='id'"
+        ")"
+    )
 
     count = 0
     with open(tsv_path, encoding="utf-8") as f:

--- a/tests/unit/test_tsv_to_sqlite.py
+++ b/tests/unit/test_tsv_to_sqlite.py
@@ -307,6 +307,49 @@ class TestTsvToSqlite:
         conn.close()
         assert count == 2
 
+    def test_fts5_tokenizer_indexes_emoji(self, tmp_path: Path) -> None:
+        """FTS5 tokenizer must index supplementary-plane emoji rows.
+
+        The default unicode61 tokenizer drops 4-byte emoji (Symbol category)
+        and U+200D ZWJ; the production schema overrides it with
+        ``categories 'L* N* Co S*' tokenchars '\\u200d'`` so bare-emoji and
+        ZWJ-grapheme artist rows can be located by exact-string FTS MATCH.
+        See WXYC/discogs-etl#161 and WXYC/library-metadata-lookup#251.
+        """
+        # Bare emoji (U+1F44B WAVING HAND SIGN) -- fails the default unicode61.
+        # ZWJ family (man + ZWJ + woman + ZWJ + girl + ZWJ + boy) -- exercises
+        # the explicit U+200D tokenchars opt-in. Each ZWJ is written as the
+        # \\u200d escape so the source stays unambiguous in editors and diffs
+        # that render zero-width characters invisibly.
+        zwj = "\u200d"
+        zwj_family = f"\U0001f468{zwj}\U0001f469{zwj}\U0001f467{zwj}\U0001f466"
+        tsv = _make_tsv(
+            [
+                ["1", "Hello", "\U0001f44b", "EM", "100", "1", "Rock", "CD", "\\N", "\\N"],
+                ["2", "Family", zwj_family, "FA", "200", "2", "Rock", "CD", "\\N", "\\N"],
+            ]
+        )
+        tsv_file = tmp_path / "input.tsv"
+        tsv_file.write_text(tsv, encoding="utf-8")
+        db_path = tmp_path / "library.db"
+
+        tsv_to_sqlite(str(tsv_file), str(db_path))
+
+        conn = sqlite3.connect(str(db_path))
+        try:
+            hits = conn.execute(
+                "SELECT rowid FROM library_fts WHERE library_fts MATCH '\"\U0001f44b\"'"
+            ).fetchall()
+            assert hits == [(1,)], f"bare emoji row not findable via FTS MATCH: {hits!r}"
+
+            hits = conn.execute(
+                "SELECT rowid FROM library_fts WHERE library_fts MATCH ?",
+                (f'"{zwj_family}"',),
+            ).fetchall()
+            assert hits == [(2,)], f"ZWJ-grapheme row not findable via FTS MATCH: {hits!r}"
+        finally:
+            conn.close()
+
     def test_tab_in_field_value(self, tmp_path: Path) -> None:
         r"""MySQL escapes literal tabs in fields as \t; they should be unescaped."""
         # MySQL -B -N escapes real tabs inside data as the two-char sequence \t.


### PR DESCRIPTION
Closes #161.

## Files changed

- `scripts/tsv_to_sqlite.py` -- added `tokenize=...` directive and explanatory comment to the `CREATE VIRTUAL TABLE library_fts USING fts5(...)` statement.
- `tests/unit/test_tsv_to_sqlite.py` -- added `test_fts5_tokenizer_indexes_emoji` covering bare-emoji (U+1F44B) and ZWJ-grapheme (`man + ZWJ + woman + ZWJ + girl + ZWJ + boy`) rows.

## CREATE statement, before / after

Before:

```python
cur.execute("""CREATE VIRTUAL TABLE library_fts USING fts5(
    title, artist, alternate_artist_name, album_artist,
    content='library', content_rowid='id'
)""")
```

After:

```python
fts_tokenizer = "unicode61 categories 'L* N* Co S*' tokenchars '‍'"
cur.execute(
    "CREATE VIRTUAL TABLE library_fts USING fts5("
    "title, artist, alternate_artist_name, album_artist, "
    f'tokenize="{fts_tokenizer}", '
    "content='library', content_rowid='id'"
    ")"
)
```

The U+200D ZWJ codepoint is written as the explicit `‍` Python escape so the source stays readable in editors and diffs that render zero-width characters invisibly. Mirrors `library.db.LIBRARY_FTS_TOKENIZER` in WXYC/library-metadata-lookup.

## Column list

Unchanged: `title, artist, alternate_artist_name, album_artist`. Only the `tokenize=...` directive is new; the `content` and `content_rowid` directives are preserved verbatim.

## Production rollout

No manual `library.db` regeneration. The next scheduled `sync-library.sh` run rebuilds the FTS index from scratch -- `tsv_to_sqlite.py` calls `CREATE VIRTUAL TABLE library_fts ...` against a fresh SQLite file every run, so the new schema applies on the next daily upload to LML staging + production.

## Why these specific tokenizer categories

- `L*` (Letters), `N*` (Numbers), `Co` (Private use) -- the default unicode61 set; preserved.
- `S*` (Symbols, all subcategories) -- adds `So` (Symbol, Other), which covers all 4-byte emoji.
- `tokenchars '‍'` -- opt in U+200D ZWJ specifically. Adding the full `Cf` category would also opt in zero-width-space, BOM, soft-hyphen, etc., which would silently merge tokens around those invisible characters in normal Latin text.

## Local sanity check

A 3-row in-memory `library.db` was built via `tsv_to_sqlite()` containing a bare 👋, a 👨‍👩‍👧‍👦 ZWJ family, and a plain "Juana Molina" row. After the fix, all three are findable via `SELECT rowid FROM library_fts WHERE library_fts MATCH '"<token>"'`. Without the fix, the 👋 and 👨‍👩‍👧‍👦 rows return no hits.

## Acceptance criteria

- [x] `tsv_to_sqlite.py` carries the new `tokenize=...` directive.
- [x] Local sanity-check: bare emoji and ZWJ rows are findable via FTS MATCH.
- [x] No other behavior changes; the column list and INSERT statements stay as they are.
- [ ] After merge, the next daily `sync-library.sh` run produces a `library.db` whose FTS5 index can locate emoji + ZWJ rows. (Verified post-deploy by the LML WX-1 detector tests on the next cron-published `library.db`.)

## Test plan

- [x] New unit test `test_fts5_tokenizer_indexes_emoji` passes.
- [x] All existing `tests/unit/test_tsv_to_sqlite.py` tests pass (13/13).
- [x] Full unit suite passes (`pytest tests/unit/ --ignore=tests/unit/test_wxyc_etl_parity.py` -- 623 passed, 9 skipped). The ignored file has a pre-existing import error unrelated to this change.
- [x] `ruff check` + `ruff format --check` pass on both modified files.