### PR TITLE
deps: bump wxyc-etl >=0.2.0 → >=0.3.0 (E3 step 5d)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,7 +136,7 @@ docker compose up db -d     # just the database (for tests)
 
 Functionality that was previously local to this repo has been extracted to shared packages:
 
-- **wxyc-etl** (Rust/PyO3) -- Artist name normalization (`normalize_artist_name`), compilation detection (`is_compilation_artist`), artist name splitting (`split_artist_name`, `split_artist_name_contextual`), pipeline state tracking (`PipelineState`), and database introspection.
+- **wxyc-etl** (Rust/PyO3) -- Artist name normalization (`to_match_form`; legacy `normalize_artist_name` is `#[deprecated]` per the WX-2 Normalizer Charter), compilation detection (`is_compilation_artist`), artist name splitting (`split_artist_name`, `split_artist_name_contextual`), pipeline state tracking (`PipelineState`), and database introspection.
 - **wxyc-catalog** -- Catalog source protocol (`CatalogSource`, `TubafrenzySource`, `BackendServiceSource`), library.db export (`wxyc-export-to-sqlite` CLI), library artist enrichment (`wxyc-enrich-library-artists` CLI), and label extraction (`wxyc-extract-library-labels` CLI).
 
 ### External Inputs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ dependencies = [
     "psycopg[binary]>=3.1.0",
     "asyncpg>=0.29.0",
     "rapidfuzz>=3.0.0",
-    "wxyc-etl>=0.2.0",
+    "wxyc-etl>=0.3.0",
     "wxyc-catalog>=0.1.1",
     "sentry-sdk>=2.0",
 ]


### PR DESCRIPTION
## Summary
- Bumps `wxyc-etl` floor from `>=0.2.0` to `>=0.3.0`, pulling in the cross-cache-identity normalizers (`to_identity_match_form` family) per [library-hook-canonicalization-plan §3.3.1 step 5](https://github.com/WXYC/wiki/blob/main/plans/library-hook-canonicalization-plan.md).
- Updates CLAUDE.md to describe the WX-2 charter API (`to_match_form` is canonical; legacy `normalize_artist_name` is `#[deprecated]`).
- The parity test in `tests/unit/test_wxyc_etl_parity.py` intentionally keeps using `normalize_artist_name` to characterize legacy↔charter agreement until WX-4.1.1 removes the legacy API.

## Test plan
- [x] `pip install -e ".[dev]"` resolves wxyc-etl 0.3.0
- [x] `pytest tests/unit -x` passes (668 tests, including parity test still green)

Closes #164
Refs WXYC/wxyc-etl#73 (E3 step 5d)