### PR TITLE
infra/ephemeral-rebuild: provision-secrets.sh for SSM bootstrap

### DIFF
--- a/infra/ephemeral-rebuild/README.md
+++ b/infra/ephemeral-rebuild/README.md
@@ -22,28 +22,14 @@ The bootstrap script lives in this repo at [`scripts/rebuild-cache-bootstrap.sh`
 
 ### 1. Provision SSM parameters
 
-The stack does **not** create the SecureString parameters — bootstrap reads them, but they're operator-managed so the secret values aren't in CloudFormation drift history. Provision once before the first run:
+The stack does **not** create the SecureString parameters — bootstrap reads them, but they're operator-managed so the secret values aren't in CloudFormation drift history. Run `./provision-secrets.sh` from this directory; it prompts (with hidden input) for each value and writes them under `/wxyc/discogs-rebuild/`:
 
 ```bash
-aws ssm put-parameter --type SecureString \
-  --name /wxyc/discogs-rebuild/DATABASE_URL_DISCOGS \
-  --value 'postgresql://postgres:<pw>@<word>.proxy.rlwy.net:<port>/railway'
-
-aws ssm put-parameter --type SecureString \
-  --name /wxyc/discogs-rebuild/GH_TOKEN \
-  --value '<classic PAT or fine-grained token with read access on WXYC/library-metadata-lookup>'
-
-aws ssm put-parameter --type SecureString \
-  --name /wxyc/discogs-rebuild/SLACK_MONITORING_WEBHOOK \
-  --value 'https://hooks.slack.com/services/...'
-
-# Optional: Sentry DSN
-aws ssm put-parameter --type SecureString \
-  --name /wxyc/discogs-rebuild/SENTRY_DSN \
-  --value 'https://<key>@<org>.ingest.sentry.io/<project>'
+cd infra/ephemeral-rebuild
+./provision-secrets.sh
 ```
 
-If you change `SsmPrefix` away from the default, mirror the new prefix in every `put-parameter` call.
+The script confirms the AWS account before writing, uses `--overwrite` so it's safe to re-run for rotations, and prints a final summary table of the parameter names + types (never the decrypted values). Override the prefix via `SSM_PREFIX=/some/other/path ./provision-secrets.sh` if you deployed the stack with a non-default `SsmPrefix`.
 
 ### 2. Deploy the stack
 

--- a/infra/ephemeral-rebuild/README.md
+++ b/infra/ephemeral-rebuild/README.md
@@ -29,7 +29,7 @@ cd infra/ephemeral-rebuild
 ./provision-secrets.sh
 ```
 
-The script confirms the AWS account before writing, uses `--overwrite` so it's safe to re-run for rotations, and prints a final summary table of the parameter names + types (never the decrypted values). Two env-var overrides are honored: `SSM_PREFIX=/some/other/path` if you deployed the stack with a non-default `SsmPrefix`, and `AWS_REGION=…` if you deployed it outside the default `us-east-1`.
+The script hard-fails before any write if the caller's AWS account isn't `503977661500` (the rebuild account), then displays account/region/prefix/caller-arn and asks for an explicit `y` confirmation as the second line of defence. `--overwrite` makes it safe to re-run for rotations. The final summary table lists parameter names + types only — never the decrypted values. Three env-var overrides are honored: `SSM_PREFIX=/some/other/path` if you deployed the stack with a non-default `SsmPrefix`, `AWS_REGION=…` if you deployed it outside the default `us-east-1`, and `EXPECTED_ACCOUNT=<id>` to deliberately target a sandbox/test account.
 
 ### 2. Deploy the stack
 

--- a/infra/ephemeral-rebuild/README.md
+++ b/infra/ephemeral-rebuild/README.md
@@ -29,7 +29,7 @@ cd infra/ephemeral-rebuild
 ./provision-secrets.sh
 ```
 
-The script confirms the AWS account before writing, uses `--overwrite` so it's safe to re-run for rotations, and prints a final summary table of the parameter names + types (never the decrypted values). Override the prefix via `SSM_PREFIX=/some/other/path ./provision-secrets.sh` if you deployed the stack with a non-default `SsmPrefix`.
+The script confirms the AWS account before writing, uses `--overwrite` so it's safe to re-run for rotations, and prints a final summary table of the parameter names + types (never the decrypted values). Two env-var overrides are honored: `SSM_PREFIX=/some/other/path` if you deployed the stack with a non-default `SsmPrefix`, and `AWS_REGION=…` if you deployed it outside the default `us-east-1`.
 
 ### 2. Deploy the stack
 

--- a/infra/ephemeral-rebuild/provision-secrets.sh
+++ b/infra/ephemeral-rebuild/provision-secrets.sh
@@ -8,10 +8,13 @@
 #     SSM_PREFIX=/some/other/path \
 #         ./provision-secrets.sh          # override the prefix (matches the
 #                                         # stack's SsmPrefix parameter)
+#     AWS_REGION=us-west-2 \
+#         ./provision-secrets.sh          # override the region (default
+#                                         # us-east-1, matches the stack)
 #
 # Prereqs:
 #     - AWS credentials configured for the rebuild account (503977661500).
-#     - aws CLI v2 on PATH.
+#     - aws CLI on PATH (v1 or v2; both support --overwrite + SecureString).
 #
 # What it writes:
 #     <prefix>/DATABASE_URL_DISCOGS         (required) — Railway public-proxy URL

--- a/infra/ephemeral-rebuild/provision-secrets.sh
+++ b/infra/ephemeral-rebuild/provision-secrets.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# provision-secrets.sh — one-time operator script that writes the SecureString
+# parameters the bootstrap reads from SSM. Idempotent (`--overwrite` everywhere)
+# and re-runnable for value rotations.
+#
+# Usage:
+#     ./provision-secrets.sh              # interactive, prompts for each value
+#     SSM_PREFIX=/some/other/path \
+#         ./provision-secrets.sh          # override the prefix (matches the
+#                                         # stack's SsmPrefix parameter)
+#
+# Prereqs:
+#     - AWS credentials configured for the rebuild account (503977661500).
+#     - aws CLI v2 on PATH.
+#
+# What it writes:
+#     <prefix>/DATABASE_URL_DISCOGS         (required) — Railway public-proxy URL
+#     <prefix>/GH_TOKEN                     (required) — PAT with repo:read on
+#                                                        WXYC/library-metadata-lookup
+#     <prefix>/SLACK_MONITORING_WEBHOOK     (optional) — Slack incoming webhook
+#     <prefix>/SENTRY_DSN                   (optional) — Sentry DSN
+#
+# Optional values are skipped on empty input. The script never deletes; if you
+# need to remove an optional parameter later, run `aws ssm delete-parameter`
+# directly.
+
+set -euo pipefail
+
+SSM_PREFIX="${SSM_PREFIX:-/wxyc/discogs-rebuild}"
+AWS_REGION="${AWS_REGION:-us-east-1}"
+export AWS_REGION
+
+# Account sanity check — writing the wrong DATABASE_URL into the wrong account
+# is silent until the next monthly tick and then very loud, so confirm before
+# anything moves.
+if ! identity="$(aws sts get-caller-identity --output text \
+    --query '[Account,Arn]' 2>/dev/null)"; then
+    echo "ERROR: aws sts get-caller-identity failed. Configure AWS credentials first." >&2
+    exit 1
+fi
+account="${identity%%[[:space:]]*}"
+arn="${identity##*[[:space:]]}"
+
+cat <<EOF
+About to write SecureString parameters to:
+    Account: ${account}
+    Region:  ${AWS_REGION}
+    Prefix:  ${SSM_PREFIX}/
+    Caller:  ${arn}
+EOF
+read -rp "Proceed? [y/N] " ack
+case "$ack" in
+    y|Y|yes|YES) ;;
+    *) echo "aborted"; exit 1 ;;
+esac
+
+put_secret() {
+    local name="$1" prompt="$2" required="$3"
+    local value
+    read -rsp "$prompt: " value
+    echo
+    if [ -z "$value" ]; then
+        if [ "$required" = "required" ]; then
+            echo "ERROR: $name is required." >&2
+            return 1
+        fi
+        echo "  (skipped)"
+        return 0
+    fi
+    aws ssm put-parameter --type SecureString --overwrite \
+        --name "${SSM_PREFIX}/${name}" --value "$value" >/dev/null
+    echo "  wrote ${SSM_PREFIX}/${name}"
+}
+
+put_secret DATABASE_URL_DISCOGS \
+    "DATABASE_URL_DISCOGS (Railway public-proxy URL)" required
+put_secret GH_TOKEN \
+    "GH_TOKEN (PAT with repo:read on WXYC/library-metadata-lookup)" required
+put_secret SLACK_MONITORING_WEBHOOK \
+    "SLACK_MONITORING_WEBHOOK (or blank to skip)" optional
+put_secret SENTRY_DSN \
+    "SENTRY_DSN (or blank to skip)" optional
+
+echo
+echo "Parameters now under ${SSM_PREFIX}/:"
+aws ssm get-parameters-by-path --path "$SSM_PREFIX" \
+    --query 'Parameters[].[Name,Type,LastModifiedDate]' --output table

--- a/infra/ephemeral-rebuild/provision-secrets.sh
+++ b/infra/ephemeral-rebuild/provision-secrets.sh
@@ -11,6 +11,9 @@
 #     AWS_REGION=us-west-2 \
 #         ./provision-secrets.sh          # override the region (default
 #                                         # us-east-1, matches the stack)
+#     EXPECTED_ACCOUNT=123456789012 \
+#         ./provision-secrets.sh          # override the account guard (default
+#                                         # 503977661500, the rebuild account)
 #
 # Prereqs:
 #     - AWS credentials configured for the rebuild account (503977661500).
@@ -31,6 +34,7 @@ set -euo pipefail
 
 SSM_PREFIX="${SSM_PREFIX:-/wxyc/discogs-rebuild}"
 AWS_REGION="${AWS_REGION:-us-east-1}"
+EXPECTED_ACCOUNT="${EXPECTED_ACCOUNT:-503977661500}"
 export AWS_REGION
 
 # Account sanity check — writing the wrong DATABASE_URL into the wrong account
@@ -43,6 +47,19 @@ if ! identity="$(aws sts get-caller-identity --output text \
 fi
 account="${identity%%[[:space:]]*}"
 arn="${identity##*[[:space:]]}"
+
+# Hard-fail before the y/N prompt if the caller is in the wrong account. The
+# y/N display below is the second line of defence; this is the typo-proof
+# first one. To deliberately target a non-default account (sandbox, test
+# stack, etc.), set EXPECTED_ACCOUNT=<id> to that account's id.
+if [ "$account" != "$EXPECTED_ACCOUNT" ]; then
+    cat <<EOF >&2
+ERROR: caller account ${account} does not match EXPECTED_ACCOUNT ${EXPECTED_ACCOUNT}.
+       Configure AWS_PROFILE / credentials for the rebuild account, or pass
+       EXPECTED_ACCOUNT=${account} to override (sandbox / test stack only).
+EOF
+    exit 1
+fi
 
 cat <<EOF
 About to write SecureString parameters to:
@@ -86,5 +103,7 @@ put_secret SENTRY_DSN \
 
 echo
 echo "Parameters now under ${SSM_PREFIX}/:"
-aws ssm get-parameters-by-path --path "$SSM_PREFIX" \
+# --recursive so a future sub-prefix layout (e.g. /optional/SLACK_…) doesn't
+# silently truncate the summary.
+aws ssm get-parameters-by-path --path "$SSM_PREFIX" --recursive \
     --query 'Parameters[].[Name,Type,LastModifiedDate]' --output table


### PR DESCRIPTION
## Summary

One-time operator script that prompts for the four bootstrap secrets and writes them as SecureString parameters under `/wxyc/discogs-rebuild/`. Replaces the inline `aws ssm put-parameter` snippets in `infra/ephemeral-rebuild/README.md` step 1 with a single `./provision-secrets.sh` call.

Follow-up to #168 (already merged); this is the first piece of the operator runway before the inaugural `sam deploy`.

## Behavior

- Reads each value via `read -s` so secrets stay off-screen and out of `~/.zsh_history`.
- Prints account / region / prefix / caller-arn and asks for explicit `y` confirmation before any write — guards against rotating creds into the wrong account.
- `--overwrite` everywhere → safe to re-run for value rotations.
- Optional secrets (`SLACK_MONITORING_WEBHOOK`, `SENTRY_DSN`) skipped on empty input. Required ones (`DATABASE_URL_DISCOGS`, `GH_TOKEN`) error out instead of silently skipping.
- Final summary lists parameter names + types + last-modified, never the decrypted values.
- `SSM_PREFIX` env var override for stacks deployed with a non-default `SsmPrefix`.

## Test plan

- [x] `bash -n` clean.
- [x] `shellcheck` clean.
- [ ] Operator dry-run before the first `sam deploy`.