### PR TITLE
alembic 0002: backfill missing trigram indexes

### DIFF
--- a/alembic/versions/0002_backfill_trigram_indexes.py
+++ b/alembic/versions/0002_backfill_trigram_indexes.py
@@ -31,6 +31,7 @@ import os
 from collections.abc import Sequence
 
 import psycopg
+from psycopg import sql
 
 from alembic import context
 
@@ -73,6 +74,13 @@ def _refuse_offline(direction: str) -> None:
         )
 
 
+_CREATE_INDEX = sql.SQL(
+    "CREATE INDEX CONCURRENTLY IF NOT EXISTS {index_name} "
+    "ON {table} USING GIN (lower(f_unaccent({column})) gin_trgm_ops)"
+)
+_DROP_INDEX = sql.SQL("DROP INDEX CONCURRENTLY IF EXISTS {index_name}")
+
+
 def upgrade() -> None:
     _refuse_offline("upgrade")
 
@@ -81,8 +89,11 @@ def upgrade() -> None:
         for index_name, table, column in _TRIGRAM_INDEXES:
             log.info("0002: building %s on %s(%s)", index_name, table, column)
             cur.execute(
-                f"CREATE INDEX CONCURRENTLY IF NOT EXISTS {index_name} "
-                f"ON {table} USING GIN (lower(f_unaccent({column})) gin_trgm_ops)"
+                _CREATE_INDEX.format(
+                    index_name=sql.Identifier(index_name),
+                    table=sql.Identifier(table),
+                    column=sql.Identifier(column),
+                )
             )
 
 
@@ -91,4 +102,4 @@ def downgrade() -> None:
 
     with psycopg.connect(_resolve_db_url(), autocommit=True) as conn, conn.cursor() as cur:
         for index_name, _, _ in _TRIGRAM_INDEXES:
-            cur.execute(f"DROP INDEX CONCURRENTLY IF EXISTS {index_name}")
+            cur.execute(_DROP_INDEX.format(index_name=sql.Identifier(index_name)))

--- a/alembic/versions/0002_backfill_trigram_indexes.py
+++ b/alembic/versions/0002_backfill_trigram_indexes.py
@@ -1,0 +1,94 @@
+"""backfill missing trigram indexes
+
+Production (and any DB stamped at 0001_initial via the baseline's
+populated-DB short-circuit) predates the moment the four GIN trigram indexes
+on release/release_track/release_artist/release_track_artist landed in
+``schema/*.sql``. Without them, the ``%`` operator falls back to a parallel
+seq scan over ``release_track`` (~1.3M rows) and ``/api/v1/lookup`` p99
+balloons to multiple seconds.
+
+This revision applies the same four ``CREATE INDEX CONCURRENTLY IF NOT EXISTS``
+statements that already live in ``schema/create_indexes.sql`` and
+``schema/create_track_indexes.sql``. ``IF NOT EXISTS`` makes the apply a no-op
+on DBs that already have them (e.g. one rebuilt from the baseline schema files
+end-to-end).
+
+Like 0001_initial, this revision opens a side-channel ``psycopg.connect(...,
+autocommit=True)`` because ``CREATE INDEX CONCURRENTLY`` cannot run inside a
+transaction, and alembic's ``run_migrations_online`` wraps the migration in
+``context.begin_transaction()``.
+
+Revision ID: 0002_backfill_trigram_indexes
+Revises: 0001_initial
+Create Date: 2026-05-09
+
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from collections.abc import Sequence
+
+import psycopg
+
+from alembic import context
+
+# revision identifiers, used by Alembic.
+revision: str = "0002_backfill_trigram_indexes"
+down_revision: str | Sequence[str] | None = "0001_initial"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+# (index_name, table, column) — column is fed verbatim into the index expression
+# ``lower(f_unaccent(<column>))``. f_unaccent is the IMMUTABLE wrapper defined in
+# schema/create_functions.sql; the baseline guarantees it exists.
+_TRIGRAM_INDEXES: tuple[tuple[str, str, str], ...] = (
+    ("idx_release_track_title_trgm", "release_track", "title"),
+    ("idx_release_track_artist_name_trgm", "release_track_artist", "artist_name"),
+    ("idx_release_artist_name_trgm", "release_artist", "artist_name"),
+    ("idx_release_title_trgm", "release", "title"),
+)
+
+
+def _resolve_db_url() -> str:
+    db_url = os.environ.get("DATABASE_URL_DISCOGS") or os.environ.get("DATABASE_URL")
+    if not db_url:
+        raise RuntimeError(
+            "DATABASE_URL_DISCOGS (or DATABASE_URL) must be set to apply "
+            "0002_backfill_trigram_indexes."
+        )
+    return db_url
+
+
+def _refuse_offline(direction: str) -> None:
+    if context.is_offline_mode():
+        raise RuntimeError(
+            f"0002_backfill_trigram_indexes does not support --sql / offline mode "
+            f"({direction}): CREATE/DROP INDEX CONCURRENTLY cannot run inside a "
+            "transaction, so this revision opens its own autocommit psycopg "
+            "connection that bypasses alembic's offline SQL emission. Run "
+            "`alembic upgrade head` (or `downgrade`) against a live DB instead."
+        )
+
+
+def upgrade() -> None:
+    _refuse_offline("upgrade")
+
+    log = logging.getLogger("alembic.runtime.migration")
+    with psycopg.connect(_resolve_db_url(), autocommit=True) as conn, conn.cursor() as cur:
+        for index_name, table, column in _TRIGRAM_INDEXES:
+            log.info("0002: building %s on %s(%s)", index_name, table, column)
+            cur.execute(
+                f"CREATE INDEX CONCURRENTLY IF NOT EXISTS {index_name} "
+                f"ON {table} USING GIN (lower(f_unaccent({column})) gin_trgm_ops)"
+            )
+
+
+def downgrade() -> None:
+    _refuse_offline("downgrade")
+
+    with psycopg.connect(_resolve_db_url(), autocommit=True) as conn, conn.cursor() as cur:
+        for index_name, _, _ in _TRIGRAM_INDEXES:
+            cur.execute(f"DROP INDEX CONCURRENTLY IF EXISTS {index_name}")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import os
 import uuid
+from collections.abc import Iterator
 
 import pytest
 
@@ -43,11 +44,11 @@ def _postgres_available() -> bool:
         return False
 
 
-@pytest.fixture(scope="module")
-def db_url():
-    """Create a temporary test database, yield its URL, and drop it on teardown.
+def _ephemeral_database() -> Iterator[str]:
+    """Generator body for a temp-DB fixture.
 
-    Skips the entire module if Postgres is not reachable.
+    Wrap with ``@pytest.fixture(scope=...)`` to get module- or function-scoped
+    isolation. Skips the test if Postgres is unreachable.
     """
     if not _postgres_available():
         pytest.skip("PostgreSQL not available (set DATABASE_URL_TEST)")
@@ -60,25 +61,47 @@ def db_url():
 
     # Build the test database URL by replacing the database name in the admin URL.
     # Handle both postgresql://host/db and postgresql://user:pass@host:port/db forms.
-    if "@" in ADMIN_URL:
-        base = ADMIN_URL.rsplit("/", 1)[0]
-    else:
-        base = ADMIN_URL.rsplit("/", 1)[0]
+    base = ADMIN_URL.rsplit("/", 1)[0]
     test_url = f"{base}/{db_name}"
 
-    yield test_url
+    try:
+        yield test_url
+    finally:
+        # Teardown: drop the test database. Force-disconnect any remaining
+        # connections first.
+        with admin_conn.cursor() as cur:
+            cur.execute(
+                sql.SQL(
+                    "SELECT pg_terminate_backend(pid) FROM pg_stat_activity "
+                    "WHERE datname = {} AND pid <> pg_backend_pid()"
+                ).format(sql.Literal(db_name))
+            )
+            cur.execute(sql.SQL("DROP DATABASE IF EXISTS {}").format(sql.Identifier(db_name)))
+        admin_conn.close()
 
-    # Teardown: drop the test database
-    # Force-disconnect any remaining connections first.
-    with admin_conn.cursor() as cur:
-        cur.execute(
-            sql.SQL(
-                "SELECT pg_terminate_backend(pid) FROM pg_stat_activity "
-                "WHERE datname = {} AND pid <> pg_backend_pid()"
-            ).format(sql.Literal(db_name))
-        )
-        cur.execute(sql.SQL("DROP DATABASE IF EXISTS {}").format(sql.Identifier(db_name)))
-    admin_conn.close()
+
+@pytest.fixture(scope="module")
+def db_url() -> Iterator[str]:
+    """Module-scoped temp DB shared across all tests in a module.
+
+    Cheap when the tests don't write to the DB (or all do equivalent setup),
+    but tests that mutate state can leak across each other in undefined
+    pytest execution order. Use ``fresh_db_url`` instead when each test
+    needs a guaranteed-clean DB.
+    """
+    yield from _ephemeral_database()
+
+
+@pytest.fixture()
+def fresh_db_url() -> Iterator[str]:
+    """Function-scoped temp DB — one fresh database per test.
+
+    Use this for tests that mutate schema/version state in ways that would
+    leak across the module (e.g. alembic migrations applied in different
+    sequences). Slower than ``db_url`` because each test pays the create+drop
+    cost, but worth it when correctness depends on a clean slate.
+    """
+    yield from _ephemeral_database()
 
 
 @pytest.fixture()

--- a/tests/integration/test_alembic_backfill_trigram_indexes.py
+++ b/tests/integration/test_alembic_backfill_trigram_indexes.py
@@ -1,0 +1,137 @@
+"""Verify 0002_backfill_trigram_indexes lands the four GIN trigram indexes
+that were missing from production after the baseline's populated-DB
+short-circuit kept them from being applied.
+
+The migration uses ``CREATE INDEX CONCURRENTLY IF NOT EXISTS`` via a
+side-channel autocommit psycopg connection (mirrors 0001_initial), so the
+guarded surface is: indexes land cleanly, the apply is idempotent on a DB
+that already has them, downgrade drops them, and offline ``--sql`` mode is
+refused.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import psycopg
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+EXPECTED_INDEXES = {
+    "idx_release_track_title_trgm",
+    "idx_release_track_artist_name_trgm",
+    "idx_release_artist_name_trgm",
+    "idx_release_title_trgm",
+}
+
+
+def _run_alembic(args: list[str], db_url: str) -> subprocess.CompletedProcess[str]:
+    env = {**os.environ, "DATABASE_URL_DISCOGS": db_url}
+    env.pop("DATABASE_URL", None)
+    return subprocess.run(
+        [sys.executable, "-m", "alembic", *args],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _present_trigram_indexes(db_url: str) -> set[str]:
+    with psycopg.connect(db_url) as conn, conn.cursor() as cur:
+        cur.execute(
+            "SELECT indexname FROM pg_indexes WHERE schemaname = 'public' AND indexname = ANY(%s)",
+            (list(EXPECTED_INDEXES),),
+        )
+        return {row[0] for row in cur.fetchall()}
+
+
+@pytest.mark.pg
+def test_upgrade_to_head_creates_all_four_trigram_indexes(db_url: str) -> None:
+    """Fresh DB → upgrade head → all four indexes exist + version stamped at 0002."""
+    result = _run_alembic(["upgrade", "head"], db_url)
+    assert result.returncode == 0, (
+        f"alembic upgrade head failed:\nstdout: {result.stdout}\nstderr: {result.stderr}"
+    )
+
+    assert _present_trigram_indexes(db_url) == EXPECTED_INDEXES, (
+        f"missing one or more trigram indexes; present: {_present_trigram_indexes(db_url)}"
+    )
+
+    with psycopg.connect(db_url) as conn, conn.cursor() as cur:
+        cur.execute("SELECT version_num FROM alembic_version")
+        assert cur.fetchone() == ("0002_backfill_trigram_indexes",)
+
+
+@pytest.mark.pg
+def test_upgrade_is_idempotent_when_indexes_already_exist(db_url: str) -> None:
+    """Backfill scenario: tables + trigram indexes pre-exist, DB stamped at 0001.
+    Running ``alembic upgrade head`` must succeed and leave the indexes alone."""
+    # Apply the baseline first so we have the schema, then create the trigram
+    # indexes by hand to simulate a DB that was patched by an operator before
+    # this migration landed (i.e. exactly what was done to production).
+    baseline = _run_alembic(["upgrade", "0001_initial"], db_url)
+    assert baseline.returncode == 0, (
+        f"baseline apply failed:\nstdout: {baseline.stdout}\nstderr: {baseline.stderr}"
+    )
+    with psycopg.connect(db_url, autocommit=True) as conn, conn.cursor() as cur:
+        for index_name, table, column in (
+            ("idx_release_track_title_trgm", "release_track", "title"),
+            ("idx_release_track_artist_name_trgm", "release_track_artist", "artist_name"),
+            ("idx_release_artist_name_trgm", "release_artist", "artist_name"),
+            ("idx_release_title_trgm", "release", "title"),
+        ):
+            cur.execute(
+                f"CREATE INDEX CONCURRENTLY IF NOT EXISTS {index_name} "
+                f"ON {table} USING GIN (lower(f_unaccent({column})) gin_trgm_ops)"
+            )
+
+    result = _run_alembic(["upgrade", "head"], db_url)
+    assert result.returncode == 0, (
+        f"alembic upgrade head should be a no-op when indexes pre-exist:\n"
+        f"stdout: {result.stdout}\nstderr: {result.stderr}"
+    )
+    assert _present_trigram_indexes(db_url) == EXPECTED_INDEXES
+
+
+@pytest.mark.pg
+def test_downgrade_drops_the_four_trigram_indexes(db_url: str) -> None:
+    """Apply head, then downgrade -1, indexes should be gone and version backed off."""
+    apply = _run_alembic(["upgrade", "head"], db_url)
+    assert apply.returncode == 0, (
+        f"upgrade head failed:\nstdout: {apply.stdout}\nstderr: {apply.stderr}"
+    )
+
+    down = _run_alembic(["downgrade", "-1"], db_url)
+    assert down.returncode == 0, (
+        f"downgrade -1 failed:\nstdout: {down.stdout}\nstderr: {down.stderr}"
+    )
+
+    assert _present_trigram_indexes(db_url) == set()
+    with psycopg.connect(db_url) as conn, conn.cursor() as cur:
+        cur.execute("SELECT version_num FROM alembic_version")
+        assert cur.fetchone() == ("0001_initial",)
+
+
+@pytest.mark.pg
+def test_offline_mode_refused_for_upgrade(db_url: str) -> None:
+    """``--sql`` (offline mode) cannot honestly dry-run a side-channel autocommit
+    revision; refusing loud avoids the silent-no-op trap that bit 0001."""
+    # First land the baseline so we don't conflate the offline-mode error with a
+    # missing-down_revision error.
+    apply = _run_alembic(["upgrade", "0001_initial"], db_url)
+    assert apply.returncode == 0
+
+    sql_run = _run_alembic(["upgrade", "head", "--sql"], db_url)
+    assert sql_run.returncode != 0, (
+        "alembic upgrade head --sql should fail; got returncode 0:\n"
+        f"stdout: {sql_run.stdout}\nstderr: {sql_run.stderr}"
+    )
+    combined = sql_run.stdout + sql_run.stderr
+    assert "offline mode" in combined.lower(), (
+        f"expected offline-mode error, got:\nstdout: {sql_run.stdout}\nstderr: {sql_run.stderr}"
+    )

--- a/tests/integration/test_alembic_backfill_trigram_indexes.py
+++ b/tests/integration/test_alembic_backfill_trigram_indexes.py
@@ -7,6 +7,13 @@ side-channel autocommit psycopg connection (mirrors 0001_initial), so the
 guarded surface is: indexes land cleanly, the apply is idempotent on a DB
 that already has them, downgrade drops them, and offline ``--sql`` mode is
 refused.
+
+Each test takes the function-scoped ``fresh_db_url`` fixture (defined in
+``tests/conftest.py``) so every test runs against a guaranteed-clean
+database. The four tests apply different migration sequences (upgrade
+head, populate-then-upgrade, upgrade+downgrade, --sql rejection) which
+would otherwise depend on pytest's definition-order execution to interleave
+cleanly under the module-scoped ``db_url`` fixture.
 """
 
 from __future__ import annotations
@@ -51,34 +58,34 @@ def _present_trigram_indexes(db_url: str) -> set[str]:
 
 
 @pytest.mark.pg
-def test_upgrade_to_head_creates_all_four_trigram_indexes(db_url: str) -> None:
+def test_upgrade_to_head_creates_all_four_trigram_indexes(fresh_db_url: str) -> None:
     """Fresh DB → upgrade head → all four indexes exist + version stamped at 0002."""
-    result = _run_alembic(["upgrade", "head"], db_url)
+    result = _run_alembic(["upgrade", "head"], fresh_db_url)
     assert result.returncode == 0, (
         f"alembic upgrade head failed:\nstdout: {result.stdout}\nstderr: {result.stderr}"
     )
 
-    assert _present_trigram_indexes(db_url) == EXPECTED_INDEXES, (
-        f"missing one or more trigram indexes; present: {_present_trigram_indexes(db_url)}"
+    assert _present_trigram_indexes(fresh_db_url) == EXPECTED_INDEXES, (
+        f"missing one or more trigram indexes; present: {_present_trigram_indexes(fresh_db_url)}"
     )
 
-    with psycopg.connect(db_url) as conn, conn.cursor() as cur:
+    with psycopg.connect(fresh_db_url) as conn, conn.cursor() as cur:
         cur.execute("SELECT version_num FROM alembic_version")
         assert cur.fetchone() == ("0002_backfill_trigram_indexes",)
 
 
 @pytest.mark.pg
-def test_upgrade_is_idempotent_when_indexes_already_exist(db_url: str) -> None:
+def test_upgrade_is_idempotent_when_indexes_already_exist(fresh_db_url: str) -> None:
     """Backfill scenario: tables + trigram indexes pre-exist, DB stamped at 0001.
     Running ``alembic upgrade head`` must succeed and leave the indexes alone."""
     # Apply the baseline first so we have the schema, then create the trigram
     # indexes by hand to simulate a DB that was patched by an operator before
     # this migration landed (i.e. exactly what was done to production).
-    baseline = _run_alembic(["upgrade", "0001_initial"], db_url)
+    baseline = _run_alembic(["upgrade", "0001_initial"], fresh_db_url)
     assert baseline.returncode == 0, (
         f"baseline apply failed:\nstdout: {baseline.stdout}\nstderr: {baseline.stderr}"
     )
-    with psycopg.connect(db_url, autocommit=True) as conn, conn.cursor() as cur:
+    with psycopg.connect(fresh_db_url, autocommit=True) as conn, conn.cursor() as cur:
         for index_name, table, column in (
             ("idx_release_track_title_trgm", "release_track", "title"),
             ("idx_release_track_artist_name_trgm", "release_track_artist", "artist_name"),
@@ -90,43 +97,43 @@ def test_upgrade_is_idempotent_when_indexes_already_exist(db_url: str) -> None:
                 f"ON {table} USING GIN (lower(f_unaccent({column})) gin_trgm_ops)"
             )
 
-    result = _run_alembic(["upgrade", "head"], db_url)
+    result = _run_alembic(["upgrade", "head"], fresh_db_url)
     assert result.returncode == 0, (
         f"alembic upgrade head should be a no-op when indexes pre-exist:\n"
         f"stdout: {result.stdout}\nstderr: {result.stderr}"
     )
-    assert _present_trigram_indexes(db_url) == EXPECTED_INDEXES
+    assert _present_trigram_indexes(fresh_db_url) == EXPECTED_INDEXES
 
 
 @pytest.mark.pg
-def test_downgrade_drops_the_four_trigram_indexes(db_url: str) -> None:
+def test_downgrade_drops_the_four_trigram_indexes(fresh_db_url: str) -> None:
     """Apply head, then downgrade -1, indexes should be gone and version backed off."""
-    apply = _run_alembic(["upgrade", "head"], db_url)
+    apply = _run_alembic(["upgrade", "head"], fresh_db_url)
     assert apply.returncode == 0, (
         f"upgrade head failed:\nstdout: {apply.stdout}\nstderr: {apply.stderr}"
     )
 
-    down = _run_alembic(["downgrade", "-1"], db_url)
+    down = _run_alembic(["downgrade", "-1"], fresh_db_url)
     assert down.returncode == 0, (
         f"downgrade -1 failed:\nstdout: {down.stdout}\nstderr: {down.stderr}"
     )
 
-    assert _present_trigram_indexes(db_url) == set()
-    with psycopg.connect(db_url) as conn, conn.cursor() as cur:
+    assert _present_trigram_indexes(fresh_db_url) == set()
+    with psycopg.connect(fresh_db_url) as conn, conn.cursor() as cur:
         cur.execute("SELECT version_num FROM alembic_version")
         assert cur.fetchone() == ("0001_initial",)
 
 
 @pytest.mark.pg
-def test_offline_mode_refused_for_upgrade(db_url: str) -> None:
+def test_offline_mode_refused_for_upgrade(fresh_db_url: str) -> None:
     """``--sql`` (offline mode) cannot honestly dry-run a side-channel autocommit
     revision; refusing loud avoids the silent-no-op trap that bit 0001."""
     # First land the baseline so we don't conflate the offline-mode error with a
     # missing-down_revision error.
-    apply = _run_alembic(["upgrade", "0001_initial"], db_url)
+    apply = _run_alembic(["upgrade", "0001_initial"], fresh_db_url)
     assert apply.returncode == 0
 
-    sql_run = _run_alembic(["upgrade", "head", "--sql"], db_url)
+    sql_run = _run_alembic(["upgrade", "head", "--sql"], fresh_db_url)
     assert sql_run.returncode != 0, (
         "alembic upgrade head --sql should fail; got returncode 0:\n"
         f"stdout: {sql_run.stdout}\nstderr: {sql_run.stderr}"

--- a/tests/integration/test_alembic_baseline.py
+++ b/tests/integration/test_alembic_baseline.py
@@ -37,7 +37,7 @@ def _run_alembic(args: list[str], db_url: str) -> subprocess.CompletedProcess[st
 
 @pytest.mark.pg
 def test_alembic_upgrade_head_against_empty_db(db_url: str) -> None:
-    result = _run_alembic(["upgrade", "head"], db_url)
+    result = _run_alembic(["upgrade", "0001_initial"], db_url)
     assert result.returncode == 0, (
         f"alembic upgrade head failed:\nstdout: {result.stdout}\nstderr: {result.stderr}"
     )
@@ -71,7 +71,7 @@ def test_alembic_upgrade_head_sql_against_populated_db_is_safe(db_url: str) -> N
     # `--sql` (offline mode) interception. Running `alembic upgrade head --sql`
     # against a populated DB used to silently DROP every release/artist table.
     # The defensive guard in 0001_initial.py refuses to run in offline mode.
-    apply = _run_alembic(["upgrade", "head"], db_url)
+    apply = _run_alembic(["upgrade", "0001_initial"], db_url)
     assert apply.returncode == 0, (
         f"baseline apply failed:\nstdout: {apply.stdout}\nstderr: {apply.stderr}"
     )
@@ -115,7 +115,7 @@ def test_alembic_upgrade_head_against_populated_unstamped_db_is_safe(db_url: str
             cur.execute(sql)
         cur.execute("INSERT INTO release (id, title) VALUES (424242, 'Sentinel')")
 
-    result = _run_alembic(["upgrade", "head"], db_url)
+    result = _run_alembic(["upgrade", "0001_initial"], db_url)
     assert result.returncode == 0, (
         f"alembic upgrade head failed against populated-unstamped DB:\n"
         f"stdout: {result.stdout}\nstderr: {result.stderr}"


### PR DESCRIPTION
Closes #171.

## Summary

- New revision \`alembic/versions/0002_backfill_trigram_indexes.py\` applies the four GIN trigram indexes \`idx_release_track_title_trgm\`, \`idx_release_track_artist_name_trgm\`, \`idx_release_artist_name_trgm\`, and \`idx_release_title_trgm\` with \`CREATE INDEX CONCURRENTLY IF NOT EXISTS\`. Idempotent, non-blocking, follows the 0001 side-channel autocommit pattern; refuses \`--sql\` / offline mode.
- New test module \`tests/integration/test_alembic_backfill_trigram_indexes.py\` covers fresh-DB upgrade, idempotent re-apply (the prod-backfill scenario), downgrade, and offline-mode refusal.
- Retargeted the existing baseline tests in \`tests/integration/test_alembic_baseline.py\` at \`upgrade 0001_initial\` instead of \`upgrade head\` so they keep testing baseline-specific behavior independent of what stacks on top.

## Why

Production \`Postgres\` service had been doing parallel seq scans over \`release_track\` (~1.3M rows) on every \`%\`-operator query, causing LML \`/api/v1/lookup\` p99 to stretch to multiple seconds (max 73.5s in 7d). Same EXPLAIN ANALYZE before/after a manual \`CREATE INDEX CONCURRENTLY\` against production:

| State | Plan | Execution time |
|---|---|---|
| Before | \`Parallel Seq Scan on release_track\` | 3,624 ms |
| After (warm) | \`Bitmap Index Scan on idx_release_track_title_trgm\` | 37 ms |

Full investigation: WXYC/library-metadata-lookup#269.

## Operational note

Production was patched by hand before this PR (the four indexes are already in place). Running \`alembic upgrade head\` against production after this merges is a clean no-op thanks to \`IF NOT EXISTS\`. The PR is what closes the gap for any other DB stamped at 0001 — and it leaves the migration history honest about the schema state.

## Test plan
- [x] \`pytest tests/integration/test_alembic_baseline.py tests/integration/test_alembic_backfill_trigram_indexes.py -m pg\` — 7 passed (4 new + 3 existing baseline tests retargeted)
- [x] \`ruff check .\` — clean
- [x] \`ruff format --check .\` — clean
- [ ] After merge, run \`alembic upgrade head\` against production to advance the version stamp from 0001_initial to 0002_backfill_trigram_indexes (the index DDL itself will be a no-op since they already exist)