### PR TITLE
ephemeral-rebuild: post-incident hardening (SSM agent, trap order, S3 breadcrumb, log-bucket plumbing)

### DIFF
--- a/infra/ephemeral-rebuild/launcher/handler.py
+++ b/infra/ephemeral-rebuild/launcher/handler.py
@@ -10,10 +10,12 @@ sets InstanceInitiatedShutdownBehavior=terminate so the instance releases
 itself when bootstrap finishes (or panics into trap EXIT and runs
 ``shutdown -h now``).
 
-Env vars (all required, set by template.yaml):
-    LAUNCH_TEMPLATE_ID    LaunchTemplate id (lt-...)
+Env vars (set by template.yaml):
+    LAUNCH_TEMPLATE_ID    LaunchTemplate id (lt-...) — required
     REPO_BRANCH           branch of WXYC/discogs-etl to clone (default: main)
-    LOG_GROUP_NAME        ignored (CloudWatch Lambda log group is implicit)
+    LOG_BUCKET_NAME       S3 bucket where the bootstrap uploads its log
+                          archive + breadcrumb. Injected as
+                          REBUILD_LOG_BUCKET in the user-data stub.
 
 Tags applied to the spawned instance:
     Project=discogs-rebuild
@@ -37,24 +39,33 @@ USER_DATA_TEMPLATE = """#!/usr/bin/env bash
 set -euxo pipefail
 exec > >(tee /var/log/cloud-init-bootstrap.log | logger -t bootstrap) 2>&1
 
+# Plumbed from the launcher Lambda's env. The bootstrap reads
+# REBUILD_LOG_BUCKET to know where to drop its breadcrumb (#174) and the
+# trap-EXIT log archive (#173). Empty value falls through to the
+# script's "WARN: REBUILD_LOG_BUCKET unset; skipping S3 breadcrumb" path.
+export REBUILD_LOG_BUCKET={log_bucket}
+
 dnf install -y --quiet git
 git clone --depth 1 --branch {branch} https://github.com/WXYC/discogs-etl.git /opt/discogs-etl
 exec /opt/discogs-etl/scripts/rebuild-cache-bootstrap.sh
 """
 
 
-def build_user_data(branch: str) -> str:
+def build_user_data(branch: str, log_bucket: str = "") -> str:
     """Render the user-data stub. Kept tiny so changes to the heavy
-    bootstrap don't require redeploying the Lambda."""
-    return USER_DATA_TEMPLATE.format(branch=branch)
+    bootstrap don't require redeploying the Lambda. ``log_bucket`` is
+    injected as ``REBUILD_LOG_BUCKET``; empty string is allowed and lets
+    the bootstrap fall through to its skip-breadcrumb path."""
+    return USER_DATA_TEMPLATE.format(branch=branch, log_bucket=log_bucket)
 
 
 def lambda_handler(event, context, ec2_client=None):
     """Entry point. Boto3 client is injectable for unit tests."""
     branch = os.environ.get("REPO_BRANCH", "main")
     launch_template_id = os.environ["LAUNCH_TEMPLATE_ID"]
+    log_bucket = os.environ.get("LOG_BUCKET_NAME", "")
 
-    user_data = build_user_data(branch)
+    user_data = build_user_data(branch, log_bucket=log_bucket)
     timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H%MZ")
     name_tag = f"discogs-rebuild-{timestamp}"
 

--- a/infra/ephemeral-rebuild/template.yaml
+++ b/infra/ephemeral-rebuild/template.yaml
@@ -108,6 +108,15 @@ Resources:
           - Effect: Allow
             Principal: { Service: ec2.amazonaws.com }
             Action: sts:AssumeRole
+      # AmazonSSMManagedInstanceCore lets the SSM Agent on the spawned
+      # instance register with Systems Manager, which is what makes
+      # `aws ssm start-session --target <i-...>` work for live debugging
+      # mid-rebuild. Without it the instance is operator-blind for the
+      # ~90 min rebuild window — see #170 (filed after the 2026-05-09 first
+      # manual run, where the bootstrap died early and we couldn't tail
+      # /var/log/cloud-init-bootstrap.log to diagnose).
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
       Policies:
         - PolicyName: ssm-secrets-read
           PolicyDocument:
@@ -188,6 +197,12 @@ Resources:
         Variables:
           LAUNCH_TEMPLATE_ID: !Ref LaunchTemplate
           REPO_BRANCH: !Ref RepoBranch
+          # The bootstrap reads REBUILD_LOG_BUCKET from env to know where
+          # to upload its log archive + the S3 breadcrumb. Plumbed through
+          # here so the launcher can inject `export REBUILD_LOG_BUCKET=...`
+          # into the user-data stub. Without this both the breadcrumb
+          # (#174) and the trap-EXIT upload (#173) silently no-op.
+          LOG_BUCKET_NAME: !Ref LogBucket
       Policies:
         - Statement:
             - Effect: Allow

--- a/scripts/rebuild-cache-bootstrap.sh
+++ b/scripts/rebuild-cache-bootstrap.sh
@@ -34,30 +34,43 @@ set -euo pipefail
 REPO_DIR="${REPO_DIR:-/opt/discogs-etl}"
 CONVERTER_DIR="${CONVERTER_DIR:-/opt/discogs-xml-converter}"
 LOG_DIR="${LOG_DIR:-/var/log/discogs-rebuild}"
+LAUNCH_ID="bootstrap-$(date -u +%Y-%m-%dT%H%MZ)-pid$$"
 BOOTSTRAP_LOG="${LOG_DIR}/bootstrap-$(date -u +%Y-%m-%dT%H%MZ).log"
+# INSTANCE_ID is replaced by the IMDS-derived value once IMDSv2 is reachable.
+# Until then the trap and breadcrumb use $LAUNCH_ID as the S3 prefix, so a
+# crash before IMDS still leaves a per-launch trace findable by timestamp +
+# CloudTrail RunInstances correlation.
+INSTANCE_ID="$LAUNCH_ID"
+# AWS_REGION needs a default before the breadcrumb's `aws s3 cp` runs —
+# aws CLI on EC2 does not auto-resolve region from IMDS without it. The
+# launch template lives in us-east-1 so this default is correct in
+# practice; IMDS overrides it below for posterity.
+AWS_REGION="${AWS_REGION:-us-east-1}"
+export AWS_REGION
 
 mkdir -p "$LOG_DIR"
 exec > >(tee -a "$BOOTSTRAP_LOG") 2>&1
 
 log() { echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] $*"; }
 
-# IMDSv2: get a session token, then read instance id + region. Required
-# regardless of whether the script runs interactively or as user-data.
-imds_token() {
-    curl -fsS -X PUT 'http://169.254.169.254/latest/api/token' \
-        -H 'X-aws-ec2-metadata-token-ttl-seconds: 300' --max-time 5
-}
-imds_get() {
-    local token="$1" path="$2"
-    curl -fsS "http://169.254.169.254/latest/${path}" \
-        -H "X-aws-ec2-metadata-token: ${token}" --max-time 5
-}
-
-TOKEN="$(imds_token)"
-INSTANCE_ID="$(imds_get "$TOKEN" meta-data/instance-id)"
-AWS_REGION="${AWS_REGION:-$(imds_get "$TOKEN" meta-data/placement/region)}"
-export AWS_REGION
-log "instance ${INSTANCE_ID} region ${AWS_REGION}"
+# Drop a "bootstrap started" breadcrumb into S3 before any set-e-fatal
+# call. Even if everything below this line dies before the trap can run,
+# the operator at least sees a marker proving the script began executing.
+# Best-effort — `|| log WARN` keeps a credentials/network failure on the
+# breadcrumb itself from killing the script. See #174.
+{
+    echo "launch_id=${LAUNCH_ID}"
+    echo "pid=$$"
+    echo "utc=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+} > "$LOG_DIR/00-started.txt"
+if [ -n "${REBUILD_LOG_BUCKET:-}" ]; then
+    aws s3 cp --only-show-errors \
+        "$LOG_DIR/00-started.txt" \
+        "s3://${REBUILD_LOG_BUCKET}/${LAUNCH_ID}/00-started.txt" \
+        || true
+else
+    log "WARN: REBUILD_LOG_BUCKET unset; skipping S3 breadcrumb"
+fi
 
 # Slack helper. Reads SLACK_MONITORING_WEBHOOK from env once it is sourced.
 notify_slack() {
@@ -74,6 +87,8 @@ notify_slack() {
 # trap EXIT runs on every exit path — clean or panic. It uploads the log
 # and calls shutdown unconditionally so a crashed bootstrap can't leak the
 # instance past the InstanceInitiatedShutdownBehavior=terminate window.
+# Registered before any IMDS / SSM / dnf / git / curl call so an early
+# failure still triggers the upload-and-shutdown chain. See #173.
 on_exit() {
     local exit_code=$?
     set +e
@@ -90,6 +105,24 @@ on_exit() {
     /usr/sbin/shutdown -h now || true
 }
 trap on_exit EXIT
+
+# IMDSv2: get a session token, then read instance id + region. Required
+# regardless of whether the script runs interactively or as user-data.
+imds_token() {
+    curl -fsS -X PUT 'http://169.254.169.254/latest/api/token' \
+        -H 'X-aws-ec2-metadata-token-ttl-seconds: 300' --max-time 5
+}
+imds_get() {
+    local token="$1" path="$2"
+    curl -fsS "http://169.254.169.254/latest/${path}" \
+        -H "X-aws-ec2-metadata-token: ${token}" --max-time 5
+}
+
+TOKEN="$(imds_token)"
+INSTANCE_ID="$(imds_get "$TOKEN" meta-data/instance-id)"
+AWS_REGION="$(imds_get "$TOKEN" meta-data/placement/region)"
+export AWS_REGION
+log "instance ${INSTANCE_ID} region ${AWS_REGION}"
 
 # ---------------------------------------------------------------------------
 # 1. System packages (Amazon Linux 2023). Idempotent — re-running this

--- a/tests/unit/test_bootstrap_ordering.py
+++ b/tests/unit/test_bootstrap_ordering.py
@@ -1,0 +1,125 @@
+"""Pin the ordering invariants of ``scripts/rebuild-cache-bootstrap.sh``.
+
+A script that runs as user-data on a one-shot EC2 has one job before any
+"real" work: be observable on failure. The 2026-05-09 first-manual-rebuild
+attempt (instance ``i-0983db6d39958c76c``) demonstrated what happens when
+the script doesn't do that — the bootstrap died early under
+``set -euo pipefail``, the trap-EXIT upload-and-shutdown chain never ran,
+and the instance sat idle for 3h 43min before the sweeper Lambda's failsafe
+caught it. The S3 log bucket was empty; ``DeleteOnTermination=true`` on the
+EBS volume erased ``/var/log/cloud-init-bootstrap.log`` on terminate. We
+have zero forensic data about what the failing line was.
+
+These tests pin two structural rules:
+
+1. **An S3 "bootstrap started" breadcrumb is written before any
+   set-e-fatal call.** Even a 0-second crash leaves a marker in
+   ``s3://${REBUILD_LOG_BUCKET}/<launch-id>/00-started.txt`` so the
+   operator at least knows the script began executing. (#174)
+
+2. **``trap on_exit EXIT`` is registered before any IMDSv2 / SSM / dnf /
+   git / curl call.** Any subsequent failure path triggers the
+   upload-and-shutdown chain. (#173)
+
+The tests are static-structural: they parse the script and assert that the
+relevant fragments appear in the required order. They do not execute the
+script — that surface is covered by manual end-to-end retest after the next
+``sam deploy``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "rebuild-cache-bootstrap.sh"
+
+
+@pytest.fixture(scope="module")
+def script_lines() -> list[str]:
+    return SCRIPT_PATH.read_text().splitlines()
+
+
+def first_line_index(lines: list[str], needle: str) -> int:
+    """Return the index of the first non-comment line containing ``needle``.
+
+    Comment-only lines are ignored so doc-string updates can describe the
+    rule without dragging the test.
+    """
+    for i, line in enumerate(lines):
+        stripped = line.lstrip()
+        if stripped.startswith("#"):
+            continue
+        if needle in line:
+            return i
+    raise AssertionError(f"{needle!r} not found in non-comment lines of {SCRIPT_PATH}")
+
+
+def test_trap_on_exit_registered_before_imds_calls(script_lines: list[str]) -> None:
+    """#173: trap must be live before the script can early-exit on IMDSv2.
+
+    If IMDS is flaky or a metadata-network blip makes ``imds_token`` exit
+    non-zero, ``set -e`` kills the script. Without the trap registered,
+    no S3 upload, no ``shutdown -h now`` — instance sits idle until the 3h
+    sweeper.
+    """
+    trap_line = first_line_index(script_lines, "trap on_exit EXIT")
+    imds_token_line = first_line_index(script_lines, "imds_token()")
+    # The function definition is fine before the trap; what matters is the
+    # *call* site, which uses the function. The earliest call is the
+    # `TOKEN="$(imds_token)"` line.
+    imds_call_line = first_line_index(script_lines, 'TOKEN="$(imds_token)"')
+    assert trap_line < imds_call_line, (
+        f"trap on_exit EXIT (line {trap_line + 1}) must precede the first "
+        f"imds_token() call (line {imds_call_line + 1}). Otherwise an IMDS "
+        f"failure under set -e exits without firing the upload-and-shutdown "
+        f"hook. See #173."
+    )
+    # Sanity: trap registered after the function definition that on_exit refers to.
+    on_exit_def_line = first_line_index(script_lines, "on_exit()")
+    assert on_exit_def_line < trap_line, "on_exit() must be defined before `trap on_exit EXIT`."
+    # imds_token function definition can sit anywhere; we don't constrain it.
+    assert imds_token_line  # silence unused; kept for future expansion
+
+
+def test_s3_breadcrumb_written_before_trap_registration(script_lines: list[str]) -> None:
+    """#174: S3 marker must drop before the trap, so even a crash that
+    prevents the trap from running still leaves a forensic trace.
+
+    The marker key is ``<launch-id>/00-started.txt`` where ``<launch-id>``
+    is the IMDS-derived instance id when available, else a
+    timestamp+pid fallback.
+    """
+    marker_line = first_line_index(script_lines, "00-started.txt")
+    trap_line = first_line_index(script_lines, "trap on_exit EXIT")
+    assert marker_line < trap_line, (
+        f"S3 breadcrumb write (line {marker_line + 1}) must precede the trap "
+        f"(line {trap_line + 1}). Otherwise a crash before the trap leaves no "
+        f"S3 record. See #174."
+    )
+
+
+def test_s3_breadcrumb_uses_aws_s3_cp_with_or_true(script_lines: list[str]) -> None:
+    """#174: marker write must not be set-e-fatal itself.
+
+    If the breadcrumb write fails (creds not yet available, network blip),
+    the script must still proceed — the breadcrumb is best-effort
+    observability, not a precondition.
+    """
+    marker_line = first_line_index(script_lines, "00-started.txt")
+    # Find the closing aws s3 cp invocation in a small window after the marker
+    # line. ``aws s3 cp ... || true`` is the canonical shape; tolerate it
+    # spread across continuation lines.
+    window = "\n".join(script_lines[marker_line : marker_line + 8])
+    assert "aws s3 cp" in window, (
+        f"breadcrumb block near line {marker_line + 1} must use 'aws s3 cp' to "
+        f"write the marker. See #174 for the rationale (CloudWatch metric on "
+        f"the bucket gives a flat-zero signal if even this fails)."
+    )
+    assert "|| true" in window, (
+        f"breadcrumb 'aws s3 cp' near line {marker_line + 1} must end with "
+        f"'|| true' so a creds/network failure on the breadcrumb itself "
+        f"doesn't kill the script. See #174."
+    )

--- a/tests/unit/test_ephemeral_rebuild_launcher.py
+++ b/tests/unit/test_ephemeral_rebuild_launcher.py
@@ -119,3 +119,39 @@ def test_lambda_handler_raises_without_launch_template(handler_module, fake_ec2,
 
     with pytest.raises(KeyError):
         handler_module.lambda_handler({}, None, ec2_client=fake_ec2)
+
+
+def test_user_data_injects_log_bucket_env_var(handler_module):
+    """#174 prerequisite: REBUILD_LOG_BUCKET must reach the spawned EC2.
+
+    Without this plumbing, both the bootstrap's S3 breadcrumb (#174) and
+    the trap-EXIT log upload (#173) silently no-op — they gate on
+    ``${REBUILD_LOG_BUCKET:-}`` and skip when it's empty.
+    """
+    rendered = handler_module.build_user_data(
+        "main", log_bucket="wxyc-discogs-rebuild-logs-503977661500"
+    )
+    assert "export REBUILD_LOG_BUCKET=wxyc-discogs-rebuild-logs-503977661500" in rendered
+
+
+def test_lambda_handler_pipes_log_bucket_from_env(handler_module, fake_ec2, monkeypatch):
+    monkeypatch.setenv("LAUNCH_TEMPLATE_ID", "lt-0fab0123456789ab0")
+    monkeypatch.setenv("LOG_BUCKET_NAME", "wxyc-discogs-rebuild-logs-503977661500")
+
+    handler_module.lambda_handler({}, None, ec2_client=fake_ec2)
+
+    user_data = fake_ec2.run_instances.call_args.kwargs["UserData"]
+    assert "export REBUILD_LOG_BUCKET=wxyc-discogs-rebuild-logs-503977661500" in user_data
+
+
+def test_lambda_handler_tolerates_missing_log_bucket(handler_module, fake_ec2, monkeypatch):
+    """Missing LOG_BUCKET_NAME shouldn't crash the launcher; the bootstrap
+    is designed to skip its breadcrumb when REBUILD_LOG_BUCKET is empty
+    (with a logged warning) rather than fail."""
+    monkeypatch.setenv("LAUNCH_TEMPLATE_ID", "lt-0fab0123456789ab0")
+    monkeypatch.delenv("LOG_BUCKET_NAME", raising=False)
+
+    handler_module.lambda_handler({}, None, ec2_client=fake_ec2)
+
+    user_data = fake_ec2.run_instances.call_args.kwargs["UserData"]
+    assert "export REBUILD_LOG_BUCKET=" in user_data  # empty value, but key is present


### PR DESCRIPTION
## Summary

Closes #170, #173, #174. Three diagnostic + reliability fixes to the ephemeral-rebuild stack after the 2026-05-09 first-manual-rebuild attempt died early under `set -euo pipefail` with no forensic trace, plus a fourth piece of env-var plumbing the breadcrumb depends on (turned out to be a latent gap that would have made #174 a silent no-op).

| Issue | Change |
|---|---|
| #170 | `InstanceRole` gains `AmazonSSMManagedInstanceCore` — SSM Agent registers with Systems Manager so `aws ssm start-session --target <i-…>` works for live mid-rebuild debugging. |
| #173 | `scripts/rebuild-cache-bootstrap.sh` registers `trap on_exit EXIT` *before* any IMDSv2 / SSM / dnf / git / curl call, so an early failure still triggers the upload-and-shutdown chain instead of leaving the instance idle for 3h. |
| #174 | Same script writes `s3://${REBUILD_LOG_BUCKET}/${LAUNCH_ID}/00-started.txt` before any set-e-fatal call, with `|| true` so a network blip on the breadcrumb itself doesn't kill the script. Even a 0-second crash leaves a forensic trace. |
| (this PR) | `LauncherFunction` template gains `LOG_BUCKET_NAME`, and the launcher Lambda injects `export REBUILD_LOG_BUCKET=…` into user-data. Without this both #173 and #174 ship as silent no-ops — the bootstrap's existing S3 calls already gated on `${REBUILD_LOG_BUCKET:-}` but nothing was setting it. |

## Test plan

- [x] `pytest tests/unit/` — 683 passing, 3 deselected (pg-marked), 1 xfail.
- [x] New: `tests/unit/test_bootstrap_ordering.py` — three structural tests pinning the trap-before-IMDS / breadcrumb-before-trap / breadcrumb-uses-`|| true` invariants. Static, no script execution.
- [x] New: 3 cases in `tests/unit/test_ephemeral_rebuild_launcher.py` for the `LOG_BUCKET_NAME` env-var injection (configured / missing-env / asserts the export line lands in user-data).
- [x] `ruff check . && ruff format --check .` clean.
- [x] `sam validate --lint -t infra/ephemeral-rebuild/template.yaml` clean.
- [x] `shellcheck scripts/rebuild-cache-bootstrap.sh` clean.
- [ ] After merge: `sam deploy` to apply the IAM + env-var changes, then `aws lambda invoke discogs-rebuild-launcher` for run #2. With #170 in place, `aws ssm start-session` should work for live tailing this time.

## Notes

- The bootstrap initializes `INSTANCE_ID="$LAUNCH_ID"` (a `bootstrap-<utc>-pid<n>` placeholder) so the trap and breadcrumb both have a meaningful S3 prefix even when IMDS is the failure mode. Once IMDS resolves, `INSTANCE_ID` is reassigned to the real value and the trap's recursive upload lands under the natural `<i-…>/` prefix; the immediate breadcrumb stays at `<launch-id>/` and is correlatable via the timestamp baked into its name.
- `AWS_REGION` now defaults to `us-east-1` before the breadcrumb's `aws s3 cp` runs — aws CLI on EC2 doesn't auto-resolve region from IMDS without an env hint, and the launch template lives in us-east-1 anyway. IMDS overrides it for posterity once reachable.
- No changes to the sweeper Lambda — the 2026-05-09 incident proved its 3h failsafe works correctly, and it's the right behavior to keep as the second line of defense.

## Related

- WXYC/discogs-etl#170, #173, #174 (closed by this PR)
- WXYC/discogs-etl#163 (closed) — original ephemeral-rebuild epic
- 2026-05-09 incident: instance `i-0983db6d39958c76c`, sweeper-terminated at 20:20:41 UTC