### PR TITLE
fix(ephemeral-rebuild): default HOME/USER/LOGNAME for cloud-init's stripped env

### DIFF
--- a/scripts/rebuild-cache-bootstrap.sh
+++ b/scripts/rebuild-cache-bootstrap.sh
@@ -31,6 +31,16 @@
 
 set -euo pipefail
 
+# cloud-init runs user-data with a stripped environment — HOME, USER, and
+# LOGNAME are not set, and `set -u` trips the moment the script references
+# any of them (e.g. the Rust-install `"$HOME/.cargo/bin/cargo"` line, or
+# `sudo chown "$USER:$USER" "$CONVERTER_DIR"`). Default to root-appropriate
+# values up front; an interactive shell inherits the existing values and
+# these no-op. See #176 (caught live on the 2026-05-10 run #2 attempt).
+export HOME="${HOME:-/root}"
+export USER="${USER:-root}"
+export LOGNAME="${LOGNAME:-root}"
+
 REPO_DIR="${REPO_DIR:-/opt/discogs-etl}"
 CONVERTER_DIR="${CONVERTER_DIR:-/opt/discogs-xml-converter}"
 LOG_DIR="${LOG_DIR:-/var/log/discogs-rebuild}"

--- a/tests/unit/test_bootstrap_ordering.py
+++ b/tests/unit/test_bootstrap_ordering.py
@@ -101,6 +101,37 @@ def test_s3_breadcrumb_written_before_trap_registration(script_lines: list[str])
     )
 
 
+def test_home_env_defaulted_before_any_home_reference(script_lines: list[str]) -> None:
+    """#176: cloud-init strips HOME/USER/LOGNAME from user-data's env.
+
+    Under ``set -u`` the bootstrap's first reference to ``$HOME`` (the
+    Rust-install ``"$HOME/.cargo/bin/cargo"`` block) trips with
+    'unbound variable' and exits before doing any real work. Confirmed
+    live on the 2026-05-10 run #2 attempt at instance
+    ``i-08acdffcd38db4906`` — caught precisely because the post-#175
+    trap+S3-archive chain landed the failing log in S3 within 80
+    seconds of launch.
+
+    Same applies to ``$USER`` (``sudo chown "$USER:$USER" ...``) — both
+    must be defaulted up-front.
+    """
+    home_default_line = first_line_index(script_lines, 'HOME="${HOME:-')
+    home_use_line = first_line_index(script_lines, '"$HOME/')
+    assert home_default_line < home_use_line, (
+        f"HOME default (line {home_default_line + 1}) must precede the first "
+        f'"$HOME/..." use (line {home_use_line + 1}). cloud-init starts user-'
+        f"data with HOME unset; under set -u the first reference dies. See #176."
+    )
+
+    user_default_line = first_line_index(script_lines, 'USER="${USER:-')
+    user_use_line = first_line_index(script_lines, '"$USER:$USER"')
+    assert user_default_line < user_use_line, (
+        f"USER default (line {user_default_line + 1}) must precede the first "
+        f'"$USER:$USER" use (line {user_use_line + 1}). Same cloud-init env-'
+        f"strip story as HOME. See #176."
+    )
+
+
 def test_s3_breadcrumb_uses_aws_s3_cp_with_or_true(script_lines: list[str]) -> None:
     """#174: marker write must not be set-e-fatal itself.
 


### PR DESCRIPTION
## Summary

Closes #176. One-line bug fix to `scripts/rebuild-cache-bootstrap.sh`: cloud-init runs user-data with `HOME` / `USER` / `LOGNAME` unset, and the bootstrap's `set -euo pipefail` plus `"$HOME/.cargo/bin/cargo"` reference trips with 'unbound variable' before the Rust toolchain installs.

Diagnosed live on the 2026-05-10 run #2 attempt. The post-#175 trap+S3-archive chain landed the bootstrap log in S3 within 80 seconds of instance launch:

```
[03:42:58Z] instance i-08acdffcd38db4906 region us-east-1
[03:42:58Z] dnf install build deps + postgres client + gh
... (dnf + gh succeed)
[03:43:24Z] install Rust toolchain
/opt/discogs-etl/scripts/rebuild-cache-bootstrap.sh: line 158: HOME: unbound variable
[03:43:24Z] on_exit (exit_code=1)
```

Almost certainly the same bug killed the 2026-05-09 run #1 too. Pre-#175 the trap was registered *after* IMDS, so on early failure we sat for 3h 43min waiting for the sweeper Lambda's failsafe with no log archive — which is exactly why #175's reordering was needed.

## What changes

`scripts/rebuild-cache-bootstrap.sh` — three env defaults right after `set -euo pipefail`:

```bash
export HOME="${HOME:-/root}"
export USER="${USER:-root}"
export LOGNAME="${LOGNAME:-root}"
```

Interactive shells inherit existing values; these are no-ops.

`tests/unit/test_bootstrap_ordering.py` — new test pinning the ordering invariant: `HOME="${HOME:-` must precede `"$HOME/`, and `USER="${USER:-` must precede `"$USER:$USER"`. Static parse of the script, no execution.

## Test plan

- [x] New test fails red against current bootstrap; passes green after the fix.
- [x] `pytest tests/unit/` — 684 passing, 3 deselected, 1 xfail.
- [x] `shellcheck scripts/rebuild-cache-bootstrap.sh` clean.
- [x] `ruff check . && ruff format --check .` clean.
- [ ] After merge: bootstrap rolls forward into Rust install on the next manual rebuild.

## Related

- WXYC/discogs-etl#176 (closes)
- WXYC/discogs-etl#175 (post-incident hardening — turned a silent 3h hang into a 6 min observable failure; this PR is the actual underlying bug)
- 2026-05-10 run #2 incident: `i-08acdffcd38db4906`, `s3://wxyc-discogs-rebuild-logs-503977661500/i-08acdffcd38db4906/bootstrap-2026-05-10T0342Z.log`