### PR TITLE
[E1 §4.1.1] Add wxyc_library v2 hook to Docker discogs cache

### DIFF
--- a/alembic/versions/0003_wxyc_library_v2.py
+++ b/alembic/versions/0003_wxyc_library_v2.py
@@ -1,0 +1,206 @@
+"""wxyc_library v2 hook (consolidated cross-cache identity schema)
+
+Lands E1 §4.1.1 of the cross-cache-identity plan:
+https://github.com/WXYC/wiki/blob/main/plans/library-hook-canonicalization.md#411-docker-discogs-port-5433-dev-subset
+
+Creates the new consolidated ``wxyc_library`` table that replaces the historical
+per-cache hooks. Per the canonical schema in §3.1:
+
+- One row per library release; library_id is the Backend wxyc_schema.library.id
+- Carries normalized artist / title / label for cache-side joins
+- B-tree indexes inline (small-table dev subset)
+- GIN trigram indexes on norm_artist + norm_title built CONCURRENTLY after the
+  table itself lands, mirroring the autocommit-side-channel pattern from
+  0001_initial / 0002_backfill_trigram_indexes (CREATE INDEX CONCURRENTLY can
+  not run inside alembic's wrapping transaction).
+
+``artist_id`` / ``label_id`` / ``format_id`` / ``release_year`` are nullable,
+matching §3.1 (per-cache loaders populate what their source exposes; not all
+do).
+
+Naming note: the spec called this revision ``0002_wxyc_library_v2`` but the
+slot was taken by ``0002_backfill_trigram_indexes`` (which landed in the
+interim, see PR #173 / commit 197009d). This revision chains as 0003 to
+preserve the linear history alembic expects.
+
+Revision ID: 0003_wxyc_library_v2
+Revises: 0002_backfill_trigram_indexes
+Create Date: 2026-05-10
+
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from collections.abc import Sequence
+
+import psycopg
+from psycopg import sql
+
+from alembic import context
+
+# revision identifiers, used by Alembic.
+revision: str = "0003_wxyc_library_v2"
+down_revision: str | Sequence[str] | None = "0002_backfill_trigram_indexes"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+# ---------------------------------------------------------------------------
+# DDL
+# ---------------------------------------------------------------------------
+
+# Per §3.1. Comments are deliberately verbose — this table is the cross-cache
+# contract and consumers (LML, semantic-index, audits) read pg_description.
+_CREATE_TABLE = """
+CREATE TABLE IF NOT EXISTS wxyc_library (
+    library_id      INTEGER PRIMARY KEY,
+    artist_id       INTEGER,
+    artist_name     TEXT NOT NULL,
+    album_title     TEXT NOT NULL,
+    label_id        INTEGER,
+    label_name      TEXT,
+    format_id       INTEGER,
+    format_name     TEXT,
+    wxyc_genre      TEXT,
+    call_letters    TEXT,
+    call_numbers    INTEGER,
+    release_year    SMALLINT,
+    norm_artist     TEXT NOT NULL,
+    norm_title      TEXT NOT NULL,
+    norm_label      TEXT,
+    snapshot_at     TIMESTAMPTZ NOT NULL,
+    snapshot_source TEXT NOT NULL
+        CHECK (snapshot_source IN ('backend', 'tubafrenzy', 'llm'))
+);
+
+COMMENT ON TABLE wxyc_library IS
+    'Consolidated WXYC library hook. Per §3.1 of '
+    'plans/library-hook-canonicalization.md. One row per library release; '
+    'library_id mirrors Backend wxyc_schema.library.id.';
+COMMENT ON COLUMN wxyc_library.library_id IS 'Backend wxyc_schema.library.id';
+COMMENT ON COLUMN wxyc_library.artist_id IS
+    'Backend wxyc_schema.artists.id. Nullable: this cache reads from '
+    'library.db (a SQLite catalog export) which does not carry it.';
+COMMENT ON COLUMN wxyc_library.format_id IS
+    'Backend wxyc_schema.format.id. Nullable for the same reason as artist_id.';
+COMMENT ON COLUMN wxyc_library.release_year IS
+    'Sourced from flowsheet.release_year aggregated per library_id, with a '
+    'fallback to a matched Discogs/MB release year. NULL for rows that '
+    'pre-date metadata enrichment.';
+COMMENT ON COLUMN wxyc_library.snapshot_at IS
+    'When this row was last written. Cross-cache freshness is observable '
+    'via the spread of snapshot_at across caches.';
+COMMENT ON COLUMN wxyc_library.snapshot_source IS
+    'Origin of the snapshot: backend | tubafrenzy | llm. Loaders set this '
+    'based on which CatalogSource produced the row.';
+"""
+
+# B-tree indexes — built inline with the table because this is the small-
+# subset dev cache (≤64K rows after Option-B drop-the-filter; tens-to-low-
+# hundreds of rows in fixture tests). On the larger Homebrew caches §4.1.4
+# warns that even these inline B-trees should run CONCURRENTLY; on this
+# Docker cache the cost is sub-second.
+_BTREE_INDEXES = """
+CREATE INDEX IF NOT EXISTS wxyc_library_norm_artist_idx
+    ON wxyc_library (norm_artist);
+CREATE INDEX IF NOT EXISTS wxyc_library_norm_title_idx
+    ON wxyc_library (norm_title);
+CREATE INDEX IF NOT EXISTS wxyc_library_artist_id_idx
+    ON wxyc_library (artist_id);
+CREATE INDEX IF NOT EXISTS wxyc_library_format_id_idx
+    ON wxyc_library (format_id);
+CREATE INDEX IF NOT EXISTS wxyc_library_release_year_idx
+    ON wxyc_library (release_year);
+"""
+
+# GIN trigram indexes — same CONCURRENTLY pattern as
+# 0002_backfill_trigram_indexes. Built after the table + B-tree indexes are in
+# place. ``gin_trgm_ops`` requires the pg_trgm extension, which the baseline
+# (0001_initial) already creates.
+_TRIGRAM_INDEXES: tuple[tuple[str, str], ...] = (
+    ("wxyc_library_norm_artist_trgm_idx", "norm_artist"),
+    ("wxyc_library_norm_title_trgm_idx", "norm_title"),
+)
+
+_CREATE_TRGM_INDEX = sql.SQL(
+    "CREATE INDEX CONCURRENTLY IF NOT EXISTS {index_name} "
+    "ON wxyc_library USING GIN ({column} gin_trgm_ops)"
+)
+_DROP_TRGM_INDEX = sql.SQL("DROP INDEX CONCURRENTLY IF EXISTS {index_name}")
+
+
+# ---------------------------------------------------------------------------
+# Helpers (mirror 0002_backfill_trigram_indexes)
+# ---------------------------------------------------------------------------
+
+
+def _resolve_db_url() -> str:
+    db_url = os.environ.get("DATABASE_URL_DISCOGS") or os.environ.get("DATABASE_URL")
+    if not db_url:
+        raise RuntimeError(
+            "DATABASE_URL_DISCOGS (or DATABASE_URL) must be set to apply "
+            "0003_wxyc_library_v2."
+        )
+    return db_url
+
+
+def _refuse_offline(direction: str) -> None:
+    if context.is_offline_mode():
+        raise RuntimeError(
+            f"0003_wxyc_library_v2 does not support --sql / offline mode "
+            f"({direction}): CREATE/DROP INDEX CONCURRENTLY cannot run inside "
+            "a transaction, so this revision opens its own autocommit psycopg "
+            "connection that bypasses alembic's offline SQL emission. Run "
+            "`alembic upgrade head` (or `downgrade`) against a live DB instead."
+        )
+
+
+# ---------------------------------------------------------------------------
+# upgrade / downgrade
+# ---------------------------------------------------------------------------
+
+
+def upgrade() -> None:
+    _refuse_offline("upgrade")
+
+    log = logging.getLogger("alembic.runtime.migration")
+    db_url = _resolve_db_url()
+
+    # Phase 1: create the table + B-tree indexes inside a regular (autocommit)
+    # connection. Splitting these from the CONCURRENTLY block below makes the
+    # migration cheaply restartable: if the trgm-index step fails, the table
+    # is already in place and re-running the migration is a no-op for it.
+    with psycopg.connect(db_url, autocommit=True) as conn, conn.cursor() as cur:
+        log.info("0003: creating wxyc_library table")
+        cur.execute(_CREATE_TABLE)
+        log.info("0003: creating wxyc_library b-tree indexes")
+        cur.execute(_BTREE_INDEXES)
+
+    # Phase 2: GIN trigram indexes via CREATE INDEX CONCURRENTLY. Each runs in
+    # its own autocommit statement.
+    with psycopg.connect(db_url, autocommit=True) as conn, conn.cursor() as cur:
+        for index_name, column in _TRIGRAM_INDEXES:
+            log.info("0003: building %s on wxyc_library(%s)", index_name, column)
+            cur.execute(
+                _CREATE_TRGM_INDEX.format(
+                    index_name=sql.Identifier(index_name),
+                    column=sql.Identifier(column),
+                )
+            )
+
+
+def downgrade() -> None:
+    _refuse_offline("downgrade")
+
+    db_url = _resolve_db_url()
+
+    # Drop the trigram indexes CONCURRENTLY first (cheap if they don't exist),
+    # then the table itself (which cascades the remaining b-tree indexes).
+    with psycopg.connect(db_url, autocommit=True) as conn, conn.cursor() as cur:
+        for index_name, _ in _TRIGRAM_INDEXES:
+            cur.execute(
+                _DROP_TRGM_INDEX.format(index_name=sql.Identifier(index_name))
+            )
+        cur.execute("DROP TABLE IF EXISTS wxyc_library")

--- a/alembic/versions/0003_wxyc_library_v2.py
+++ b/alembic/versions/0003_wxyc_library_v2.py
@@ -140,8 +140,7 @@ def _resolve_db_url() -> str:
     db_url = os.environ.get("DATABASE_URL_DISCOGS") or os.environ.get("DATABASE_URL")
     if not db_url:
         raise RuntimeError(
-            "DATABASE_URL_DISCOGS (or DATABASE_URL) must be set to apply "
-            "0003_wxyc_library_v2."
+            "DATABASE_URL_DISCOGS (or DATABASE_URL) must be set to apply 0003_wxyc_library_v2."
         )
     return db_url
 
@@ -200,7 +199,5 @@ def downgrade() -> None:
     # then the table itself (which cascades the remaining b-tree indexes).
     with psycopg.connect(db_url, autocommit=True) as conn, conn.cursor() as cur:
         for index_name, _ in _TRIGRAM_INDEXES:
-            cur.execute(
-                _DROP_TRGM_INDEX.format(index_name=sql.Identifier(index_name))
-            )
+            cur.execute(_DROP_TRGM_INDEX.format(index_name=sql.Identifier(index_name)))
         cur.execute("DROP TABLE IF EXISTS wxyc_library")

--- a/loaders/__init__.py
+++ b/loaders/__init__.py
@@ -1,0 +1,1 @@
+"""Loaders that populate cache-side hook tables from the WXYC library catalog."""

--- a/loaders/wxyc.py
+++ b/loaders/wxyc.py
@@ -82,7 +82,11 @@ class LibraryRow:
     Mirrors §3.1's column list. ``artist_id`` / ``label_id`` / ``format_id``
     / ``release_year`` are nullable: per-cache loaders populate what their
     source exposes, and library.db (the SQLite catalog export this loader
-    reads) does not carry Backend's integer IDs.
+    reads) does not carry Backend's integer IDs. **For this cache today,
+    every row stamps NULL on those four columns** — there's no follow-up
+    path that backfills them; they exist for forward compatibility with a
+    future Backend-direct loader (or a wxyc-catalog ``BackendServiceSource``
+    SELECT extension that exposes the IDs).
     """
 
     library_id: int
@@ -247,6 +251,10 @@ def populate_wxyc_library_v2(
     ]
 
     stmt = _INSERT_V2.format(table=sql.Identifier(table))
+    # NOTE: psycopg3's executemany is essentially a Python-side loop; for the
+    # ≤64K-row prod load this completes in seconds. If load times become an
+    # issue (e.g. on the full discogs cache once §4.1.4 lands), switch to
+    # `psycopg.copy()` or a single multi-VALUES INSERT.
     with pg_conn.cursor() as cur:
         cur.executemany(stmt, payload)
     pg_conn.commit()

--- a/loaders/wxyc.py
+++ b/loaders/wxyc.py
@@ -1,0 +1,264 @@
+"""WXYC library hook loader for the Docker discogs cache.
+
+Implements E1 §4.1.1 of the cross-cache-identity plan:
+https://github.com/WXYC/wiki/blob/main/plans/library-hook-canonicalization.md#411-docker-discogs-port-5433-dev-subset
+
+- :func:`populate_wxyc_library_v2` — the consolidated loader per §3.1.
+  Target table ``wxyc_library``. Loads ALL library rows (Option B from
+  ``WXYC/catalog-audits#11``); no filter. Per the wiki §4.1.1 amendment,
+  this cache is schema-validation only — there is no in-repo legacy
+  predecessor and no dual-write window to police.
+
+The loader reads from a SQLite ``library.db``, is idempotent
+(``ON CONFLICT (library_id) DO NOTHING``), and writes the normalization
+columns required by the new schema.
+
+Normalization
+=============
+
+The new schema requires ``norm_artist`` / ``norm_title`` / ``norm_label`` —
+populated by ``wxyc_etl.text`` (the canonical Rust/PyO3 implementation of
+the plan §3.3.2 algorithm; lives in ``wxyc-etl`` ≥ 0.3.0).
+
+Per the plan, the loader uses two sibling functions:
+
+- :func:`wxyc_etl.text.to_identity_match_form` — locked-on baseline. Used
+  for ``norm_artist`` AND ``norm_label`` (labels share the artist-side
+  pipeline; no ``_label`` variant exists or is needed).
+- :func:`wxyc_etl.text.to_identity_match_form_title` — title-side variant.
+  Used for ``norm_title``.
+
+The opt-in variants (``_with_punctuation``, ``_with_disambiguator_strip``)
+are deliberately not invoked here — the cross-cache-identity hook stays on
+the locked-on baseline so every consumer cache normalizes identically.
+"""
+
+from __future__ import annotations
+
+import logging
+import sqlite3
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import psycopg
+from psycopg import sql
+from wxyc_etl.text import to_identity_match_form, to_identity_match_form_title
+
+from lib.pg_text import strip_pg_null_bytes
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Normalization
+# ---------------------------------------------------------------------------
+# Identifier preserved for log messages and integration-test sentinels.
+NORMALIZER_NAME = "wxyc_etl.text.to_identity_match_form"
+
+
+def _norm_label(value: str | None) -> str | None:
+    """Identity-tier normalization for the optional label column.
+
+    The PyO3 binding accepts ``Option<&str>`` and returns an empty string for
+    ``None``; we want NULL to flow through to PostgreSQL for the nullable
+    ``norm_label`` column, so re-introduce the None at the boundary.
+    """
+    if value is None:
+        return None
+    return to_identity_match_form(value)
+
+
+# ---------------------------------------------------------------------------
+# Row model
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class LibraryRow:
+    """A single row for the wxyc_library hook.
+
+    Mirrors §3.1's column list. ``artist_id`` / ``label_id`` / ``format_id``
+    / ``release_year`` are nullable: per-cache loaders populate what their
+    source exposes, and library.db (the SQLite catalog export this loader
+    reads) does not carry Backend's integer IDs.
+    """
+
+    library_id: int
+    artist_name: str
+    album_title: str
+    artist_id: int | None = None
+    label_id: int | None = None
+    label_name: str | None = None
+    format_id: int | None = None
+    format_name: str | None = None
+    wxyc_genre: str | None = None
+    call_letters: str | None = None
+    call_numbers: int | None = None
+    release_year: int | None = None
+
+
+# ---------------------------------------------------------------------------
+# Reading library.db
+# ---------------------------------------------------------------------------
+
+
+# library.db is produced by wxyc-catalog. The minimal-fixture schema is
+# (id, artist, title, format); the prod schema has more (genre, call_letters,
+# etc.). We adapt to whatever columns are present rather than failing.
+_OPTIONAL_COLUMNS = (
+    "label",
+    "genre",
+    "call_letters",
+    "release_call_number",
+    "format",
+)
+
+
+def _existing_columns(conn: sqlite3.Connection, table: str) -> set[str]:
+    rows = conn.execute(f"PRAGMA table_info({table})").fetchall()
+    return {row[1] for row in rows}
+
+
+def _read_library_db(library_db_path: Path) -> list[LibraryRow]:
+    """Read every row from a library.db SQLite file into LibraryRow records."""
+    if not library_db_path.exists():
+        raise FileNotFoundError(f"library.db not found at {library_db_path}")
+
+    with sqlite3.connect(library_db_path) as conn:
+        conn.row_factory = sqlite3.Row
+        cols = _existing_columns(conn, "library")
+
+        select_parts = ["id", "artist", "title"]
+        for c in _OPTIONAL_COLUMNS:
+            if c in cols:
+                select_parts.append(c)
+        query = f"SELECT {', '.join(select_parts)} FROM library"  # noqa: S608
+
+        rows: list[LibraryRow] = []
+        for row in conn.execute(query):
+            data: dict[str, Any] = dict(row)
+            rows.append(
+                LibraryRow(
+                    library_id=int(data["id"]),
+                    artist_name=str(data["artist"]),
+                    album_title=str(data["title"]),
+                    label_name=data.get("label"),
+                    format_name=data.get("format"),
+                    wxyc_genre=data.get("genre"),
+                    call_letters=data.get("call_letters"),
+                    call_numbers=(
+                        int(data["release_call_number"])
+                        if data.get("release_call_number") is not None
+                        else None
+                    ),
+                )
+            )
+    return rows
+
+
+# ---------------------------------------------------------------------------
+# Writer
+# ---------------------------------------------------------------------------
+
+
+_INSERT_V2 = sql.SQL(
+    """
+    INSERT INTO {table} (
+        library_id, artist_id, artist_name, album_title,
+        label_id, label_name, format_id, format_name,
+        wxyc_genre, call_letters, call_numbers, release_year,
+        norm_artist, norm_title, norm_label,
+        snapshot_at, snapshot_source
+    ) VALUES (
+        %(library_id)s, %(artist_id)s, %(artist_name)s, %(album_title)s,
+        %(label_id)s, %(label_name)s, %(format_id)s, %(format_name)s,
+        %(wxyc_genre)s, %(call_letters)s, %(call_numbers)s, %(release_year)s,
+        %(norm_artist)s, %(norm_title)s, %(norm_label)s,
+        %(snapshot_at)s, %(snapshot_source)s
+    )
+    ON CONFLICT (library_id) DO NOTHING
+    """
+)
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def populate_wxyc_library_v2(
+    pg_conn: psycopg.Connection,
+    library_db_path: Path,
+    *,
+    snapshot_source: str = "backend",
+    table: str = "wxyc_library",
+    snapshot_at: datetime | None = None,
+) -> int:
+    """Populate the consolidated hook table from library.db.
+
+    Per E1 §4.1.1 + §3.1: every library row is written (Option B; no filter).
+    Idempotent on ``library_id`` (``ON CONFLICT DO NOTHING``).
+
+    Args:
+        pg_conn: psycopg connection to the discogs cache database.
+        library_db_path: SQLite library.db produced by ``wxyc-export-to-sqlite``.
+        snapshot_source: ``backend`` | ``tubafrenzy`` | ``llm`` per §3.1.
+        table: target table name. Override only for tests.
+        snapshot_at: timestamp to stamp on every row. Defaults to ``now()``.
+
+    Returns the number of rows attempted (pre-conflict).
+    """
+    if snapshot_source not in ("backend", "tubafrenzy", "llm"):
+        raise ValueError(
+            f"snapshot_source must be backend|tubafrenzy|llm, got {snapshot_source!r}"
+        )
+
+    rows = _read_library_db(library_db_path)
+    if not rows:
+        logger.warning("populate_wxyc_library_v2: no rows from %s", library_db_path)
+        return 0
+
+    stamp = snapshot_at or datetime.now(timezone.utc)
+    payload = [
+        {
+            "library_id": r.library_id,
+            "artist_id": r.artist_id,
+            "artist_name": strip_pg_null_bytes(r.artist_name),
+            "album_title": strip_pg_null_bytes(r.album_title),
+            "label_id": r.label_id,
+            "label_name": strip_pg_null_bytes(r.label_name),
+            "format_id": r.format_id,
+            "format_name": strip_pg_null_bytes(r.format_name),
+            "wxyc_genre": strip_pg_null_bytes(r.wxyc_genre),
+            "call_letters": strip_pg_null_bytes(r.call_letters),
+            "call_numbers": r.call_numbers,
+            "release_year": r.release_year,
+            # norm_artist / norm_title are NOT NULL per §3.1; the normalizer
+            # collapses to a non-empty string for any non-empty input. If it
+            # ever returns an empty string for a real artist/title, that's a
+            # bug worth crashing on — no `or ""` fallback.
+            "norm_artist": to_identity_match_form(r.artist_name),
+            "norm_title": to_identity_match_form_title(r.album_title),
+            "norm_label": _norm_label(r.label_name),
+            "snapshot_at": stamp,
+            "snapshot_source": snapshot_source,
+        }
+        for r in rows
+    ]
+
+    stmt = _INSERT_V2.format(table=sql.Identifier(table))
+    with pg_conn.cursor() as cur:
+        cur.executemany(stmt, payload)
+    pg_conn.commit()
+
+    logger.info(
+        "populate_wxyc_library_v2: wrote %d rows to %s "
+        "(snapshot_source=%s, normalizer=%s)",
+        len(rows),
+        table,
+        snapshot_source,
+        NORMALIZER_NAME,
+    )
+    return len(rows)

--- a/loaders/wxyc.py
+++ b/loaders/wxyc.py
@@ -211,9 +211,7 @@ def populate_wxyc_library_v2(
     Returns the number of rows attempted (pre-conflict).
     """
     if snapshot_source not in ("backend", "tubafrenzy", "llm"):
-        raise ValueError(
-            f"snapshot_source must be backend|tubafrenzy|llm, got {snapshot_source!r}"
-        )
+        raise ValueError(f"snapshot_source must be backend|tubafrenzy|llm, got {snapshot_source!r}")
 
     rows = _read_library_db(library_db_path)
     if not rows:
@@ -254,8 +252,7 @@ def populate_wxyc_library_v2(
     pg_conn.commit()
 
     logger.info(
-        "populate_wxyc_library_v2: wrote %d rows to %s "
-        "(snapshot_source=%s, normalizer=%s)",
+        "populate_wxyc_library_v2: wrote %d rows to %s (snapshot_source=%s, normalizer=%s)",
         len(rows),
         table,
         snapshot_source,

--- a/schema/create_database.sql
+++ b/schema/create_database.sql
@@ -193,6 +193,35 @@ CREATE TABLE cache_metadata (
 );
 
 -- ============================================
+-- WXYC library hook (cross-cache-identity §3.1)
+-- ============================================
+-- One row per library release; library_id mirrors Backend wxyc_schema.library.id.
+-- Mirrored from alembic/versions/0003_wxyc_library_v2.py per the dual-write
+-- convention so a fresh rebuild produces the same end state as the alembic
+-- upgrade chain.
+DROP TABLE IF EXISTS wxyc_library CASCADE;
+CREATE TABLE wxyc_library (
+    library_id      integer PRIMARY KEY,
+    artist_id       integer,
+    artist_name     text NOT NULL,
+    album_title     text NOT NULL,
+    label_id        integer,
+    label_name      text,
+    format_id       integer,
+    format_name     text,
+    wxyc_genre      text,
+    call_letters    text,
+    call_numbers    integer,
+    release_year    smallint,
+    norm_artist     text NOT NULL,
+    norm_title      text NOT NULL,
+    norm_label      text,
+    snapshot_at     timestamptz NOT NULL,
+    snapshot_source text NOT NULL
+        CHECK (snapshot_source IN ('backend', 'tubafrenzy', 'llm'))
+);
+
+-- ============================================
 -- Indexes
 -- ============================================
 

--- a/schema/create_indexes.sql
+++ b/schema/create_indexes.sql
@@ -23,6 +23,34 @@ CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_release_title_trgm
 ON release USING GIN (lower(f_unaccent(title)) gin_trgm_ops);
 
 -- ============================================
+-- WXYC library hook indexes (cross-cache-identity §3.1)
+-- ============================================
+-- Mirrored from alembic/versions/0003_wxyc_library_v2.py per the dual-write
+-- convention. The alembic migration runs the same DDL inside an autocommit
+-- side-channel so it is restartable; this file uses CONCURRENTLY to match
+-- the prevailing style in this file (run on a populated DB).
+
+-- B-tree indexes
+CREATE INDEX CONCURRENTLY IF NOT EXISTS wxyc_library_norm_artist_idx
+ON wxyc_library (norm_artist);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS wxyc_library_norm_title_idx
+ON wxyc_library (norm_title);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS wxyc_library_artist_id_idx
+ON wxyc_library (artist_id);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS wxyc_library_format_id_idx
+ON wxyc_library (format_id);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS wxyc_library_release_year_idx
+ON wxyc_library (release_year);
+
+-- GIN trigram indexes (locked-on-baseline normalized columns; no f_unaccent
+-- because the columns are already case-folded and diacritic-folded by
+-- wxyc_etl.text.to_identity_match_form{,_title}).
+CREATE INDEX CONCURRENTLY IF NOT EXISTS wxyc_library_norm_artist_trgm_idx
+ON wxyc_library USING GIN (norm_artist gin_trgm_ops);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS wxyc_library_norm_title_trgm_idx
+ON wxyc_library USING GIN (norm_title gin_trgm_ops);
+
+-- ============================================
 -- Verification queries
 -- ============================================
 

--- a/tests/integration/test_alembic_backfill_trigram_indexes.py
+++ b/tests/integration/test_alembic_backfill_trigram_indexes.py
@@ -59,10 +59,12 @@ def _present_trigram_indexes(db_url: str) -> set[str]:
 
 @pytest.mark.pg
 def test_upgrade_to_head_creates_all_four_trigram_indexes(fresh_db_url: str) -> None:
-    """Fresh DB → upgrade head → all four indexes exist + version stamped at 0002."""
-    result = _run_alembic(["upgrade", "head"], fresh_db_url)
+    """Fresh DB → upgrade through 0002 → all four indexes exist + version stamped at 0002."""
+    # Pin the upgrade to this specific revision so the assertion stays stable
+    # as later revisions land on top of head.
+    result = _run_alembic(["upgrade", "0002_backfill_trigram_indexes"], fresh_db_url)
     assert result.returncode == 0, (
-        f"alembic upgrade head failed:\nstdout: {result.stdout}\nstderr: {result.stderr}"
+        f"alembic upgrade 0002 failed:\nstdout: {result.stdout}\nstderr: {result.stderr}"
     )
 
     assert _present_trigram_indexes(fresh_db_url) == EXPECTED_INDEXES, (
@@ -107,10 +109,10 @@ def test_upgrade_is_idempotent_when_indexes_already_exist(fresh_db_url: str) -> 
 
 @pytest.mark.pg
 def test_downgrade_drops_the_four_trigram_indexes(fresh_db_url: str) -> None:
-    """Apply head, then downgrade -1, indexes should be gone and version backed off."""
-    apply = _run_alembic(["upgrade", "head"], fresh_db_url)
+    """Apply through 0002, then downgrade -1, indexes should be gone and version backed off."""
+    apply = _run_alembic(["upgrade", "0002_backfill_trigram_indexes"], fresh_db_url)
     assert apply.returncode == 0, (
-        f"upgrade head failed:\nstdout: {apply.stdout}\nstderr: {apply.stderr}"
+        f"upgrade 0002 failed:\nstdout: {apply.stdout}\nstderr: {apply.stderr}"
     )
 
     down = _run_alembic(["downgrade", "-1"], fresh_db_url)

--- a/tests/integration/test_schema.py
+++ b/tests/integration/test_schema.py
@@ -255,7 +255,13 @@ class TestCreateBaseIndexes:
         assert expected.issubset(indexes)
 
     def test_base_trigram_indexes_use_unaccent(self) -> None:
-        """Base trigram indexes use f_unaccent() for accent-insensitive matching."""
+        """Base trigram indexes use f_unaccent() for accent-insensitive matching.
+
+        ``wxyc_library_*_trgm_idx`` are excluded because their backing columns
+        (``norm_artist`` / ``norm_title``) are pre-normalized at write time by
+        ``wxyc_etl.text.to_identity_match_form{,_title}`` — already case-folded
+        and diacritic-folded — so ``f_unaccent`` would be redundant.
+        """
         conn = psycopg.connect(self.db_url, autocommit=True)
         with conn.cursor() as cur:
             sql = SCHEMA_DIR.joinpath("create_indexes.sql").read_text()
@@ -266,6 +272,7 @@ class TestCreateBaseIndexes:
                 SELECT indexname, indexdef FROM pg_indexes
                 WHERE schemaname = 'public'
                   AND indexname LIKE '%trgm%'
+                  AND indexname NOT LIKE 'wxyc_library_%'
             """)
             rows = cur.fetchall()
         conn.close()

--- a/tests/integration/test_wxyc_library_v2.py
+++ b/tests/integration/test_wxyc_library_v2.py
@@ -52,8 +52,7 @@ def migrated_db(fresh_db_url: str) -> Iterator[str]:
     """Apply alembic upgrade head to a fresh DB; yield its URL."""
     result = _run_alembic(["upgrade", "head"], fresh_db_url)
     assert result.returncode == 0, (
-        f"alembic upgrade head failed:\n"
-        f"stdout: {result.stdout}\nstderr: {result.stderr}"
+        f"alembic upgrade head failed:\nstdout: {result.stdout}\nstderr: {result.stderr}"
     )
     yield fresh_db_url
 
@@ -132,9 +131,7 @@ def test_migration_creates_wxyc_library_with_indexes(migrated_db: str) -> None:
 
 
 @pytest.mark.pg
-def test_v2_loader_writes_every_fixture_row(
-    migrated_db: str, library_db: Path
-) -> None:
+def test_v2_loader_writes_every_fixture_row(migrated_db: str, library_db: Path) -> None:
     """Option B: every library.db row lands in wxyc_library, fully populated.
 
     This is the §4.1.1 verifier — fixture-based, not legacy-parity, since this
@@ -166,8 +163,7 @@ def test_v2_loader_writes_every_fixture_row(
         assert norm_artist, f"norm_artist empty for library_id={library_id}"
         assert norm_title, f"norm_title empty for library_id={library_id}"
         assert source == "backend", (
-            f"snapshot_source for library_id={library_id} was {source!r}, "
-            f"expected 'backend'"
+            f"snapshot_source for library_id={library_id} was {source!r}, expected 'backend'"
         )
 
 
@@ -187,9 +183,7 @@ def test_v2_loader_is_idempotent(migrated_db: str, library_db: Path) -> None:
 
 
 @pytest.mark.pg
-def test_v2_loader_rejects_invalid_snapshot_source(
-    migrated_db: str, library_db: Path
-) -> None:
+def test_v2_loader_rejects_invalid_snapshot_source(migrated_db: str, library_db: Path) -> None:
     """The CHECK constraint in §3.1 is mirrored in the loader's argument check."""
     with psycopg.connect(migrated_db) as conn:  # noqa: F841 (unused; ValueError raises before write)
         with pytest.raises(ValueError, match="snapshot_source"):

--- a/tests/integration/test_wxyc_library_v2.py
+++ b/tests/integration/test_wxyc_library_v2.py
@@ -70,6 +70,10 @@ _FIXTURE_ROWS = [
         "Jazz",
     ),
     (5, "Stereolab", "Aluminum Tunes", "CD", "Duophonic", "Rock"),
+    # Diacritic-bearing canonical name from wxyc-shared's wxycCanonicalArtistNames.
+    # Exercises the diacritic-fold path through the storage layer end-to-end —
+    # the normalizer pin test below asserts ü is folded.
+    (6, "Nilüfer Yanya", "Painless", "LP", "ATO Records", "Rock"),
 ]
 
 
@@ -224,3 +228,24 @@ def test_normalizer_is_to_identity_match_form(migrated_db: str, library_db: Path
         assert norm_a == to_identity_match_form(artist)
         assert norm_t == to_identity_match_form_title(title)
         assert norm_l == to_identity_match_form(label)
+
+        # Hard-coded value pin: catches algorithm drift in wxyc-etl (the
+        # equality assertions above pass even if both sides change). Library
+        # row 1 is "Juana Molina" / "DOGA" / "Sonamos" — no diacritics, no
+        # leading articles, just lowercasing.
+        assert norm_a == "juana molina"
+        assert norm_t == "doga"
+        assert norm_l == "sonamos"
+
+        # Diacritic-fold pin: row 6 has ü which must fold to u in storage.
+        # Property assertion (not a hard-coded value) so the test is robust
+        # to other normalization changes that don't affect diacritic folding.
+        with conn.cursor() as cur:
+            cur.execute("SELECT norm_artist FROM wxyc_library WHERE library_id = 6")
+            (norm_a_diacritic,) = cur.fetchone()
+        assert "ü" not in norm_a_diacritic, (
+            f"diacritic survived normalization: {norm_a_diacritic!r}"
+        )
+        assert norm_a_diacritic.lower() == norm_a_diacritic, (
+            f"normalization should lowercase: {norm_a_diacritic!r}"
+        )

--- a/tests/integration/test_wxyc_library_v2.py
+++ b/tests/integration/test_wxyc_library_v2.py
@@ -1,0 +1,232 @@
+"""Integration tests for the v2 wxyc_library hook (E1 §4.1.1).
+
+Validates the alembic migration ``0003_wxyc_library_v2`` and the matching
+``populate_wxyc_library_v2()`` loader from ``loaders/wxyc.py``. Per the wiki
+§4.1.1 amendment, this cache is schema-validation only — there is no in-repo
+legacy predecessor to compare against, so the loader is verified against the
+input fixture's row count rather than a parity comparator.
+
+Marked ``pg`` because every test connects to PostgreSQL via the shared
+``fresh_db_url`` / ``db_url`` fixtures from ``tests/conftest.py``.
+"""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+import subprocess
+import sys
+from collections.abc import Iterator
+from pathlib import Path
+
+import psycopg
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT))
+
+from loaders.wxyc import (  # noqa: E402  (sys.path side-effect above)
+    NORMALIZER_NAME,
+    populate_wxyc_library_v2,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _run_alembic(args: list[str], db_url: str) -> subprocess.CompletedProcess[str]:
+    env = {**os.environ, "DATABASE_URL_DISCOGS": db_url}
+    env.pop("DATABASE_URL", None)
+    return subprocess.run(
+        [sys.executable, "-m", "alembic", *args],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+
+@pytest.fixture()
+def migrated_db(fresh_db_url: str) -> Iterator[str]:
+    """Apply alembic upgrade head to a fresh DB; yield its URL."""
+    result = _run_alembic(["upgrade", "head"], fresh_db_url)
+    assert result.returncode == 0, (
+        f"alembic upgrade head failed:\n"
+        f"stdout: {result.stdout}\nstderr: {result.stderr}"
+    )
+    yield fresh_db_url
+
+
+_FIXTURE_ROWS = [
+    (1, "Juana Molina", "DOGA", "LP", "Sonamos", "Rock"),
+    (2, "Jessica Pratt", "On Your Own Love Again", "LP", "Drag City", "Rock"),
+    (3, "Chuquimamani-Condori", "Edits", "CD", "self-released", "Electronic"),
+    (
+        4,
+        "Duke Ellington & John Coltrane",
+        "Duke Ellington & John Coltrane",
+        "LP",
+        "Impulse Records",
+        "Jazz",
+    ),
+    (5, "Stereolab", "Aluminum Tunes", "CD", "Duophonic", "Rock"),
+]
+
+
+@pytest.fixture()
+def library_db(tmp_path: Path) -> Path:
+    """Build a tiny library.db with WXYC-representative artists.
+
+    Uses the canonical fixture rows from the org-level CLAUDE.md.
+    """
+    db_path = tmp_path / "library.db"
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            """
+            CREATE TABLE library (
+                id INTEGER PRIMARY KEY,
+                artist TEXT NOT NULL,
+                title TEXT NOT NULL,
+                format TEXT,
+                label TEXT,
+                genre TEXT
+            )
+            """
+        )
+        conn.executemany(
+            "INSERT INTO library (id, artist, title, format, label, genre) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            _FIXTURE_ROWS,
+        )
+        conn.commit()
+    return db_path
+
+
+# ---------------------------------------------------------------------------
+# Migration + loader tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.pg
+def test_migration_creates_wxyc_library_with_indexes(migrated_db: str) -> None:
+    """Migration lands the table + b-tree + GIN trgm indexes per §3.1."""
+    expected_indexes = {
+        "wxyc_library_pkey",
+        "wxyc_library_norm_artist_idx",
+        "wxyc_library_norm_title_idx",
+        "wxyc_library_artist_id_idx",
+        "wxyc_library_format_id_idx",
+        "wxyc_library_release_year_idx",
+        "wxyc_library_norm_artist_trgm_idx",
+        "wxyc_library_norm_title_trgm_idx",
+    }
+    with psycopg.connect(migrated_db) as conn, conn.cursor() as cur:
+        cur.execute(
+            "SELECT indexname FROM pg_indexes "
+            "WHERE schemaname = 'public' AND tablename = 'wxyc_library'"
+        )
+        present = {row[0] for row in cur.fetchall()}
+    missing = expected_indexes - present
+    assert not missing, f"missing indexes after migration: {missing}; present: {present}"
+
+
+@pytest.mark.pg
+def test_v2_loader_writes_every_fixture_row(
+    migrated_db: str, library_db: Path
+) -> None:
+    """Option B: every library.db row lands in wxyc_library, fully populated.
+
+    This is the §4.1.1 verifier — fixture-based, not legacy-parity, since this
+    cache is schema-validation only and has no in-repo legacy predecessor.
+    Asserts:
+      - row count matches the fixture
+      - every fixture library_id is present
+      - every row has populated norm_artist / norm_title
+      - every row has snapshot_source = 'backend'
+    """
+    expected_ids = {row[0] for row in _FIXTURE_ROWS}
+
+    with psycopg.connect(migrated_db) as conn:
+        written = populate_wxyc_library_v2(conn, library_db, snapshot_source="backend")
+        assert written == len(_FIXTURE_ROWS)
+
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT library_id, artist_name, album_title, "
+                "norm_artist, norm_title, snapshot_source "
+                "FROM wxyc_library ORDER BY library_id"
+            )
+            rows = cur.fetchall()
+
+    assert {r[0] for r in rows} == expected_ids
+    for library_id, artist_name, album_title, norm_artist, norm_title, source in rows:
+        assert artist_name, f"artist_name empty for library_id={library_id}"
+        assert album_title, f"album_title empty for library_id={library_id}"
+        assert norm_artist, f"norm_artist empty for library_id={library_id}"
+        assert norm_title, f"norm_title empty for library_id={library_id}"
+        assert source == "backend", (
+            f"snapshot_source for library_id={library_id} was {source!r}, "
+            f"expected 'backend'"
+        )
+
+
+@pytest.mark.pg
+def test_v2_loader_is_idempotent(migrated_db: str, library_db: Path) -> None:
+    """Re-running the loader on the same library.db is a no-op (ON CONFLICT)."""
+    with psycopg.connect(migrated_db) as conn:
+        first = populate_wxyc_library_v2(conn, library_db)
+        second = populate_wxyc_library_v2(conn, library_db)
+        # Both calls report rows-attempted, not rows-inserted; idempotency is
+        # observable in COUNT(*).
+        assert first == second == len(_FIXTURE_ROWS)
+        with conn.cursor() as cur:
+            cur.execute("SELECT COUNT(*) FROM wxyc_library")
+            (count,) = cur.fetchone()
+        assert count == len(_FIXTURE_ROWS)
+
+
+@pytest.mark.pg
+def test_v2_loader_rejects_invalid_snapshot_source(
+    migrated_db: str, library_db: Path
+) -> None:
+    """The CHECK constraint in §3.1 is mirrored in the loader's argument check."""
+    with psycopg.connect(migrated_db) as conn:  # noqa: F841 (unused; ValueError raises before write)
+        with pytest.raises(ValueError, match="snapshot_source"):
+            populate_wxyc_library_v2(conn, library_db, snapshot_source="bogus")
+
+
+@pytest.mark.pg
+def test_normalizer_is_to_identity_match_form(migrated_db: str, library_db: Path) -> None:
+    """The loader is locked onto ``wxyc_etl.text.to_identity_match_form``.
+
+    Per plans/library-hook-canonicalization.md §3.3 / E3 step 4 — the
+    cross-cache-identity hook runs on the locked-on baseline, not on any
+    opt-in variant. ``NORMALIZER_NAME`` is the audit string the loader emits
+    in INFO logs; this test pins both the constant and the actual normalized
+    output so a future API rename is caught even if the constant drifts.
+    """
+    with psycopg.connect(migrated_db) as conn:
+        populate_wxyc_library_v2(conn, library_db)
+
+        # The audit string names the locked-on baseline.
+        assert NORMALIZER_NAME == "wxyc_etl.text.to_identity_match_form"
+
+        # The actual normalized values match what the canonical functions
+        # produce — diacritic-fold + case-fold + collapse — so any future
+        # algorithm drift in wxyc-etl is caught here.
+        from wxyc_etl.text import (
+            to_identity_match_form,
+            to_identity_match_form_title,
+        )
+
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT artist_name, album_title, label_name, "
+                "norm_artist, norm_title, norm_label "
+                "FROM wxyc_library WHERE library_id = 1"
+            )
+            artist, title, label, norm_a, norm_t, norm_l = cur.fetchone()
+        assert norm_a == to_identity_match_form(artist)
+        assert norm_t == to_identity_match_form_title(title)
+        assert norm_l == to_identity_match_form(label)


### PR DESCRIPTION
## Summary

First in the serial E1 cache rollout for the cross-cache-identity initiative (WXYC/wxyc-etl#72 epic). Lands the consolidated `wxyc_library` schema in the Docker dev cache (port 5433) per the canonical schema in [WXYC/wiki plans/library-hook-canonicalization.md §3.1](https://github.com/WXYC/wiki/blob/main/plans/library-hook-canonicalization.md#31-the-library-hook).

This cache is **schema-validation only** — see amended [§4.1.1](https://github.com/WXYC/wiki/blob/main/plans/library-hook-canonicalization.md#411-docker-discogs-port-5433-dev-subset) + the [§4.2 dual-write exemption](https://github.com/WXYC/wiki/blob/main/plans/library-hook-canonicalization.md#42-dual-write-window-and-observability). The historical 23,977-row hook in this cache was loaded out-of-band; `discogs-etl` has never had a Python predecessor, so the verifier is fixture-based, not legacy-parity.

## Migration

- `alembic/versions/0003_wxyc_library_v2.py` — new table + 5 b-tree indexes inline + 2 GIN trigram indexes via `CREATE INDEX CONCURRENTLY` (autocommit side-channel pattern matching `0001_initial` / `0002_backfill_trigram_indexes`)
- `schema/create_database.sql` + `schema/create_indexes.sql` — mirrored DDL per the project's dual-write convention; fresh rebuild produces the same end state as the alembic chain

Slot `0002` is occupied by `0002_backfill_trigram_indexes`, so this revision chains as `0003`.

## Loader

- `loaders/wxyc.py::populate_wxyc_library_v2()` — reads `library.db` (SQLite, produced by wxyc-catalog) and writes the new schema
- Idempotent on `library_id` (`ON CONFLICT DO NOTHING`)
- Loads ALL library rows per WXYC/catalog-audits#11 Option B sign-off (no filter)
- `norm_artist` / `norm_label` ← `wxyc_etl.text.to_identity_match_form`
- `norm_title` ← `wxyc_etl.text.to_identity_match_form_title`
- `artist_id` / `label_id` / `format_id` / `release_year` left nullable — the SQLite source carries names but not Backend IDs (per amended §3.1 canonical schema)

## Tests

- [x] `pytest tests/integration -m pg -k wxyc_library_v2` — 5/5 pass
- [x] `pytest tests/integration -m pg` — 254 pass, 1 skip (full suite, no regressions)
- [x] `ruff check .` — clean
- [x] `pytest` (default no-marker) — pre-existing failures unrelated to this work, confirmed reproducible against `origin/main`

## Follow-up filed

- #184 — reshape `test_base_trigram_indexes_use_unaccent` from blocklist to allowlist. The blocklist exclusion (`AND indexname NOT LIKE 'wxyc_library_%'`) in this PR is the minimum-viable fix.

## Test plan

- [x] Migration applies cleanly + creates all 8 indexes
- [x] Loader idempotent on `library_id`
- [x] `snapshot_source` CHECK rejects invalid values
- [x] Normalization round-trips through `wxyc_etl.text`
- [x] Schema/*.sql parity with alembic migration

Closes #178