### PR TITLE
Pin reusable workflow refs to gha/v1

### DIFF
--- a/.github/workflows/charset-corpus-drift.yml
+++ b/.github/workflows/charset-corpus-drift.yml
@@ -14,9 +14,10 @@ on:
 
 jobs:
   drift:
-    uses: WXYC/wxyc-shared/.github/workflows/check-charset-corpus-drift.yml@main
+    uses: WXYC/wxyc-shared/.github/workflows/check-charset-corpus-drift.yml@gha/v1
     with:
       pinned-sha256: 75a3395bb10894480dba95bf5b7f379f5056645098d6a1bf9e94416709e5214a
       package-version: "0.10.0"
+      wxyc-shared-ref: gha/v1
     secrets:
       npm-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,8 +84,9 @@ jobs:
           --cov-fail-under=60
 
   marker-sync:
-    uses: WXYC/wxyc-etl/.github/workflows/check-ci-marker-sync.yml@main
+    uses: WXYC/wxyc-etl/.github/workflows/check-ci-marker-sync.yml@gha/v1
     with:
       repo-path: "."
       workflows-dir: ".github/workflows"
       tests-dir: "tests"
+      wxyc-etl-ref: gha/v1


### PR DESCRIPTION
## Summary

Pins reusable workflow refs from `@main` to the new `gha/v1` stability tags on `wxyc-shared` / `wxyc-etl`, and passes the matching `*-ref` input so the inner script checkout in each reusable workflow stays pinned (default was `main`).

## Why

Before this PR, a push to `wxyc-shared/main` or `wxyc-etl/main` would cascade into this repo's CI with this repo's secrets. The new `gha/v1` stability tags provide a pin-able ref. Tag policy: `gha/v1` moves for non-breaking updates; `gha/v2` for breaking changes.

## Project

Part of [GitHub Actions Supply-Chain Hardening](https://github.com/orgs/WXYC/projects/31), Phase 2.

## Test plan

- [ ] Reusable-workflow jobs still pass after merge.