### PR TITLE
Bump aws-actions/setup-sam to v3 and configure-aws-credentials to v6

### DIFF
--- a/.github/workflows/deploy-ephemeral-rebuild.yml
+++ b/.github/workflows/deploy-ephemeral-rebuild.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-      - uses: aws-actions/setup-sam@v2
+      - uses: aws-actions/setup-sam@v3
         with:
           use-installer: true
       - name: SAM validate
@@ -48,10 +48,10 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-      - uses: aws-actions/setup-sam@v2
+      - uses: aws-actions/setup-sam@v3
         with:
           use-installer: true
-      - uses: aws-actions/configure-aws-credentials@v4
+      - uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
## Summary

- Bump `aws-actions/setup-sam@v2` → `@v3` (lines 31, 51) and `aws-actions/configure-aws-credentials@v4` → `@v6` (line 54) in `.github/workflows/deploy-ephemeral-rebuild.yml` so the actions run on Node 24 before GitHub's 2026-06-02 auto-coercion.
- `setup-sam@v3` (released 2026-05-01) is a pure Node 16→24 runtime bump per its release notes.
- `configure-aws-credentials@v6` (released 2026-02-04, latest v6.1.1 on 2026-05-05) bumps the action runtime to Node 24; the only other breaking change in the v5/v6 line is stricter boolean-input parsing, which doesn't apply here — only string secrets are passed.
- Confirmed these are the only `aws-actions/*` pins in `.github/workflows/`; no other workflow files need bumping.

## Test plan

- [x] Repo CI passes on the PR
- [ ] Once #188 is resolved and the Ephemeral Rebuild Stack workflow runs end-to-end, the Node 20 deprecation annotation is no longer emitted

The ephemeral-rebuild workflow is itself blocked on #188 (Discogs S3 403); end-to-end verification of these bumps waits on that. Landing this now so a second class of failure doesn't compound after #188 resolves.

Closes #200

Sibling tickets (independent, no ordering required): WXYC/wxyc-canary#21 (merged), WXYC/Backend-Service#846.