### PR TITLE
Rebuild pipeline: TRUNCATE-existing, prebuilt binary, c6i.large

### DIFF
--- a/infra/ephemeral-rebuild/template.yaml
+++ b/infra/ephemeral-rebuild/template.yaml
@@ -25,11 +25,13 @@ Parameters:
 
   InstanceType:
     Type: String
-    Default: t3.medium
+    Default: c6i.large
     Description: >
-      EC2 instance type. t3.medium (~$0.04/hr on-demand) clears the
-      90-minute rebuild comfortably. Bump to c6i.large or larger if a
-      future schema or library expansion pushes wall-clock past the budget.
+      EC2 instance type. c6i.large (~$0.10/hr on-demand) is roughly 2x
+      faster than t3.medium on the converter scan (CPU-bound) and the
+      cargo build, at ~$0.06 marginal cost per monthly run (1.5 hr).
+      Use t3.medium (~$0.04/hr) via --parameter-overrides for non-critical
+      reruns where time matters less than cost.
 
   RootVolumeSizeGb:
     Type: Number

--- a/scripts/import_csv.py
+++ b/scripts/import_csv.py
@@ -208,6 +208,60 @@ MASTER_TABLES: list[TableConfig] = [
 TABLES: list[TableConfig] = BASE_TABLES + TRACK_TABLES + VIDEO_TABLES
 
 
+# Cache tables wiped by --truncate-existing. Matches the operator-level
+# manual TRUNCATE SQL used when re-running a rebuild against a destination
+# DB that holds stale rows from a prior failed attempt. Two exclusions:
+#
+#   - entity.identity / entity.reconciliation_log — WXYC-side identity
+#     records the rebuild must NOT touch.
+#   - alembic_version — migration history must persist across rebuilds.
+#
+# The list is mode-agnostic. --base-only and --tracks-only both share it
+# because stale data in any of these tables can fail a future rebuild
+# regardless of which mode is running first.
+CACHE_TABLES_TO_TRUNCATE: list[str] = [
+    "release",
+    "release_artist",
+    "release_label",
+    "release_genre",
+    "release_style",
+    "release_track",
+    "release_track_artist",
+    "release_video",
+    "artist",
+    "artist_alias",
+    "artist_member",
+    "artist_name_variation",
+    "artist_url",
+    "master",
+    "master_artist",
+    "cache_metadata",
+]
+
+
+def _truncate_tables(conn, table_names: list[str]) -> None:
+    """Wipe the named tables with a single TRUNCATE ... CASCADE.
+
+    One statement keeps the operation atomic (either all empty or none).
+    CASCADE handles FK dependencies for any table not in the explicit list
+    (e.g., release_image's FK to release if release_image is ever added to
+    the schema but not yet to CACHE_TABLES_TO_TRUNCATE).
+
+    Commits immediately. Otherwise parallel workers — which open fresh
+    connections via ``_import_tables_parallel`` — would still see the
+    pre-TRUNCATE rows under MVCC isolation and the COPY would fail with
+    the same duplicate-key violation we're trying to avoid.
+    """
+    if not table_names:
+        return
+    quoted = ", ".join(f'"{t}"' for t in table_names)
+    sql = f"TRUNCATE {quoted} CASCADE"
+    logger.warning(f"--truncate-existing: TRUNCATE {len(table_names)} cache tables")
+    with conn.cursor() as cur:
+        cur.execute(sql)
+    conn.commit()
+
+
 def import_csv(
     conn,
     csv_path: Path,
@@ -723,6 +777,14 @@ def main():
         action="store_true",
         help="Import only track tables, filtered to surviving release IDs",
     )
+    parser.add_argument(
+        "--truncate-existing",
+        action="store_true",
+        help="TRUNCATE the cache tables before COPY. Use when re-running a "
+        "rebuild against a DB with stale rows from a prior failed attempt. "
+        "Preserves entity.identity and alembic_version. Without this flag, "
+        "a duplicate-key violation on the first table aborts the pipeline.",
+    )
 
     args = parser.parse_args()
     csv_dir = args.csv_dir
@@ -734,6 +796,9 @@ def main():
 
     logger.info(f"Connecting to {db_url}")
     conn = psycopg.connect(db_url)
+
+    if args.truncate_existing:
+        _truncate_tables(conn, CACHE_TABLES_TO_TRUNCATE)
 
     if args.tracks_only:
         # Query surviving release IDs from the database

--- a/scripts/import_csv.py
+++ b/scripts/import_csv.py
@@ -208,18 +208,21 @@ MASTER_TABLES: list[TableConfig] = [
 TABLES: list[TableConfig] = BASE_TABLES + TRACK_TABLES + VIDEO_TABLES
 
 
-# Cache tables wiped by --truncate-existing. Matches the operator-level
-# manual TRUNCATE SQL used when re-running a rebuild against a destination
-# DB that holds stale rows from a prior failed attempt. Two exclusions:
+# Cache tables wiped by --truncate-existing, partitioned by mode. The base
+# set wipes the full cache; the tracks set wipes only the tables that
+# --tracks-only writes to. Two exclusions in either set:
 #
 #   - entity.identity / entity.reconciliation_log — WXYC-side identity
 #     records the rebuild must NOT touch.
 #   - alembic_version — migration history must persist across rebuilds.
 #
-# The list is mode-agnostic. --base-only and --tracks-only both share it
-# because stale data in any of these tables can fail a future rebuild
-# regardless of which mode is running first.
-CACHE_TABLES_TO_TRUNCATE: list[str] = [
+# Mode-awareness matters: in a full run_pipeline.py invocation the base
+# step runs first, then dedup, then the tracks step. If --tracks-only
+# wiped base tables, the tracks step would erase the just-deduped data
+# and find zero release IDs to filter against. The tracks subset only
+# touches track-domain tables, so a tracks-only rerun against an
+# already-populated cache only refreshes the tracks.
+CACHE_TABLES_TO_TRUNCATE_BASE: list[str] = [
     "release",
     "release_artist",
     "release_label",
@@ -236,6 +239,12 @@ CACHE_TABLES_TO_TRUNCATE: list[str] = [
     "master",
     "master_artist",
     "cache_metadata",
+]
+
+CACHE_TABLES_TO_TRUNCATE_TRACKS: list[str] = [
+    "release_track",
+    "release_track_artist",
+    "release_video",
 ]
 
 
@@ -798,7 +807,10 @@ def main():
     conn = psycopg.connect(db_url)
 
     if args.truncate_existing:
-        _truncate_tables(conn, CACHE_TABLES_TO_TRUNCATE)
+        truncate_set = (
+            CACHE_TABLES_TO_TRUNCATE_TRACKS if args.tracks_only else CACHE_TABLES_TO_TRUNCATE_BASE
+        )
+        _truncate_tables(conn, truncate_set)
 
     if args.tracks_only:
         # Query surviving release IDs from the database

--- a/scripts/rebuild-cache.sh
+++ b/scripts/rebuild-cache.sh
@@ -88,8 +88,40 @@ echo "[$(date -u +%H:%M:%SZ)] refresh Python venv + Rust converter binary"
 # shellcheck disable=SC1091
 source "$REPO_DIR/.venv/bin/activate"
 pip install --quiet -e "${REPO_DIR}[dev]"
-(cd "$CONVERTER_DIR" && cargo build --release --quiet)
-export PATH="$CONVERTER_DIR/target/release:$PATH"
+
+# Try the prebuilt converter binary published by WXYC/discogs-xml-converter's
+# Release Binary workflow. Skips the ~20-30 min cargo build on EC2. Falls back
+# to source build on any failure (release not published yet, asset missing,
+# checksum mismatch, network error) so the rebuild stays resilient against
+# converter-side publishing problems. The function returns non-zero on any
+# step that fails; the caller decides whether to fall back.
+download_prebuilt_converter() {
+    local target_dir="$1"
+    mkdir -p "$target_dir"
+    # gh works against public repos without auth and honors GH_TOKEN when set.
+    if ! gh release download \
+            --repo WXYC/discogs-xml-converter \
+            --pattern 'discogs-xml-converter-linux-x86_64.tar.gz' \
+            --pattern 'discogs-xml-converter-linux-x86_64.tar.gz.sha256' \
+            --dir "$target_dir" \
+            --clobber; then
+        return 1
+    fi
+    (cd "$target_dir" && sha256sum -c discogs-xml-converter-linux-x86_64.tar.gz.sha256) || return 1
+    tar -xzf "$target_dir/discogs-xml-converter-linux-x86_64.tar.gz" -C "$target_dir" || return 1
+    test -x "$target_dir/discogs-xml-converter" || return 1
+    return 0
+}
+
+PREBUILT_DIR="$REPO_DIR/.prebuilt-converter"
+if download_prebuilt_converter "$PREBUILT_DIR"; then
+    echo "    using prebuilt converter from WXYC/discogs-xml-converter latest release"
+    export PATH="$PREBUILT_DIR:$PATH"
+else
+    echo "    prebuilt binary unavailable; falling back to cargo build"
+    (cd "$CONVERTER_DIR" && cargo build --release --quiet)
+    export PATH="$CONVERTER_DIR/target/release:$PATH"
+fi
 
 # ---------------------------------------------------------------------------
 # 3. Pull daily-fresh library.db produced by sync-library workflow
@@ -171,10 +203,17 @@ curl -fL --continue-at - --retry 5 --retry-delay 30 --retry-all-errors \
 echo "    download complete ($(du -h "$WORK_DIR/releases.xml.gz" | cut -f1))"
 
 echo "[$(date -u +%H:%M:%SZ)] start pipeline"
+# --truncate-existing wipes the cache tables before COPY so a rerun after a
+# prior failed rebuild doesn't hit a duplicate-key violation on the first
+# table (the failure mode from WXYC/discogs-etl#188's 2026-05-13 run). The
+# flag is a no-op on a freshly-stamped DB, so it's safe to keep on
+# unconditionally — the only cost is ~1s of TRUNCATE DDL on empty tables.
+# Preserves entity.identity and alembic_version.
 python "$REPO_DIR/scripts/run_pipeline.py" \
     --xml "$WORK_DIR/releases.xml.gz" \
     --xml-type releases \
-    --library-db "$WORK_DIR/library.db"
+    --library-db "$WORK_DIR/library.db" \
+    --truncate-existing
 
 # ---------------------------------------------------------------------------
 # 6. Drift watchdog — same library.db the pipeline just filtered against

--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -269,6 +269,14 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         help="Path to pipeline state file for tracking/resuming progress "
         "(default: .pipeline_state.json).",
     )
+    parser.add_argument(
+        "--truncate-existing",
+        action="store_true",
+        help="Pass --truncate-existing to scripts/import_csv.py so the cache "
+        "tables are wiped before COPY. Use when re-running a rebuild against "
+        "a DB with stale rows from a prior failed attempt. Preserves "
+        "entity.identity and alembic_version.",
+    )
 
     args = parser.parse_args(argv)
 
@@ -792,6 +800,7 @@ def _run_xml_pipeline(
                 label_hierarchy=hierarchy_csv,
                 catalog_source=args.catalog_source,
                 catalog_db_url=args.catalog_db_url,
+                truncate_existing=args.truncate_existing,
             )
 
     if keep_csv_dir is not None:
@@ -856,6 +865,7 @@ def main() -> None:
             catalog_db_url=args.catalog_db_url,
             state=state,
             state_file=args.state_file,
+            truncate_existing=args.truncate_existing,
         )
 
     total = time.monotonic() - pipeline_start
@@ -986,6 +996,7 @@ def _run_database_build(
     catalog_db_url: str | None = None,
     state: PipelineState | None = None,
     state_file: Path | None = None,
+    truncate_existing: bool = False,
 ) -> None:
     """Database build: create_schema through vacuum.
 
@@ -1027,10 +1038,11 @@ def _run_database_build(
     if state and state.is_completed("import_csv"):
         logger.info("Skipping import_csv (already completed)")
     else:
-        run_step(
-            "Import base CSVs",
-            [python, str(SCRIPT_DIR / "import_csv.py"), "--base-only", str(csv_dir), db_url],
-        )
+        import_cmd = [python, str(SCRIPT_DIR / "import_csv.py"), "--base-only"]
+        if truncate_existing:
+            import_cmd.append("--truncate-existing")
+        import_cmd.extend([str(csv_dir), db_url])
+        run_step("Import base CSVs", import_cmd)
         if state:
             state.mark_completed("import_csv")
             _save_state()
@@ -1097,10 +1109,11 @@ def _run_database_build(
     if state and state.is_completed("import_tracks"):
         logger.info("Skipping import_tracks (already completed)")
     else:
-        run_step(
-            "Import tracks",
-            [python, str(SCRIPT_DIR / "import_csv.py"), "--tracks-only", str(csv_dir), db_url],
-        )
+        tracks_cmd = [python, str(SCRIPT_DIR / "import_csv.py"), "--tracks-only"]
+        if truncate_existing:
+            tracks_cmd.append("--truncate-existing")
+        tracks_cmd.extend([str(csv_dir), db_url])
+        run_step("Import tracks", tracks_cmd)
         if state:
             state.mark_completed("import_tracks")
             _save_state()

--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -1109,9 +1109,15 @@ def _run_database_build(
     if state and state.is_completed("import_tracks"):
         logger.info("Skipping import_tracks (already completed)")
     else:
+        # --truncate-existing is intentionally NOT forwarded here. In a full
+        # pipeline run the base step already truncated + repopulated; the
+        # tracks step runs AFTER dedup against that data. Truncating the
+        # tracks subset again now would just wipe and rebuild empty track
+        # tables. (import_csv's --tracks-only --truncate-existing is mode-
+        # aware and only touches track tables for standalone callers — see
+        # CACHE_TABLES_TO_TRUNCATE_TRACKS — but the orchestrator skips it
+        # to make the no-op explicit.)
         tracks_cmd = [python, str(SCRIPT_DIR / "import_csv.py"), "--tracks-only"]
-        if truncate_existing:
-            tracks_cmd.append("--truncate-existing")
         tracks_cmd.extend([str(csv_dir), db_url])
         run_step("Import tracks", tracks_cmd)
         if state:

--- a/tests/unit/test_import_csv.py
+++ b/tests/unit/test_import_csv.py
@@ -549,23 +549,27 @@ class TestTruncateExisting:
     alembic_version (migration history).
     """
 
-    def test_cache_tables_list_excludes_entity_schema(self) -> None:
+    def test_base_truncate_list_excludes_entity_schema(self) -> None:
         """The entity schema holds the WXYC-side identity records — they must
-        survive a rebuild. None of CACHE_TABLES_TO_TRUNCATE may target them."""
-        for name in _ic.CACHE_TABLES_TO_TRUNCATE:
+        survive a rebuild. Neither truncate set may target it."""
+        for name in _ic.CACHE_TABLES_TO_TRUNCATE_BASE:
             assert not name.startswith("entity."), (
-                f"entity-schema table {name!r} must not be in CACHE_TABLES_TO_TRUNCATE"
+                f"entity-schema table {name!r} must not be in CACHE_TABLES_TO_TRUNCATE_BASE"
+            )
+        for name in _ic.CACHE_TABLES_TO_TRUNCATE_TRACKS:
+            assert not name.startswith("entity."), (
+                f"entity-schema table {name!r} must not be in CACHE_TABLES_TO_TRUNCATE_TRACKS"
             )
 
-    def test_cache_tables_list_excludes_alembic_version(self) -> None:
+    def test_truncate_lists_exclude_alembic_version(self) -> None:
         """alembic_version tracks migration history and must persist across
         rebuilds. Truncating it would break the dual-write convention."""
-        assert "alembic_version" not in _ic.CACHE_TABLES_TO_TRUNCATE
+        assert "alembic_version" not in _ic.CACHE_TABLES_TO_TRUNCATE_BASE
+        assert "alembic_version" not in _ic.CACHE_TABLES_TO_TRUNCATE_TRACKS
 
-    def test_cache_tables_list_covers_base_track_video_artist_master_sets(self) -> None:
-        """Every public table that --base-only or --tracks-only writes to
-        must appear in CACHE_TABLES_TO_TRUNCATE, plus cache_metadata which
-        populate_cache_metadata fills after import."""
+    def test_base_truncate_list_covers_full_cache(self) -> None:
+        """The base set wipes the FULL cache so a rerun after a partial
+        failed --base-only attempt clears everything from any prior state."""
         expected_tables = {
             # BASE_TABLES
             "release",
@@ -573,7 +577,7 @@ class TestTruncateExisting:
             "release_label",
             "release_genre",
             "release_style",
-            # TRACK_TABLES + VIDEO_TABLES
+            # TRACK_TABLES + VIDEO_TABLES (cleared because partial prior tracks would conflict too)
             "release_track",
             "release_track_artist",
             "release_video",
@@ -589,10 +593,47 @@ class TestTruncateExisting:
             # populate_cache_metadata target
             "cache_metadata",
         }
-        actual = set(_ic.CACHE_TABLES_TO_TRUNCATE)
+        actual = set(_ic.CACHE_TABLES_TO_TRUNCATE_BASE)
         assert actual == expected_tables, (
             f"missing: {expected_tables - actual}, extra: {actual - expected_tables}"
         )
+
+    def test_tracks_truncate_list_is_tracks_subset_only(self) -> None:
+        """The tracks set wipes ONLY track-domain tables. In a full pipeline
+        run the tracks step runs AFTER base+dedup; wiping base tables here
+        would erase the deduped data and the SELECT id FROM release filter
+        would find zero rows."""
+        expected_tables = {
+            "release_track",
+            "release_track_artist",
+            "release_video",
+        }
+        actual = set(_ic.CACHE_TABLES_TO_TRUNCATE_TRACKS)
+        assert actual == expected_tables, (
+            f"missing: {expected_tables - actual}, extra: {actual - expected_tables}"
+        )
+
+    def test_tracks_truncate_list_does_not_include_base_tables(self) -> None:
+        """Explicit guard: the tracks set must not include any base table,
+        because the orchestrator runs tracks AFTER base+dedup. This is the
+        regression that the pre-PR-review hook caught on 2026-05-13."""
+        base_only_tables = {
+            "release",
+            "release_artist",
+            "release_label",
+            "release_genre",
+            "release_style",
+            "artist",
+            "artist_alias",
+            "artist_member",
+            "artist_name_variation",
+            "artist_url",
+            "master",
+            "master_artist",
+            "cache_metadata",
+        }
+        leaked = base_only_tables & set(_ic.CACHE_TABLES_TO_TRUNCATE_TRACKS)
+        assert not leaked, f"--tracks-only --truncate-existing must not wipe base tables: {leaked}"
 
     def test_truncate_tables_issues_single_cascade_statement(self) -> None:
         """_truncate_tables emits one TRUNCATE ... CASCADE statement. One
@@ -635,9 +676,9 @@ class TestTruncateExisting:
         mock_conn.cursor.assert_not_called()
         mock_conn.commit.assert_not_called()
 
-    def test_flag_invokes_truncate_before_import_in_base_only(self, tmp_path) -> None:
-        """--base-only --truncate-existing calls _truncate_tables(conn,
-        CACHE_TABLES_TO_TRUNCATE) before any import work happens."""
+    def test_flag_with_base_only_truncates_full_cache_set(self, tmp_path) -> None:
+        """--base-only --truncate-existing wipes the FULL cache (the BASE
+        set) so a partial failed run is fully cleared before reimport."""
         from unittest.mock import MagicMock, patch
 
         csv_dir = tmp_path / "csv"
@@ -669,12 +710,14 @@ class TestTruncateExisting:
         mock_truncate.assert_called_once()
         call_args = mock_truncate.call_args
         assert call_args[0][0] is mock_conn
-        assert call_args[0][1] == _ic.CACHE_TABLES_TO_TRUNCATE
+        assert call_args[0][1] == _ic.CACHE_TABLES_TO_TRUNCATE_BASE
 
-    def test_flag_invokes_truncate_in_tracks_only(self, tmp_path) -> None:
-        """--tracks-only --truncate-existing wipes the same cache-table set.
-        The list is mode-agnostic: stale data in any of these tables can
-        fail a future rebuild regardless of which mode is running."""
+    def test_flag_with_tracks_only_truncates_tracks_subset(self, tmp_path) -> None:
+        """--tracks-only --truncate-existing wipes ONLY the track-domain
+        tables, preserving base+dedup output. This is the bug the
+        pre-PR-review hook caught: an earlier draft passed the full cache
+        set unconditionally, so a tracks rerun erased the deduped base
+        data and tracks ended up empty."""
         from unittest.mock import MagicMock, patch
 
         csv_dir = tmp_path / "csv"
@@ -703,6 +746,8 @@ class TestTruncateExisting:
             _ic.main()
 
         mock_truncate.assert_called_once()
+        call_args = mock_truncate.call_args
+        assert call_args[0][1] == _ic.CACHE_TABLES_TO_TRUNCATE_TRACKS
 
     def test_flag_omitted_does_not_truncate(self, tmp_path) -> None:
         """Default (flag absent) preserves prior behavior — no TRUNCATE on

--- a/tests/unit/test_import_csv.py
+++ b/tests/unit/test_import_csv.py
@@ -538,6 +538,202 @@ class TestMainArgParsing:
 
 
 # ---------------------------------------------------------------------------
+# --truncate-existing flag
+# ---------------------------------------------------------------------------
+
+
+class TestTruncateExisting:
+    """``--truncate-existing`` wipes the cache tables before COPY so a partial
+    state from a prior failed rebuild doesn't fail the import with a
+    duplicate-key violation. Excludes entity.identity (WXYC-side data) and
+    alembic_version (migration history).
+    """
+
+    def test_cache_tables_list_excludes_entity_schema(self) -> None:
+        """The entity schema holds the WXYC-side identity records — they must
+        survive a rebuild. None of CACHE_TABLES_TO_TRUNCATE may target them."""
+        for name in _ic.CACHE_TABLES_TO_TRUNCATE:
+            assert not name.startswith("entity."), (
+                f"entity-schema table {name!r} must not be in CACHE_TABLES_TO_TRUNCATE"
+            )
+
+    def test_cache_tables_list_excludes_alembic_version(self) -> None:
+        """alembic_version tracks migration history and must persist across
+        rebuilds. Truncating it would break the dual-write convention."""
+        assert "alembic_version" not in _ic.CACHE_TABLES_TO_TRUNCATE
+
+    def test_cache_tables_list_covers_base_track_video_artist_master_sets(self) -> None:
+        """Every public table that --base-only or --tracks-only writes to
+        must appear in CACHE_TABLES_TO_TRUNCATE, plus cache_metadata which
+        populate_cache_metadata fills after import."""
+        expected_tables = {
+            # BASE_TABLES
+            "release",
+            "release_artist",
+            "release_label",
+            "release_genre",
+            "release_style",
+            # TRACK_TABLES + VIDEO_TABLES
+            "release_track",
+            "release_track_artist",
+            "release_video",
+            # ARTIST_TABLES + import_artist_details stub-row target
+            "artist",
+            "artist_alias",
+            "artist_member",
+            "artist_name_variation",
+            "artist_url",
+            # MASTER_TABLES
+            "master",
+            "master_artist",
+            # populate_cache_metadata target
+            "cache_metadata",
+        }
+        actual = set(_ic.CACHE_TABLES_TO_TRUNCATE)
+        assert actual == expected_tables, (
+            f"missing: {expected_tables - actual}, extra: {actual - expected_tables}"
+        )
+
+    def test_truncate_tables_issues_single_cascade_statement(self) -> None:
+        """_truncate_tables emits one TRUNCATE ... CASCADE statement. One
+        statement keeps the operation atomic and CASCADE handles FK
+        dependencies for any table not in the explicit list."""
+        from unittest.mock import MagicMock
+
+        mock_conn = MagicMock()
+        mock_cursor = MagicMock()
+        mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
+        mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+
+        _ic._truncate_tables(mock_conn, ["release", "release_artist"])
+
+        mock_cursor.execute.assert_called_once()
+        sql = mock_cursor.execute.call_args[0][0]
+        assert "TRUNCATE" in sql.upper()
+        assert "CASCADE" in sql.upper()
+        assert "release" in sql
+        assert "release_artist" in sql
+
+    def test_truncate_tables_commits_immediately(self) -> None:
+        """The truncate must commit on its own conn before any parallel
+        workers open new conns — otherwise MVCC isolation would let workers
+        still see the pre-TRUNCATE rows and the COPY would still fail."""
+        from unittest.mock import MagicMock
+
+        mock_conn = MagicMock()
+        _ic._truncate_tables(mock_conn, ["release"])
+
+        mock_conn.commit.assert_called_once()
+
+    def test_truncate_tables_empty_list_is_noop(self) -> None:
+        """Defensive: empty table list short-circuits without issuing SQL."""
+        from unittest.mock import MagicMock
+
+        mock_conn = MagicMock()
+        _ic._truncate_tables(mock_conn, [])
+
+        mock_conn.cursor.assert_not_called()
+        mock_conn.commit.assert_not_called()
+
+    def test_flag_invokes_truncate_before_import_in_base_only(self, tmp_path) -> None:
+        """--base-only --truncate-existing calls _truncate_tables(conn,
+        CACHE_TABLES_TO_TRUNCATE) before any import work happens."""
+        from unittest.mock import MagicMock, patch
+
+        csv_dir = tmp_path / "csv"
+        csv_dir.mkdir()
+        mock_conn = MagicMock()
+
+        with (
+            patch(
+                "sys.argv",
+                [
+                    "import_csv.py",
+                    "--base-only",
+                    "--truncate-existing",
+                    str(csv_dir),
+                    "postgresql:///test",
+                ],
+            ),
+            patch.object(_ic.psycopg, "connect", return_value=mock_conn),
+            patch.object(_ic, "_truncate_tables") as mock_truncate,
+            patch.object(_ic, "_import_tables_parallel", return_value=100),
+            patch.object(_ic, "import_artwork", return_value=10),
+            patch.object(_ic, "populate_release_year", return_value=50),
+            patch.object(_ic, "populate_cache_metadata", return_value=50),
+            patch.object(_ic, "create_track_count_table", return_value=20),
+            patch.object(_ic, "import_artist_details", return_value=20),
+        ):
+            _ic.main()
+
+        mock_truncate.assert_called_once()
+        call_args = mock_truncate.call_args
+        assert call_args[0][0] is mock_conn
+        assert call_args[0][1] == _ic.CACHE_TABLES_TO_TRUNCATE
+
+    def test_flag_invokes_truncate_in_tracks_only(self, tmp_path) -> None:
+        """--tracks-only --truncate-existing wipes the same cache-table set.
+        The list is mode-agnostic: stale data in any of these tables can
+        fail a future rebuild regardless of which mode is running."""
+        from unittest.mock import MagicMock, patch
+
+        csv_dir = tmp_path / "csv"
+        csv_dir.mkdir()
+        mock_conn = MagicMock()
+        mock_cursor = MagicMock()
+        mock_cursor.fetchall.return_value = [(5001,)]
+        mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
+        mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+
+        with (
+            patch(
+                "sys.argv",
+                [
+                    "import_csv.py",
+                    "--tracks-only",
+                    "--truncate-existing",
+                    str(csv_dir),
+                    "postgresql:///test",
+                ],
+            ),
+            patch.object(_ic.psycopg, "connect", return_value=mock_conn),
+            patch.object(_ic, "_truncate_tables") as mock_truncate,
+            patch.object(_ic, "_import_tables_parallel", return_value=200),
+        ):
+            _ic.main()
+
+        mock_truncate.assert_called_once()
+
+    def test_flag_omitted_does_not_truncate(self, tmp_path) -> None:
+        """Default (flag absent) preserves prior behavior — no TRUNCATE on
+        a fresh-DB rebuild, where the schema-create step yields empty tables
+        and TRUNCATE would be wasted DDL."""
+        from unittest.mock import MagicMock, patch
+
+        csv_dir = tmp_path / "csv"
+        csv_dir.mkdir()
+        mock_conn = MagicMock()
+
+        with (
+            patch(
+                "sys.argv",
+                ["import_csv.py", "--base-only", str(csv_dir), "postgresql:///test"],
+            ),
+            patch.object(_ic.psycopg, "connect", return_value=mock_conn),
+            patch.object(_ic, "_truncate_tables") as mock_truncate,
+            patch.object(_ic, "_import_tables_parallel", return_value=100),
+            patch.object(_ic, "import_artwork", return_value=10),
+            patch.object(_ic, "populate_release_year", return_value=50),
+            patch.object(_ic, "populate_cache_metadata", return_value=50),
+            patch.object(_ic, "create_track_count_table", return_value=20),
+            patch.object(_ic, "import_artist_details", return_value=20),
+        ):
+            _ic.main()
+
+        mock_truncate.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
 # Artist table dedup and filtering
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/test_run_pipeline.py
+++ b/tests/unit/test_run_pipeline.py
@@ -150,6 +150,90 @@ class TestArgParsing:
         args = run_pipeline.parse_args(["--csv-dir", "/tmp/csv"])
         assert args.truncate_existing is False
 
+
+class TestTruncateExistingPropagation:
+    """``run_pipeline.py --truncate-existing`` plumbs into the base step
+    only — never into the tracks step. In a full pipeline the tracks step
+    runs AFTER base+dedup, so propagating the flag would erase the
+    deduped base rows and the ``SELECT id FROM release`` filter inside
+    the tracks step would return zero IDs.
+
+    Regression: caught by the pre-PR-review hook on 2026-05-13 when an
+    earlier draft propagated the flag to both subprocess invocations.
+    """
+
+    def _invoke_database_build_capturing_run_step(
+        self, *, truncate_existing: bool
+    ) -> list[list[str]]:
+        """Run ``_run_database_build`` with all DB-touching helpers stubbed
+        out, and capture the argv each ``run_step`` was given. Every other
+        helper that would normally hit Postgres is patched to a no-op."""
+        from unittest.mock import MagicMock, patch
+
+        import psycopg
+
+        captured_cmds: list[list[str]] = []
+
+        def fake_run_step(step_name, cmd, *args, **kwargs):
+            captured_cmds.append(cmd)
+
+        mock_cursor = MagicMock()
+        mock_cursor.fetchone.return_value = [True]
+        mock_cursor.fetchall.return_value = [
+            ("idx_release_artist_name_trgm",),
+            ("idx_release_title_trgm",),
+        ]
+        mock_conn = MagicMock()
+        mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
+        mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+
+        with (
+            patch.object(run_pipeline, "run_step", side_effect=fake_run_step),
+            patch.object(run_pipeline, "wait_for_postgres"),
+            patch.object(run_pipeline, "run_sql_file"),
+            patch.object(run_pipeline, "run_sql_statements_parallel"),
+            patch.object(run_pipeline, "set_tables_unlogged"),
+            patch.object(run_pipeline, "report_sizes"),
+            patch.object(psycopg, "connect", return_value=mock_conn),
+        ):
+            run_pipeline._run_database_build(
+                "postgresql:///test",
+                Path("/tmp/csv"),
+                None,
+                sys.executable,
+                truncate_existing=truncate_existing,
+            )
+
+        return captured_cmds
+
+    def test_flag_propagates_to_base_step(self) -> None:
+        """With --truncate-existing, the base subprocess invocation carries
+        the flag so stale rows are wiped before COPY."""
+        cmds = self._invoke_database_build_capturing_run_step(truncate_existing=True)
+        base_cmds = [c for c in cmds if "--base-only" in c]
+        assert len(base_cmds) == 1
+        assert "--truncate-existing" in base_cmds[0]
+
+    def test_flag_does_not_propagate_to_tracks_step(self) -> None:
+        """Even with --truncate-existing set on the orchestrator, the tracks
+        subprocess does NOT carry the flag. The tracks step runs AFTER
+        dedup; truncating now would just wipe what we want to filter against.
+        """
+        cmds = self._invoke_database_build_capturing_run_step(truncate_existing=True)
+        tracks_cmds = [c for c in cmds if "--tracks-only" in c]
+        assert len(tracks_cmds) == 1
+        assert "--truncate-existing" not in tracks_cmds[0], (
+            "Propagating --truncate-existing to the tracks step would wipe the "
+            "deduped base data and leave the cache with empty release_track tables."
+        )
+
+    def test_flag_absent_does_not_appear_in_any_invocation(self) -> None:
+        """Default behavior: neither subprocess gets --truncate-existing.
+        Preserves the prior fresh-DB rebuild path."""
+        cmds = self._invoke_database_build_capturing_run_step(truncate_existing=False)
+        for cmd in cmds:
+            assert "--truncate-existing" not in cmd
+
     def test_converter_default(self) -> None:
         args = run_pipeline.parse_args(["--xml", "/tmp/releases.xml.gz"])
         assert args.converter == "discogs-xml-converter"

--- a/tests/unit/test_run_pipeline.py
+++ b/tests/unit/test_run_pipeline.py
@@ -137,6 +137,19 @@ class TestArgParsing:
         args = run_pipeline.parse_args(["--csv-dir", "/tmp/csv"])
         assert args.state_file == Path(".pipeline_state.json")
 
+    def test_truncate_existing_flag_parsed(self) -> None:
+        """--truncate-existing flows through to import_csv subprocess to
+        wipe stale rows before COPY. Use when re-running against a DB with
+        partial state from a prior failed rebuild."""
+        args = run_pipeline.parse_args(["--csv-dir", "/tmp/csv", "--truncate-existing"])
+        assert args.truncate_existing is True
+
+    def test_truncate_existing_default_false(self) -> None:
+        """Default is False — a fresh-DB rebuild doesn't need it and the
+        wasted TRUNCATE DDL would slow the empty case."""
+        args = run_pipeline.parse_args(["--csv-dir", "/tmp/csv"])
+        assert args.truncate_existing is False
+
     def test_converter_default(self) -> None:
         args = run_pipeline.parse_args(["--xml", "/tmp/releases.xml.gz"])
         assert args.converter == "discogs-xml-converter"


### PR DESCRIPTION
## Summary

Three rebuild-pipeline optimizations plus the fix for the underlying failure mode from the 2026-05-13 monthly run (#188):

1. **`--truncate-existing` flag** on `import_csv.py` (+ `run_pipeline.py` plumbing). Wipes the cache tables CASCADE before COPY so a rerun after a partial failed rebuild doesn't hit duplicate-key violations. Preserves `entity.identity` and `alembic_version`. **Mode-aware**: `--base-only` wipes the full cache; `--tracks-only` only the track-domain tables (preserves base+dedup). `run_pipeline.py` forwards the flag only to the base subprocess.
2. **Prebuilt converter binary** in `rebuild-cache.sh`. Tries `gh release download` against [WXYC/discogs-xml-converter](https://github.com/WXYC/discogs-xml-converter)'s Release Binary workflow asset, sha256-verifies, falls back to in-tree `cargo build` on any failure. Saves ~20-30 min per run.
3. **Default instance type -> `c6i.large`** in the SAM template. Roughly 2x speedup on the converter scan (CPU-bound on ~19M releases) and the cargo build, at +\$0.06/run.

## Motivation

#188's first real prod rebuild — instance `i-0dcb1f8265156dc42`, 2026-05-13 — failed at the first COPY with:

\`\`\`
psycopg.errors.UniqueViolation: duplicate key value violates unique constraint \"release_pkey\"
DETAIL:  Key (id)=(903158) already exists.
CONTEXT:  COPY release, line 30759
\`\`\`

Root cause: \`schema/create_database.sql\` is \`CREATE TABLE IF NOT EXISTS\` (idempotent) and prod held leftover rows from an earlier partial attempt. The TRUNCATE flag addresses this; the other two optimizations were motivated by the same run's slow startup (~30 min on cargo build, ~14 min on the converter scan).

## Notes on commit history

Three commits land sequentially, but the middle two leave a transient broken state. The pre-PR-review hook caught a propagation bug in commit \`ce142a0\` (the original \`--truncate-existing\` introduction passed the flag to BOTH the \`--base-only\` and \`--tracks-only\` subprocesses; in a full pipeline run the tracks step would then wipe the just-deduped base data). The tip commit \`61d0fd0\` fixes it: mode-aware truncate sets at the low level + orchestrator-side guard against propagating to tracks. Squash-on-merge to land as a single coherent change.

## Validation

- 706 unit tests pass on the worktree (added 13 new across the flag's behavior surface).
- \`ruff check\` + \`ruff format --check\` clean.
- \`shellcheck scripts/rebuild-cache.sh\` clean.

## Operational follow-ups

- The \`template.yaml\` change needs \`sam deploy\` to flip the deployed stack's instance type. The CI deploy workflow is currently blocked by #202 (missing AWS GHA secrets), so a local \`sam deploy --parameter-overrides AlertEmail=...\` from \`infra/ephemeral-rebuild/\` is required post-merge.
- The prebuilt-binary leg depends on [WXYC/discogs-xml-converter#52](https://github.com/WXYC/discogs-xml-converter/pull/52) being merged so the release asset exists. Until then, \`rebuild-cache.sh\`'s fallback runs \`cargo build\` — functional but slow, exactly the pre-PR state.

## Related

- Closes #188
- WXYC/discogs-xml-converter#52 — companion PR that publishes the prebuilt binary
- #202 — deploy-workflow AWS secrets, blocks the SAM redeploy step