### PR TITLE
import_csv: tolerate LML's concurrent cache_metadata writes during rebuild

### DIFF
--- a/scripts/import_csv.py
+++ b/scripts/import_csv.py
@@ -430,24 +430,32 @@ def import_csv(
 
 
 def populate_cache_metadata(conn) -> int:
-    """Populate cache_metadata for all releases via COPY.
+    """Populate cache_metadata for all releases.
 
-    Much faster than INSERT...SELECT with ON CONFLICT for large tables.
-    Assumes cache_metadata is empty (schema freshly created).
+    Uses INSERT ... SELECT ... ON CONFLICT DO NOTHING rather than COPY
+    because cache_metadata is concurrently written by the live
+    library-metadata-lookup service: on every Discogs API miss, LML's
+    ``discogs/cache_service.py`` inserts a row with source='api_fetch'.
+    During a rebuild, those concurrent writes race the bulk populate
+    and cause duplicate-key violations on COPY (which has no upsert
+    semantics). See WXYC/discogs-etl#188 (2026-05-13 21:32 UTC run, 52
+    'api_fetch' rows appeared in the 34-second window between TRUNCATE
+    and the populate step).
 
-    Returns the number of rows inserted.
+    Returns the number of rows actually inserted; ON CONFLICT skips
+    are excluded, which is the right denominator for "how much did this
+    populate step add?". Rows already present from concurrent
+    'api_fetch' writes keep their original source.
     """
     with conn.cursor() as cur:
-        cur.execute("SELECT id FROM release")
-        release_ids = [row[0] for row in cur.fetchall()]
-
-    count = len(release_ids)
-    with conn.cursor() as cur:
-        with cur.copy("COPY cache_metadata (release_id, source) FROM STDIN") as copy:
-            for rid in release_ids:
-                copy.write_row((rid, "bulk_import"))
+        cur.execute("""
+            INSERT INTO cache_metadata (release_id, source)
+            SELECT id, 'bulk_import' FROM release
+            ON CONFLICT (release_id) DO NOTHING
+        """)
+        count = cur.rowcount
     conn.commit()
-    logger.info(f"  Populated cache_metadata with {count:,} rows")
+    logger.info(f"  Populated cache_metadata with {count:,} rows (ON CONFLICT skips excluded)")
     return count
 
 

--- a/tests/unit/test_import_csv.py
+++ b/tests/unit/test_import_csv.py
@@ -31,6 +31,110 @@ CSV_DIR = FIXTURES_DIR / "csv"
 
 
 # ---------------------------------------------------------------------------
+# populate_cache_metadata race-tolerance
+# ---------------------------------------------------------------------------
+
+
+class TestPopulateCacheMetadataRaceTolerance:
+    """``cache_metadata`` is concurrently written by the live LML service:
+    on every Discogs API miss, LML's ``discogs/cache_service.py`` inserts an
+    ``'api_fetch'`` row. During a rebuild, those concurrent writes race the
+    bulk populate and cause duplicate-key violations on COPY.
+
+    The fix uses INSERT ... ON CONFLICT DO NOTHING so the bulk populate
+    skips rows LML has already inserted. Surfaced in the 2026-05-13
+    21:32 UTC rebuild run (#188), where 52 ``'api_fetch'`` rows appeared
+    in the 34-second window between TRUNCATE and ``populate_cache_metadata``.
+    """
+
+    def test_uses_insert_on_conflict_not_copy(self) -> None:
+        """The function emits an INSERT ... ON CONFLICT DO NOTHING statement,
+        not a COPY. The race with LML's runtime cache writes requires the
+        ON CONFLICT semantics that COPY can't provide."""
+        from unittest.mock import MagicMock
+
+        mock_cursor = MagicMock()
+        mock_cursor.rowcount = 50
+        mock_conn = MagicMock()
+        mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
+        mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+
+        _ic.populate_cache_metadata(mock_conn)
+
+        # cur.copy should NEVER be called — that's the failure mode we're fixing.
+        mock_cursor.copy.assert_not_called()
+        # cur.execute should be called with an INSERT ... ON CONFLICT statement.
+        mock_cursor.execute.assert_called_once()
+        sql = mock_cursor.execute.call_args[0][0]
+        assert "INSERT INTO cache_metadata" in sql
+        assert "ON CONFLICT" in sql
+        assert "DO NOTHING" in sql
+
+    def test_insert_uses_bulk_import_source(self) -> None:
+        """The bulk populate's source column must be 'bulk_import' so
+        post-rebuild analytics can distinguish bulk-loaded rows from
+        LML's runtime ``'api_fetch'`` writes."""
+        from unittest.mock import MagicMock
+
+        mock_cursor = MagicMock()
+        mock_cursor.rowcount = 0
+        mock_conn = MagicMock()
+        mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
+        mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+
+        _ic.populate_cache_metadata(mock_conn)
+
+        sql = mock_cursor.execute.call_args[0][0]
+        assert "'bulk_import'" in sql
+
+    def test_targets_release_id_conflict(self) -> None:
+        """ON CONFLICT must reference (release_id), the cache_metadata pkey."""
+        from unittest.mock import MagicMock
+
+        mock_cursor = MagicMock()
+        mock_cursor.rowcount = 0
+        mock_conn = MagicMock()
+        mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
+        mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+
+        _ic.populate_cache_metadata(mock_conn)
+
+        sql = mock_cursor.execute.call_args[0][0]
+        # The ON CONFLICT target is the primary key (release_id).
+        assert "ON CONFLICT (release_id)" in sql
+
+    def test_commits_on_success(self) -> None:
+        """The function commits the transaction so the inserted rows are
+        durable before the next pipeline step starts."""
+        from unittest.mock import MagicMock
+
+        mock_cursor = MagicMock()
+        mock_cursor.rowcount = 0
+        mock_conn = MagicMock()
+        mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
+        mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+
+        _ic.populate_cache_metadata(mock_conn)
+
+        mock_conn.commit.assert_called_once()
+
+    def test_returns_rowcount(self) -> None:
+        """The return value is the number of rows actually inserted
+        (cur.rowcount after INSERT). ON CONFLICT skips don't count, which is
+        the right denominator for the log line that reports the populate's
+        effect."""
+        from unittest.mock import MagicMock
+
+        mock_cursor = MagicMock()
+        mock_cursor.rowcount = 677_934
+        mock_conn = MagicMock()
+        mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
+        mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+
+        assert _ic.populate_cache_metadata(mock_conn) == 677_934
+
+
+# ---------------------------------------------------------------------------
 # extract_year
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Switch `populate_cache_metadata` from COPY to `INSERT ... SELECT ... ON CONFLICT (release_id) DO NOTHING` so the bulk populate tolerates concurrent writes from the live library-metadata-lookup service.

## The race

`cache_metadata` is shared between two writers:

- **Rebuild pipeline** (`populate_cache_metadata`): bulk COPY with `source='bulk_import'`, runs once per monthly rebuild.
- **LML runtime** (`discogs/cache_service.py`): inserts `source='api_fetch'` on every cache miss when LML falls through to the Discogs API.

On the 2026-05-13 21:32 UTC rebuild attempt (#188), 52 `'api_fetch'` rows appeared in the 34-second window between my pre-import TRUNCATE and the `populate_cache_metadata` step. The COPY hit `psycopg.errors.UniqueViolation` on its first row and the entire pipeline aborted before `create_indexes`, `dedup`, and the rest.

```
psycopg.errors.UniqueViolation: duplicate key value violates unique constraint "cache_metadata_pkey"
DETAIL:  Key (release_id)=(3306352) already exists.
CONTEXT:  COPY cache_metadata, line 1
```

## Fix

```python
INSERT INTO cache_metadata (release_id, source)
SELECT id, 'bulk_import' FROM release
ON CONFLICT (release_id) DO NOTHING
```

Rows LML has already cached keep their `'api_fetch'` source; new releases get `'bulk_import'`. Both attributions are correct.

## Trade-off

COPY-vs-INSERT on 677K rows over the Railway public proxy is roughly 5-10 seconds slower per rebuild — the right trade for "actually completes" vs "fails on the first concurrent write". Returned `rowcount` excludes ON CONFLICT skips, which is the right denominator for the log line that reports the populate's effect.

## Validation

- 5 new unit tests pin the SQL shape (INSERT, ON CONFLICT (release_id), DO NOTHING, 'bulk_import'), the commit semantics, and the rowcount return.
- 711 unit tests pass; no regressions.
- `ruff check` + `ruff format --check` clean.

## Related

- #188 — the cache-rebuild blocker this PR unblocks
- #204 — separate `release_artist.csv` missing `role` column drift surfaced in the same run; non-fatal, filed for follow-up
- Companion docs note for LML-side context: PR #324 (graceful fallback) was filed earlier in the workstream but covers a different concurrency pattern (LML reads during dedup-swap, not LML writes during populate)

## Next step after merge

Re-invoke the rebuild launcher. Don't re-TRUNCATE — the existing 52 `'api_fetch'` rows in `cache_metadata` are valid; the new INSERT will skip them and fill the remaining ~677K with `'bulk_import'`.