### PR TITLE
import_csv: drop 'role' from release_artist column list

### DIFF
--- a/scripts/import_csv.py
+++ b/scripts/import_csv.py
@@ -95,8 +95,15 @@ BASE_TABLES: list[TableConfig] = [
     {
         "csv_file": "release_artist.csv",
         "table": "release_artist",
-        "csv_columns": ["release_id", "artist_id", "artist_name", "extra", "role"],
-        "db_columns": ["release_id", "artist_id", "artist_name", "extra", "role"],
+        # The schema has a ``role`` column for extra-credit attribution
+        # ("Producer", "Mixed By", etc.), but the converter
+        # (WXYC/discogs-xml-converter v0.1.0) doesn't emit it. Listing
+        # ``role`` here caused the import to bail out with "Missing
+        # columns" and write zero release_artist rows (see #204). Keep
+        # the schema column nullable so a future converter version can
+        # populate it without a schema migration.
+        "csv_columns": ["release_id", "artist_id", "artist_name", "extra"],
+        "db_columns": ["release_id", "artist_id", "artist_name", "extra"],
         "required": ["release_id", "artist_name"],
         "transforms": {},
         "unique_key": ["release_id", "artist_name"],

--- a/tests/unit/test_import_csv.py
+++ b/tests/unit/test_import_csv.py
@@ -35,6 +35,32 @@ CSV_DIR = FIXTURES_DIR / "csv"
 # ---------------------------------------------------------------------------
 
 
+class TestReleaseArtistColumnsMatchConverterOutput:
+    """The ``release_artist`` table config must NOT include a column the
+    converter doesn't emit.
+
+    WXYC/discogs-xml-converter v0.1.0 writes release_artist.csv with
+    ``release_id, artist_id, artist_name, extra, anv, position, join_field``.
+    Any column listed in ``csv_columns`` that's missing from the CSV header
+    causes ``import_csv`` to bail out at line 257 with ``return 0`` — the
+    failure mode that left release_artist empty in the 2026-05-13 rebuild
+    (#204). The schema's ``role`` column stays nullable; this test pins
+    that the importer doesn't try to read it.
+    """
+
+    def test_release_artist_csv_columns_exclude_role(self) -> None:
+        ra_config = next(t for t in BASE_TABLES if t["table"] == "release_artist")
+        assert "role" not in ra_config["csv_columns"], (
+            "'role' must not appear in csv_columns until the converter writes it; see #204"
+        )
+
+    def test_release_artist_db_columns_exclude_role(self) -> None:
+        """db_columns must mirror csv_columns (positional mapping). The schema's
+        ``role`` column accepts NULL so the import succeeds without it."""
+        ra_config = next(t for t in BASE_TABLES if t["table"] == "release_artist")
+        assert "role" not in ra_config["db_columns"]
+
+
 class TestPopulateCacheMetadataRaceTolerance:
     """``cache_metadata`` is concurrently written by the live LML service:
     on every Discogs API miss, LML's ``discogs/cache_service.py`` inserts an


### PR DESCRIPTION
## Summary

Drop the `role` column from the `release_artist` table config in `scripts/import_csv.py`. The 2026-05-13 21:32 UTC rebuild (#188) ended with zero `release_artist` rows imported because of this column drift; this PR closes #204 and unblocks the next rebuild attempt.

## The drift

Three different sources of truth on `release_artist`'s columns:

| Source | Columns |
|---|---|
| `schema/create_database.sql` | `release_id, artist_id, artist_name, extra, role` |
| `scripts/import_csv.py` (before this PR) | `release_id, artist_id, artist_name, extra, role` |
| `WXYC/discogs-xml-converter` v0.1.0 CSV output | `release_id, artist_id, artist_name, extra, anv, position, join_field` |

The converter doesn't write `role`. When the importer's pre-check at `scripts/import_csv.py:257` discovers a missing-from-CSV column, it logs an ERROR and `return 0`s without any COPY. That left `release_artist` empty in the last rebuild attempt despite 678K successful `release` rows.

## The fix

Drop `role` from both `csv_columns` and `db_columns`. The DB column stays nullable, so when a future converter version writes `role` we can add it back without a schema migration.

The converter's surplus columns (`anv`, `position`, `join_field`) continue to be silently ignored by the importer — they were never in `csv_columns` either, and the importer only complains about MISSING expected columns, not extra emitted ones.

## Trade-off

`release_artist.role` rows are now always NULL. A grep across this repo finds no consumer querying `release_artist.role`; LML and Backend-Service consumers also don't reference it. If a future use case needs the data, the converter PR + restoring `role` to this config is the cleanest path.

## Validation

- 2 new unit tests pin that `role` is not in the `release_artist` config (`csv_columns` and `db_columns`).
- 713 unit tests pass; no regressions.
- `ruff check` + `ruff format --check` clean.

## Related

- Closes #204
- Discovered during: #188 (cache rebuild)
- Companion fix: #205 (cache_metadata race) — both required for the rebuild to complete end-to-end

## Next step after merge

Re-invoke the rebuild launcher. With #205 + this PR + the existing `--truncate-existing` flag, the rebuild should run to completion: populate base tables (now including `release_artist`), populate cache_metadata via ON CONFLICT, create indexes, dedup, import tracks, vacuum, drift watchdog.