### PR TITLE
dedup + create_track_indexes: clean orphans + NOT VALID FK constraints

### DIFF
--- a/schema/create_track_indexes.sql
+++ b/schema/create_track_indexes.sql
@@ -8,20 +8,40 @@
 CREATE EXTENSION IF NOT EXISTS pg_trgm;
 
 -- ============================================
+-- Orphan cleanup before FK validation
+-- ============================================
+-- The live library-metadata-lookup service inserts release_track +
+-- release_track_artist rows for every Discogs API miss. During the dedup
+-- swap window, LML can produce track rows referencing release ids that
+-- aren't in the post-dedup release table. Deleting those orphans before
+-- the FK ADD step prevents the validation from failing on the race window
+-- (the dedup-side base FK fix uses the same pattern; see
+-- scripts/dedup_releases.py::add_base_constraints_and_indexes).
+
+DELETE FROM release_track
+WHERE NOT EXISTS (SELECT 1 FROM release r WHERE r.id = release_track.release_id);
+
+DELETE FROM release_track_artist
+WHERE NOT EXISTS (SELECT 1 FROM release r WHERE r.id = release_track_artist.release_id);
+
+-- ============================================
 -- FK constraints (idempotent via DO blocks)
 -- ============================================
+-- NOT VALID skips re-validation of existing rows so the ADD step itself
+-- can't race-fail on orphans from LML's writes between the cleanup above
+-- and this constraint creation. Future INSERTs still enforce the FK.
 
 DO $$
 BEGIN
     ALTER TABLE release_track ADD CONSTRAINT fk_release_track_release
-        FOREIGN KEY (release_id) REFERENCES release(id) ON DELETE CASCADE;
+        FOREIGN KEY (release_id) REFERENCES release(id) ON DELETE CASCADE NOT VALID;
 EXCEPTION WHEN duplicate_object THEN NULL;
 END $$;
 
 DO $$
 BEGIN
     ALTER TABLE release_track_artist ADD CONSTRAINT fk_release_track_artist_release
-        FOREIGN KEY (release_id) REFERENCES release(id) ON DELETE CASCADE;
+        FOREIGN KEY (release_id) REFERENCES release(id) ON DELETE CASCADE NOT VALID;
 EXCEPTION WHEN duplicate_object THEN NULL;
 END $$;
 

--- a/scripts/dedup_releases.py
+++ b/scripts/dedup_releases.py
@@ -443,19 +443,56 @@ def add_base_constraints_and_indexes(conn, db_url: str | None = None) -> None:
     conn.commit()
     logger.info(f"    done in {time.time() - pk_start:.1f}s")
 
-    # Level 2: FK constraints + PK on cache_metadata + FK indexes (parallel)
+    # Level 1.5: Clean orphan child rows (parallel).
+    #
+    # The live library-metadata-lookup service inserts release + release_label
+    # + release_artist + cache_metadata rows for every Discogs API miss. During
+    # the dedup copy-swap window, LML can produce child rows referencing
+    # release ids that are NOT in the post-dedup release table. Those orphans
+    # would cause the FK constraint validation at Level 2 to fail with
+    # ``ForeignKeyViolation``, aborting the entire rebuild — exactly what
+    # happened in the 2026-05-13 23:42 UTC run (instance i-03e2afe2410ad43f8,
+    # see WXYC/discogs-etl#188 comment thread).
+    #
+    # Combined with the NOT VALID modifier in Level 2 below, this gives a
+    # race-tolerant constraint creation: existing orphans are removed here,
+    # and the small window of new orphans landing between this cleanup and
+    # the NOT VALID constraint creation is tolerated because NOT VALID skips
+    # re-validation of existing rows. Future LML inserts are blocked by the
+    # FK at INSERT time, which is the durable correct behavior.
+    _exec_parallel(
+        [
+            "DELETE FROM release_artist "
+            "WHERE NOT EXISTS (SELECT 1 FROM release r WHERE r.id = release_artist.release_id)",
+            "DELETE FROM release_label "
+            "WHERE NOT EXISTS (SELECT 1 FROM release r WHERE r.id = release_label.release_id)",
+            "DELETE FROM release_genre "
+            "WHERE NOT EXISTS (SELECT 1 FROM release r WHERE r.id = release_genre.release_id)",
+            "DELETE FROM release_style "
+            "WHERE NOT EXISTS (SELECT 1 FROM release r WHERE r.id = release_style.release_id)",
+            "DELETE FROM cache_metadata "
+            "WHERE NOT EXISTS (SELECT 1 FROM release r WHERE r.id = cache_metadata.release_id)",
+        ],
+        "Level 1.5: Clean orphan child rows before FK validation",
+    )
+
+    # Level 2: FK constraints + PK on cache_metadata + FK indexes (parallel).
+    # FK constraints use NOT VALID so the ADD step itself can't race-fail
+    # on orphans created by LML during the brief Level-1.5 → Level-2 window.
+    # Postgres still enforces the FK on new inserts after the constraint is
+    # added, so the durable behavior is identical to a validated constraint.
     _exec_parallel(
         [
             "ALTER TABLE release_artist ADD CONSTRAINT fk_release_artist_release "
-            "FOREIGN KEY (release_id) REFERENCES release(id) ON DELETE CASCADE",
+            "FOREIGN KEY (release_id) REFERENCES release(id) ON DELETE CASCADE NOT VALID",
             "ALTER TABLE release_label ADD CONSTRAINT fk_release_label_release "
-            "FOREIGN KEY (release_id) REFERENCES release(id) ON DELETE CASCADE",
+            "FOREIGN KEY (release_id) REFERENCES release(id) ON DELETE CASCADE NOT VALID",
             "ALTER TABLE release_genre ADD CONSTRAINT fk_release_genre_release "
-            "FOREIGN KEY (release_id) REFERENCES release(id) ON DELETE CASCADE",
+            "FOREIGN KEY (release_id) REFERENCES release(id) ON DELETE CASCADE NOT VALID",
             "ALTER TABLE release_style ADD CONSTRAINT fk_release_style_release "
-            "FOREIGN KEY (release_id) REFERENCES release(id) ON DELETE CASCADE",
+            "FOREIGN KEY (release_id) REFERENCES release(id) ON DELETE CASCADE NOT VALID",
             "ALTER TABLE cache_metadata ADD CONSTRAINT fk_cache_metadata_release "
-            "FOREIGN KEY (release_id) REFERENCES release(id) ON DELETE CASCADE",
+            "FOREIGN KEY (release_id) REFERENCES release(id) ON DELETE CASCADE NOT VALID",
             "ALTER TABLE cache_metadata ADD PRIMARY KEY (release_id)",
             "CREATE INDEX idx_release_artist_release_id ON release_artist(release_id)",
             "CREATE INDEX idx_release_label_release_id ON release_label(release_id)",

--- a/tests/unit/test_dedup_fk_race.py
+++ b/tests/unit/test_dedup_fk_race.py
@@ -1,0 +1,169 @@
+"""Unit tests for the FK-constraint race-tolerance changes in
+``scripts/dedup_releases.py::add_base_constraints_and_indexes``.
+
+The live library-metadata-lookup service inserts release + release_label +
+release_artist + cache_metadata rows for every Discogs API miss. During the
+dedup copy-swap window, LML can produce child rows referencing release ids
+that are NOT in the post-dedup release table. Those orphans would cause
+``ALTER TABLE ... ADD CONSTRAINT ... FOREIGN KEY`` to fail with
+``ForeignKeyViolation`` and abort the whole rebuild (the 2026-05-13 23:42
+UTC run, instance i-03e2afe2410ad43f8).
+
+The fix combines two changes:
+
+  1. A Level 1.5 step that deletes orphan child rows before constraint
+     creation (so the bulk of the orphans are gone).
+  2. NOT VALID on each FK constraint (so the small race window between
+     cleanup and ADD doesn't matter — Postgres skips validation of
+     existing rows, but new inserts are still checked).
+
+This test pins both pieces against regression. The SQL shape is the
+behavior — refactoring to a different valid SQL pattern would fail these
+tests, which is appropriate because the WHOLE POINT of the change is the
+specific SQL shape that's race-tolerant.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest  # noqa: F401  (kept for marker consistency; tests use plain assertions)
+
+# Load dedup_releases as a module (it's a script, not a package).
+_SCRIPT_PATH = Path(__file__).parent.parent.parent / "scripts" / "dedup_releases.py"
+_spec = importlib.util.spec_from_file_location("dedup_releases", _SCRIPT_PATH)
+assert _spec is not None and _spec.loader is not None
+_dr = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_dr)
+
+
+class TestLevel15OrphanCleanup:
+    """The dedup pipeline must clean orphan child rows BEFORE adding FK
+    constraints. Otherwise LML's concurrent writes during the dedup
+    swap window produce orphans that block the FK validation.
+    """
+
+    def _captured_statements(self) -> list[str]:
+        """Run ``add_base_constraints_and_indexes`` with all parallel
+        execution stubbed out, capturing the SQL it would have run."""
+        from unittest.mock import MagicMock, patch
+
+        captured: list[str] = []
+
+        def fake_exec_one(db_url, stmt):
+            captured.append(stmt)
+
+        mock_cursor = MagicMock()
+        mock_conn = MagicMock()
+        mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
+        mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+        mock_conn.info.dsn = "postgresql:///test"
+
+        with patch.object(_dr, "_exec_one", side_effect=fake_exec_one):
+            _dr.add_base_constraints_and_indexes(mock_conn, db_url="postgresql:///test")
+
+        # The serial cur.execute calls also produce SQL — capture those too.
+        for call in mock_cursor.execute.call_args_list:
+            captured.append(call.args[0])
+
+        return captured
+
+    def test_orphan_cleanup_runs_for_release_label(self) -> None:
+        """release_label is the table that caused the 2026-05-13 failure."""
+        stmts = self._captured_statements()
+        cleanup_stmts = [s for s in stmts if "DELETE FROM release_label" in s and "NOT EXISTS" in s]
+        assert len(cleanup_stmts) == 1, (
+            f"expected exactly one orphan-cleanup DELETE for release_label; got: {cleanup_stmts}"
+        )
+
+    def test_orphan_cleanup_covers_all_fk_child_tables(self) -> None:
+        """Every table with an FK to release(id) needs orphan cleanup.
+        Otherwise the cleanup is incomplete and the constraint can still race.
+        """
+        stmts = self._captured_statements()
+        for table in [
+            "release_artist",
+            "release_label",
+            "release_genre",
+            "release_style",
+            "cache_metadata",
+        ]:
+            cleanup = [s for s in stmts if f"DELETE FROM {table}" in s and "NOT EXISTS" in s]
+            assert len(cleanup) == 1, (
+                f"missing orphan-cleanup DELETE for {table!r}; "
+                f"got {len(cleanup)} matching statements: {cleanup}"
+            )
+
+    def test_cleanup_runs_before_fk_constraints(self) -> None:
+        """Order matters: cleanup must complete before the ADD CONSTRAINT
+        block starts. _exec_parallel waits for each level to finish before
+        the next is dispatched (it uses as_completed inside one call), so
+        the cleanup batch must be earlier in the statement list than the
+        FK batch."""
+        stmts = self._captured_statements()
+        cleanup_index = next(
+            (i for i, s in enumerate(stmts) if "DELETE FROM release_label" in s),
+            -1,
+        )
+        fk_index = next(
+            (i for i, s in enumerate(stmts) if "ADD CONSTRAINT fk_release_label_release" in s),
+            -1,
+        )
+        assert cleanup_index >= 0, "release_label cleanup statement not found"
+        assert fk_index >= 0, "release_label FK constraint statement not found"
+        assert cleanup_index < fk_index, (
+            f"orphan cleanup at index {cleanup_index} must come before FK creation "
+            f"at index {fk_index}; otherwise the FK validates against the orphans"
+        )
+
+
+class TestFkConstraintsUseNotValid:
+    """All FK constraints added by ``add_base_constraints_and_indexes`` use
+    the NOT VALID modifier so the ADD step itself can't race-fail on orphan
+    rows that LML inserts during the brief window between Level-1.5 cleanup
+    and the constraint creation.
+    """
+
+    def _captured_statements(self) -> list[str]:
+        from unittest.mock import MagicMock, patch
+
+        captured: list[str] = []
+
+        def fake_exec_one(db_url, stmt):
+            captured.append(stmt)
+
+        mock_cursor = MagicMock()
+        mock_conn = MagicMock()
+        mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
+        mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+        mock_conn.info.dsn = "postgresql:///test"
+
+        with patch.object(_dr, "_exec_one", side_effect=fake_exec_one):
+            _dr.add_base_constraints_and_indexes(mock_conn, db_url="postgresql:///test")
+        return captured
+
+    def test_every_fk_constraint_uses_not_valid(self) -> None:
+        """No FK ADD CONSTRAINT statement may omit NOT VALID. Re-checking
+        existing rows is exactly the failure mode the race exposes."""
+        stmts = self._captured_statements()
+        fk_stmts = [s for s in stmts if "ADD CONSTRAINT fk_" in s and "FOREIGN KEY" in s]
+        assert len(fk_stmts) == 5, (
+            f"expected 5 FK constraints (release_artist, release_label, release_genre, "
+            f"release_style, cache_metadata); got {len(fk_stmts)}: {fk_stmts}"
+        )
+        for stmt in fk_stmts:
+            assert "NOT VALID" in stmt, (
+                f"FK constraint must include NOT VALID to avoid race-validation; got: {stmt}"
+            )
+
+    def test_not_valid_preserves_on_delete_cascade(self) -> None:
+        """NOT VALID is a separate modifier from ON DELETE CASCADE — both
+        must be present. CASCADE keeps the schema's referential cleanup
+        semantics; NOT VALID keeps the ADD step from re-validating."""
+        stmts = self._captured_statements()
+        fk_stmts = [s for s in stmts if "ADD CONSTRAINT fk_" in s and "FOREIGN KEY" in s]
+        for stmt in fk_stmts:
+            assert "ON DELETE CASCADE" in stmt, (
+                f"FK constraint must keep ON DELETE CASCADE; got: {stmt}"
+            )


### PR DESCRIPTION
## Summary

The dedup pipeline's FK-constraint re-creation races with the live library-metadata-lookup service's runtime cache writes. Apply two parallel fixes:

1. **`scripts/dedup_releases.py::add_base_constraints_and_indexes`** — add a Level 1.5 step that DELETEs orphan child rows before the Level 2 FK constraint creation, and use `NOT VALID` on each FK so the ADD step itself can't race-fail on orphans created in the small cleanup → ADD window.
2. **`schema/create_track_indexes.sql`** — same pattern for the track-side FKs (`fk_release_track_release`, `fk_release_track_artist_release`).

## The race

`cache_metadata` (#205) and `release_artist`/`release_label`/`release_genre`/`release_style`/`release_track`/`release_track_artist` are all written by LML on every Discogs API miss. During the dedup copy-swap, the new release table contains only the post-dedup subset. LML's inserts for releases NOT in that subset land in child tables as orphans relative to the new release table. The subsequent `ALTER TABLE ADD CONSTRAINT FOREIGN KEY` validates against existing rows and fails.

The 2026-05-13 23:42 UTC rebuild attempt (instance `i-03e2afe2410ad43f8`) failed exactly this way:

```
psycopg.errors.ForeignKeyViolation: insert or update on table "release_label"
violates foreign key constraint "fk_release_label_release"
DETAIL:  Key (release_id)=(328442) is not present in table "release".
```

## The fix

For each FK constraint that runs after a child table can hold orphans:

1. **Pre-clean**: `DELETE FROM <child> WHERE NOT EXISTS (SELECT 1 FROM release r WHERE r.id = <child>.release_id)`
2. **Constraint**: `ALTER TABLE <child> ADD CONSTRAINT ... FOREIGN KEY (release_id) REFERENCES release(id) ON DELETE CASCADE NOT VALID`

`NOT VALID` skips re-validation of existing rows, so any orphans landing in the cleanup → ADD window are tolerated. Postgres still enforces the FK on new inserts after the constraint lands, which is the durable correct behavior.

## Trade-off

`NOT VALID` constraints aren't trusted by the query planner for some optimizations. We can run `VALIDATE CONSTRAINT` later (in a follow-up after the rebuild has settled) without taking an `ACCESS EXCLUSIVE` lock; for now the consistency trade-off is fine because consumers self-filter via JOIN.

## Validation

- 5 new unit tests pin both pieces (orphan-cleanup coverage across all 5 FK child tables in the base set, ordering of cleanup before constraint creation, `NOT VALID` on every FK, `ON DELETE CASCADE` preserved alongside `NOT VALID`).
- 718 unit tests pass; no regressions.
- `ruff check` + `ruff format --check` clean.

## Related

- #188 — original cache-rebuild blocker
- #205 — companion fix for the `cache_metadata` race on COPY (uses `INSERT ... ON CONFLICT` instead of NOT VALID; both patterns coexist because the COPY path is data-loading not constraint-creation)
- #206 — third blocker (role-column drift) fixed in a prior PR
- #207 / #208 — follow-up PG integration tests for the race semantics (mock-only coverage today)

## Next step after merge

Re-invoke the rebuild launcher. With #205 + #206 + this PR, the rebuild should complete end-to-end: convert + base import + populate_cache_metadata (ON CONFLICT) + indexes + **dedup (cleaned + NOT VALID FKs)** + track import + **track indexes (cleaned + NOT VALID FKs)** + vacuum + drift watchdog.