### PR TITLE
fk-race: apply orphan-cleanup + NOT VALID across all four FK creation sites

### DIFF
--- a/scripts/dedup_releases.py
+++ b/scripts/dedup_releases.py
@@ -553,13 +553,28 @@ def add_track_constraints_and_indexes(conn, db_url: str | None = None) -> None:
                 future.result()
         logger.info(f"    done in {time.time() - level_start:.1f}s")
 
-    # Level 1: FK constraints (parallel)
+    # Level 0: Clean orphan track rows (parallel). LML writes release_track
+    # + release_track_artist rows on every Discogs API miss; during the dedup
+    # swap window those land as orphans. Parallel to the base-side cleanup
+    # in add_base_constraints_and_indexes. See #211 for the original fix
+    # and #188 for the 2026-05-14 02:20 UTC failure that surfaced this site.
+    _exec_parallel(
+        [
+            "DELETE FROM release_track WHERE NOT EXISTS "
+            "(SELECT 1 FROM release r WHERE r.id = release_track.release_id)",
+            "DELETE FROM release_track_artist WHERE NOT EXISTS "
+            "(SELECT 1 FROM release r WHERE r.id = release_track_artist.release_id)",
+        ],
+        "Level 0: Clean orphan track rows before FK validation",
+    )
+
+    # Level 1: FK constraints (parallel, NOT VALID for race tolerance).
     _exec_parallel(
         [
             "ALTER TABLE release_track ADD CONSTRAINT fk_release_track_release "
-            "FOREIGN KEY (release_id) REFERENCES release(id) ON DELETE CASCADE",
+            "FOREIGN KEY (release_id) REFERENCES release(id) ON DELETE CASCADE NOT VALID",
             "ALTER TABLE release_track_artist ADD CONSTRAINT fk_release_track_artist_release "
-            "FOREIGN KEY (release_id) REFERENCES release(id) ON DELETE CASCADE",
+            "FOREIGN KEY (release_id) REFERENCES release(id) ON DELETE CASCADE NOT VALID",
         ],
         "Level 1: FK constraints",
     )

--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -934,17 +934,38 @@ def _run_database_build_post_import(
     run_step("Deduplicate releases", dedup_cmd)
 
     # -- create_track_indexes (FK constraints, FK indexes, trigram indexes)
-    # Level 1: FK constraints (parallel)
+    # Level 0: Clean orphan track rows before FK validation (parallel).
+    # The live library-metadata-lookup service inserts release_track +
+    # release_track_artist rows on every Discogs API miss; during the dedup
+    # swap window those land as orphans relative to the post-dedup release
+    # table. The base-side parallel fix lives in dedup_releases.py and was
+    # shipped in #211; this is the track-side parallel — surfaced by the
+    # 2026-05-14 02:20 UTC failure on instance i-03a3040c5367faaf1 (#188).
+    run_sql_statements_parallel(
+        db_url,
+        [
+            "DELETE FROM release_track WHERE NOT EXISTS "
+            "(SELECT 1 FROM release r WHERE r.id = release_track.release_id)",
+            "DELETE FROM release_track_artist WHERE NOT EXISTS "
+            "(SELECT 1 FROM release r WHERE r.id = release_track_artist.release_id)",
+        ],
+        description="clean orphan track rows before FK",
+    )
+    # Level 1: FK constraints (parallel, NOT VALID for race tolerance).
+    # NOT VALID skips re-validation of existing rows so the ADD step can't
+    # race-fail on orphans created between cleanup and constraint creation.
+    # See dedup_releases.py::add_base_constraints_and_indexes for the
+    # equivalent base-side pattern with full reasoning.
     run_sql_statements_parallel(
         db_url,
         [
             "DO $$ BEGIN "
             "ALTER TABLE release_track ADD CONSTRAINT fk_release_track_release "
-            "FOREIGN KEY (release_id) REFERENCES release(id) ON DELETE CASCADE; "
+            "FOREIGN KEY (release_id) REFERENCES release(id) ON DELETE CASCADE NOT VALID; "
             "EXCEPTION WHEN duplicate_object THEN NULL; END $$",
             "DO $$ BEGIN "
             "ALTER TABLE release_track_artist ADD CONSTRAINT fk_release_track_artist_release "
-            "FOREIGN KEY (release_id) REFERENCES release(id) ON DELETE CASCADE; "
+            "FOREIGN KEY (release_id) REFERENCES release(id) ON DELETE CASCADE NOT VALID; "
             "EXCEPTION WHEN duplicate_object THEN NULL; END $$",
         ],
         description="track FK constraints",
@@ -1128,17 +1149,29 @@ def _run_database_build(
     if state and state.is_completed("create_track_indexes"):
         logger.info("Skipping create_track_indexes (already completed)")
     else:
-        # Level 1: FK constraints (parallel)
+        # Level 0: Clean orphan track rows before FK validation. Same race
+        # as in the resumable path above; see comment there for details.
+        run_sql_statements_parallel(
+            db_url,
+            [
+                "DELETE FROM release_track WHERE NOT EXISTS "
+                "(SELECT 1 FROM release r WHERE r.id = release_track.release_id)",
+                "DELETE FROM release_track_artist WHERE NOT EXISTS "
+                "(SELECT 1 FROM release r WHERE r.id = release_track_artist.release_id)",
+            ],
+            description="clean orphan track rows before FK",
+        )
+        # Level 1: FK constraints (parallel, NOT VALID for race tolerance).
         run_sql_statements_parallel(
             db_url,
             [
                 "DO $$ BEGIN "
                 "ALTER TABLE release_track ADD CONSTRAINT fk_release_track_release "
-                "FOREIGN KEY (release_id) REFERENCES release(id) ON DELETE CASCADE; "
+                "FOREIGN KEY (release_id) REFERENCES release(id) ON DELETE CASCADE NOT VALID; "
                 "EXCEPTION WHEN duplicate_object THEN NULL; END $$",
                 "DO $$ BEGIN "
                 "ALTER TABLE release_track_artist ADD CONSTRAINT fk_release_track_artist_release "
-                "FOREIGN KEY (release_id) REFERENCES release(id) ON DELETE CASCADE; "
+                "FOREIGN KEY (release_id) REFERENCES release(id) ON DELETE CASCADE NOT VALID; "
                 "EXCEPTION WHEN duplicate_object THEN NULL; END $$",
             ],
             description="track FK constraints",

--- a/scripts/verify_cache.py
+++ b/scripts/verify_cache.py
@@ -829,34 +829,54 @@ def prune_releases_copy_swap(
             # PK on release
             cur.execute("ALTER TABLE release ADD PRIMARY KEY (id)")
 
-            # FK constraints
+            # Clean orphan child rows before FK validation. The live LML
+            # service writes child rows for releases NOT in the post-prune
+            # subset; deleting them now keeps the ADD CONSTRAINT step below
+            # from failing on validation. NOT VALID on the constraint itself
+            # tolerates new orphans landing between cleanup and ADD. See
+            # #211 + #188 for the parallel fix in dedup_releases.py.
+            for child_table in (
+                "release_artist",
+                "release_label",
+                "release_genre",
+                "release_style",
+                "release_track",
+                "release_track_artist",
+                "cache_metadata",
+            ):
+                cur.execute(
+                    f"DELETE FROM {child_table} WHERE NOT EXISTS "
+                    f"(SELECT 1 FROM release r WHERE r.id = {child_table}.release_id)"
+                )
+
+            # FK constraints (NOT VALID for race tolerance).
             cur.execute(
                 "ALTER TABLE release_artist ADD CONSTRAINT fk_release_artist_release "
-                "FOREIGN KEY (release_id) REFERENCES release(id) ON DELETE CASCADE"
+                "FOREIGN KEY (release_id) REFERENCES release(id) ON DELETE CASCADE NOT VALID"
             )
             cur.execute(
                 "ALTER TABLE release_label ADD CONSTRAINT fk_release_label_release "
-                "FOREIGN KEY (release_id) REFERENCES release(id) ON DELETE CASCADE"
+                "FOREIGN KEY (release_id) REFERENCES release(id) ON DELETE CASCADE NOT VALID"
             )
             cur.execute(
                 "ALTER TABLE release_genre ADD CONSTRAINT fk_release_genre_release "
-                "FOREIGN KEY (release_id) REFERENCES release(id) ON DELETE CASCADE"
+                "FOREIGN KEY (release_id) REFERENCES release(id) ON DELETE CASCADE NOT VALID"
             )
             cur.execute(
                 "ALTER TABLE release_style ADD CONSTRAINT fk_release_style_release "
-                "FOREIGN KEY (release_id) REFERENCES release(id) ON DELETE CASCADE"
+                "FOREIGN KEY (release_id) REFERENCES release(id) ON DELETE CASCADE NOT VALID"
             )
             cur.execute(
                 "ALTER TABLE release_track ADD CONSTRAINT fk_release_track_release "
-                "FOREIGN KEY (release_id) REFERENCES release(id) ON DELETE CASCADE"
+                "FOREIGN KEY (release_id) REFERENCES release(id) ON DELETE CASCADE NOT VALID"
             )
             cur.execute(
                 "ALTER TABLE release_track_artist ADD CONSTRAINT fk_release_track_artist_release "
-                "FOREIGN KEY (release_id) REFERENCES release(id) ON DELETE CASCADE"
+                "FOREIGN KEY (release_id) REFERENCES release(id) ON DELETE CASCADE NOT VALID"
             )
             cur.execute(
                 "ALTER TABLE cache_metadata ADD CONSTRAINT fk_cache_metadata_release "
-                "FOREIGN KEY (release_id) REFERENCES release(id) ON DELETE CASCADE"
+                "FOREIGN KEY (release_id) REFERENCES release(id) ON DELETE CASCADE NOT VALID"
             )
             cur.execute("ALTER TABLE cache_metadata ADD PRIMARY KEY (release_id)")
 

--- a/tests/unit/test_fk_not_valid_pin.py
+++ b/tests/unit/test_fk_not_valid_pin.py
@@ -1,0 +1,92 @@
+"""Cross-file pin: every FK on release(id) is added with NOT VALID.
+
+The dedup + verify + run_pipeline paths all DROP CASCADE and re-add FK
+constraints. Each ADD CONSTRAINT validates the existing rows in the child
+table against the new parent — which races with LML's runtime cache writes
+inserting orphans. The fix is uniform: add the FK with NOT VALID, which
+skips re-validation of existing rows but still enforces the FK on new
+INSERTs.
+
+History of the rolling rediscoveries:
+  - #211: dedup_releases.py + schema/create_track_indexes.sql
+  - #188 / 2026-05-14 02:20 UTC: surfaced two more sites in run_pipeline.py
+    and one more in dedup_releases.py (track-side function) +
+    verify_cache.py (verify-and-prune path).
+
+This test is the durable defense: it greps every script for any
+``ADD CONSTRAINT fk_*_release FOREIGN KEY ... REFERENCES release(id)``
+and asserts ``NOT VALID`` follows within a few tokens. Catches future
+regressions at unit-test time instead of at the next rebuild.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).parent.parent.parent
+SCRIPTS_DIR = REPO_ROOT / "scripts"
+
+# Files that own FK constraint creation. The schema/*.sql files are
+# applied via run_sql_file / alembic; the python scripts execute their
+# own ALTER TABLE statements.
+TARGET_FILES = [
+    SCRIPTS_DIR / "run_pipeline.py",
+    SCRIPTS_DIR / "dedup_releases.py",
+    SCRIPTS_DIR / "verify_cache.py",
+    REPO_ROOT / "schema" / "create_track_indexes.sql",
+]
+
+
+def _collapse_python_string_concatenation(text: str) -> str:
+    """Join adjacent Python string literals into one logical line.
+
+    Python's implicit concat (``"foo " "bar"``) lets the FK SQL be split
+    across multiple source lines. To grep for ``ADD CONSTRAINT ... NOT
+    VALID`` we need to join those literals into a single string so the
+    pattern matches across what's logically one statement.
+    """
+    # Collapse ``"...end-of-line\n        "...`` into a single ``"...end-of-line...``.
+    return re.sub(r'"\s*\n\s*"', " ", text)
+
+
+def test_every_release_fk_constraint_uses_not_valid() -> None:
+    """For every ``ALTER TABLE ... ADD CONSTRAINT fk_*_release FOREIGN KEY
+    (release_id) REFERENCES release(id) ON DELETE CASCADE``, the immediately-
+    following tokens must include ``NOT VALID``. Otherwise the next rebuild
+    will hit a ForeignKeyViolation on the orphans LML inserts during the
+    dedup swap window — exactly the failure mode of #188 / 2026-05-14
+    02:20 UTC.
+    """
+    pattern = re.compile(
+        r"ADD CONSTRAINT (fk_\w+_release) "
+        r"FOREIGN KEY \(release_id\) REFERENCES release\(id\) "
+        r"ON DELETE CASCADE(?P<tail>[^,;]*)",
+    )
+
+    failures: list[str] = []
+    for path in TARGET_FILES:
+        text = _collapse_python_string_concatenation(path.read_text())
+        for m in pattern.finditer(text):
+            constraint = m.group(1)
+            tail = m.group("tail")
+            if "NOT VALID" not in tail:
+                # Show line number in the original (pre-collapse) text for usefulness.
+                line = text[: m.start()].count("\n") + 1
+                failures.append(
+                    f"{path.relative_to(REPO_ROOT)}:~{line}  {constraint}  (tail: {tail!r})"
+                )
+
+    assert not failures, (
+        "FK constraint(s) missing NOT VALID — these will race-fail the next rebuild:\n  "
+        + "\n  ".join(failures)
+        + "\n\nSee #211 + #188 for the failure mode. The fix is to add NOT VALID "
+        "after ON DELETE CASCADE."
+    )
+
+
+def test_target_files_exist() -> None:
+    """Sanity: if any of the TARGET_FILES disappears (refactor, rename),
+    the pin above silently passes. Catch that here."""
+    for path in TARGET_FILES:
+        assert path.exists(), f"{path} disappeared — update TARGET_FILES"


### PR DESCRIPTION
## Summary

#211 fixed the dedup base-table FK race but only covered ONE of FOUR sites where this codebase re-creates FK constraints on `release(id)`. The 2026-05-14 02:20 UTC rebuild attempt (instance `i-03a3040c5367faaf1`, fourth attempt) failed at one of the three sites #211 didn't touch:

```
psycopg.errors.ForeignKeyViolation: insert or update on table "release_track"
violates foreign key constraint "fk_release_track_release"
DETAIL:  Key (release_id)=(11842722) is not present in table "release".
CONTEXT:  SQL statement "ALTER TABLE release_track ADD CONSTRAINT fk_release_track_release
FOREIGN KEY (release_id) REFERENCES release(id) ON DELETE CASCADE"
```

Note the SQL in `CONTEXT` is the pre-fix version — no `NOT VALID`. This is because the failing site lives in `scripts/run_pipeline.py`'s inline SQL (not the `schema/create_track_indexes.sql` file #211 updated).

## The four sites

A `grep -rn "ADD CONSTRAINT fk_" scripts/ schema/ alembic/` enumerates every place that creates an FK constraint on `release(id)`:

| Site | What it does | Status pre-PR | Status post-PR |
|---|---|---|---|
| `scripts/run_pipeline.py:938` | Track FKs (non-state-tracked path) | ❌ no cleanup, no NOT VALID | ✅ |
| `scripts/run_pipeline.py:1132` | Track FKs (state-tracked path — failed at 02:20 UTC) | ❌ | ✅ |
| `scripts/dedup_releases.py::add_base_constraints_and_indexes` | Base FKs (release_artist, release_label, release_genre, release_style, cache_metadata) | ✅ fixed in #211 | ✅ |
| `scripts/dedup_releases.py::add_track_constraints_and_indexes` | Track FKs | ❌ | ✅ |
| `scripts/verify_cache.py` (line 834) | All 7 FKs in verify-and-prune path | ❌ | ✅ |
| `schema/create_track_indexes.sql` | Track FKs (alembic / fresh-build path) | ✅ fixed in #211 | ✅ |

## The fix (uniform across sites)

For each site, prepend orphan cleanup and use `NOT VALID` on the constraint:

```sql
-- Cleanup
DELETE FROM release_label
WHERE NOT EXISTS (SELECT 1 FROM release r WHERE r.id = release_label.release_id);

-- Constraint (NOT VALID for race tolerance)
ALTER TABLE release_label ADD CONSTRAINT fk_release_label_release
FOREIGN KEY (release_id) REFERENCES release(id) ON DELETE CASCADE NOT VALID;
```

`NOT VALID` skips re-validation of existing rows, so the ADD step can't race-fail on orphans that LML inserts during the brief cleanup→ADD window. Future inserts still hit the FK at INSERT time, which is the durable correct behavior.

## Defensive pin against future regressions

`tests/unit/test_fk_not_valid_pin.py` greps every script + SQL file in TARGET_FILES and asserts every `ADD CONSTRAINT fk_*_release ... REFERENCES release(id) ON DELETE CASCADE` is followed by `NOT VALID`. If a future change introduces a fifth site without the modifier, the unit suite fails at lint time instead of at the next rebuild.

## Validation

- 2 new unit tests in the cross-file pin (`test_every_release_fk_constraint_uses_not_valid` + `test_target_files_exist`).
- 720 unit tests pass; no regressions.
- `ruff check` + `ruff format --check` clean.
- Visual verification: `grep -A 1 "ADD CONSTRAINT fk_" scripts/` shows every constraint followed by `FOREIGN KEY ... NOT VALID`.

## Related

- #188 — original cache rebuild blocker
- #211 — first FK-race fix (base tables in dedup_releases.py + schema/create_track_indexes.sql)
- #205 — cache_metadata race fix (companion COPY-side problem)
- #206 — release_artist role-column drift fix
- #212 / #213 — earlier follow-ups (integration test + VALIDATE decision); #213 still applicable to the additional NOT VALID constraints this PR introduces