### PR TITLE
import_csv: import artist_name_variation.csv into its own table

### DIFF
--- a/scripts/import_csv.py
+++ b/scripts/import_csv.py
@@ -181,6 +181,19 @@ ARTIST_TABLES: list[TableConfig] = [
         "unique_key": ["artist_id", "alias_name"],
     },
     {
+        # WXYC/discogs-xml-converter#54 splits Discogs `<namevariations>`
+        # (spelling variants) out of artist_alias.csv into their own file.
+        # Without this entry the table would stay empty after every rebuild
+        # and LML's fuzzy-name path would query an empty table; see #215.
+        "csv_file": "artist_name_variation.csv",
+        "table": "artist_name_variation",
+        "csv_columns": ["artist_id", "name"],
+        "db_columns": ["artist_id", "name"],
+        "required": ["artist_id", "name"],
+        "transforms": {},
+        "unique_key": ["artist_id", "name"],
+    },
+    {
         "csv_file": "artist_member.csv",
         "table": "artist_member",
         "csv_columns": ["group_artist_id", "member_artist_id", "member_name"],

--- a/tests/unit/test_import_csv.py
+++ b/tests/unit/test_import_csv.py
@@ -928,6 +928,28 @@ class TestArtistTablesConfig:
         assert "unique_key" in config
         assert config["unique_key"] == ["group_artist_id", "member_artist_id"]
 
+    def test_artist_name_variation_entry_exists(self) -> None:
+        """ARTIST_TABLES must include artist_name_variation.
+
+        Pre-#215 the table was never populated by the rebuild (the converter
+        folded namevariations into artist_alias.csv). With the converter
+        emitting a separate artist_name_variation.csv, the importer needs a
+        matching config or the file would silently drop on the floor.
+        """
+        config = next(
+            (t for t in ARTIST_TABLES if t["table"] == "artist_name_variation"), None
+        )
+        assert config is not None, (
+            "ARTIST_TABLES is missing an entry for artist_name_variation — "
+            "see WXYC/discogs-etl#215 + WXYC/discogs-xml-converter#54"
+        )
+        assert config["csv_file"] == "artist_name_variation.csv"
+        assert config["csv_columns"] == ["artist_id", "name"]
+        assert config["db_columns"] == ["artist_id", "name"]
+        assert "artist_id" in config["required"]
+        assert "name" in config["required"]
+        assert config["unique_key"] == ["artist_id", "name"]
+
 
 class TestReleaseTrackUniqueKey:
     """release_track must have unique_key for dedup."""

--- a/tests/unit/test_import_csv.py
+++ b/tests/unit/test_import_csv.py
@@ -936,9 +936,7 @@ class TestArtistTablesConfig:
         emitting a separate artist_name_variation.csv, the importer needs a
         matching config or the file would silently drop on the floor.
         """
-        config = next(
-            (t for t in ARTIST_TABLES if t["table"] == "artist_name_variation"), None
-        )
+        config = next((t for t in ARTIST_TABLES if t["table"] == "artist_name_variation"), None)
         assert config is not None, (
             "ARTIST_TABLES is missing an entry for artist_name_variation — "
             "see WXYC/discogs-etl#215 + WXYC/discogs-xml-converter#54"


### PR DESCRIPTION
## Summary

This is the importer half of the architecturally correct fix from #215 (path C). The converter half is WXYC/discogs-xml-converter#54.

The Discogs converter now writes Discogs `<namevariations>` (spelling variants) into a dedicated `artist_name_variation.csv` instead of folding them into `artist_alias.csv`. Without a matching importer config the new CSV would silently drop on the floor and the `artist_name_variation` table would stay empty after every rebuild — exactly the gap that prompted #215 in the first place.

## Changes

Adds an `ARTIST_TABLES` entry that imports `artist_name_variation.csv` into the `artist_name_variation` table with columns `(artist_id, name)` and a `(artist_id, name)` unique_key for in-memory dedup during COPY.

- The existing `import_artist_details` artist_id filter applies to the new table for free: `_import_tables` picks the first column containing `artist_id` from `csv_columns`, so name-variation rows for unknown artists are dropped the same way alias rows already are.
- `CACHE_TABLES_TO_TRUNCATE_BASE` already lists `artist_name_variation`, so `--truncate-existing` is unchanged.
- Schema is unchanged. The `artist_name_variation` table has existed for a while; this PR just makes the rebuild populate it.

## Tests

- New unit: `TestArtistTablesConfig::test_artist_name_variation_entry_exists` — pins the config shape (csv_file, csv_columns, db_columns, required, unique_key).
- All 720 unit tests pass; ruff check + ruff format --check clean on the touched files.

## Test plan

- [x] `pytest tests/unit/` passes
- [x] `ruff check` + `ruff format --check` pass
- [ ] CI green
- [ ] Land in lockstep with WXYC/discogs-xml-converter#54 before the next monthly rebuild

## Coordination notes

Until both PRs ship to prod, the new CSV is either absent (old converter still in flight, importer config no-ops via the "Skipping ... not found" branch) or present-but-not-imported (old importer). Neither state breaks the rebuild — it just doesn't populate the new table.

## Related

- Closes #215
- Pair PR: WXYC/discogs-xml-converter#54
- Original ANV-gap finding lives in the `project_artist_name_variation_source.md` memory note from the same session