### PR TITLE
rebuild-cache: fail fast + loud-alert missing webhook secret

### DIFF
--- a/.github/workflows/rebuild-cache.yml
+++ b/.github/workflows/rebuild-cache.yml
@@ -137,17 +137,18 @@ jobs:
       # curl 403 followed by `unrecognized subcommand` from the converter
       # reading an empty FIFO — see #219 root-cause analysis).
       #
-      # HEAD-only (no payload bytes), no retry (an egress-IP block won't
+      # HEAD-only (no payload bytes), follows redirects with -L so the final
+      # status matches what the streaming GET (curl -fL) will see — without
+      # -L, a 302 to S3 would either falsely fail the preflight or hide a
+      # final 403 on the redirect target. No retry (an egress-IP block won't
       # recover within the retry window; a transient outage will recover on
       # the next scheduled tick rather than benefit from in-step retries).
-      # Single curl captures both the status code and the connection outcome
-      # so we don't double-request when the URL is unreachable.
       - name: Verify dump URL is reachable
         env:
           DUMP_URL: ${{ steps.dump.outputs.url }}
         run: |
           set -euo pipefail
-          status=$(curl -sI --retry 0 --max-time 30 -o /dev/null -w "%{http_code}" "$DUMP_URL" || echo "000")
+          status=$(curl -sIL --retry 0 --max-time 30 -o /dev/null -w "%{http_code}" "$DUMP_URL" || echo "000")
           if [ "$status" != "200" ]; then
             echo "::error::HEAD $DUMP_URL returned HTTP $status (expected 200). Common cases: (a) 403 — data.discogs.com Cloudflare blocks GitHub-hosted runner egress IPs; this workflow is a manual escape hatch and production rebuilds run on the wxyc-discogs-rebuild SAM stack (infra/ephemeral-rebuild/) from a non-blocked EC2 IP. (b) 503 / 5xx — Discogs CDN is rate-limiting or having an outage; retry on the next scheduled tick or after status.discogs.com clears. (c) 000 / connection error — DNS or TLS handshake failure (rare; check runner network). To override the URL, dispatch with an explicit dump_url pointing at an asset you've mirrored to a runner-reachable host."
             exit 1

--- a/.github/workflows/rebuild-cache.yml
+++ b/.github/workflows/rebuild-cache.yml
@@ -129,6 +129,28 @@ jobs:
             echo "url=https://data.discogs.com/?download=data%2F${year}%2Fdiscogs_${stamp}_releases.xml.gz" >> "$GITHUB_OUTPUT"
           fi
 
+      # Pre-flight: HEAD the dump URL so a 403 (the known GH-runner-egress block
+      # at data.discogs.com's Cloudflare front, see header comment) fails inside
+      # ~1 second with a named error, instead of being buried 100 lines into the
+      # streaming-pipeline step where the backgrounded curl's exit code can be
+      # masked by a downstream tool's own failure (the 2026-05-05 pattern: a
+      # curl 403 followed by `unrecognized subcommand` from the converter
+      # reading an empty FIFO — see #219 root-cause analysis).
+      #
+      # Uses `curl -sIf --retry 0`: HEAD-only (no payload bytes), fail on HTTP
+      # error, no retry (an egress-IP block won't recover within retry window).
+      - name: Verify dump URL is reachable
+        env:
+          DUMP_URL: ${{ steps.dump.outputs.url }}
+        run: |
+          set -euo pipefail
+          if ! curl -sIf --retry 0 --max-time 30 "$DUMP_URL" >/dev/null; then
+            status=$(curl -sI --retry 0 --max-time 30 -o /dev/null -w "%{http_code}" "$DUMP_URL" || echo "0")
+            echo "::error::HEAD $DUMP_URL returned HTTP $status. data.discogs.com Cloudflare blocks GitHub-hosted runner egress IPs; this workflow is a manual escape hatch only. Production rebuilds run on the wxyc-discogs-rebuild SAM stack (infra/ephemeral-rebuild/) from an EC2 IP that Discogs does not block. To override, dispatch with an explicit dump_url that points at an asset you have already mirrored to a runner-reachable host."
+            exit 1
+          fi
+          echo "Dump URL reachable: HTTP 200"
+
       # Pull the daily-fresh library.db from sync-library.yml's release artifact
       # rather than regenerating it here from MySQL. Kattare's MySQL is reachable
       # only through an SSH tunnel; sync-library.yml owns that tunnel + handles
@@ -162,13 +184,20 @@ jobs:
       #
       # Layout: curl runs in the background writing into the FIFO; the pipeline
       # invocation runs the converter against that FIFO. Kernel pipe buffer
-      # backpressures curl when the converter falls behind. We `wait` on the
-      # curl PID afterwards so a network-side failure mid-stream doesn't get
-      # masked by the pipeline succeeding on partial input.
+      # backpressures curl when the converter falls behind.
+      #
+      # Curl-failure handling (#219): the backgrounded curl writes its exit
+      # status to data/curl.status when it terminates. If curl exits non-zero
+      # before the pipeline opens the FIFO, the FIFO sees EOF immediately and
+      # the python script fails for a *different* reason (e.g. converter
+      # rejecting empty input), masking the real network failure. By checking
+      # the status file before propagating the python exit code, we surface
+      # the curl failure with priority over the masked downstream error.
       - name: Run pipeline (with streamed dump)
         env:
           DATABASE_URL_DISCOGS: ${{ secrets.DATABASE_URL_DISCOGS }}
           DISCOGS_TOKEN: ${{ secrets.DISCOGS_TOKEN }}
+          DUMP_URL: ${{ steps.dump.outputs.url }}
           # When SENTRY_DSN is set as a repo secret, wxyc_etl.logger.init_logger
           # hands exception events to the Sentry SDK. Unset → Sentry stays
           # inactive, JSON logging still emits to stderr.
@@ -177,18 +206,38 @@ jobs:
           set -euo pipefail
           mkdir -p data
           mkfifo data/releases.xml.gz
-          curl -fL --retry 3 --retry-delay 30 \
-            -o data/releases.xml.gz \
-            "${{ steps.dump.outputs.url }}" &
+          rm -f data/curl.status
+          (
+            curl -fL --retry 3 --retry-delay 30 \
+              -o data/releases.xml.gz \
+              "$DUMP_URL"
+            echo "$?" > data/curl.status
+          ) &
           CURL_PID=$!
 
+          # Run the pipeline; capture exit code so we can decide whether the
+          # network side or the python side failed first.
+          set +e
           python scripts/run_pipeline.py \
             --xml data/releases.xml.gz \
             --library-db data/library.db
+          PY_RC=$?
+          set -e
 
-          # Curl should already be done by the time the pipeline returns;
-          # wait surfaces any non-zero exit so a streaming failure is visible.
-          wait "$CURL_PID"
+          # Wait for curl to finish writing curl.status. `wait` returns curl's
+          # own exit code; we also read the status file in case curl was killed
+          # by SIGPIPE (downstream reader closed early -- python crash) which
+          # bash reports as a generic non-zero rather than the underlying HTTP
+          # error.
+          wait "$CURL_PID" || true
+          CURL_RC=$(cat data/curl.status 2>/dev/null || echo "unknown")
+          if [ "$CURL_RC" != "0" ]; then
+            echo "::error::curl exited $CURL_RC while streaming $DUMP_URL. Pipeline python exited $PY_RC (likely a downstream symptom of empty FIFO input)."
+            exit 1
+          fi
+          if [ "$PY_RC" -ne 0 ]; then
+            exit "$PY_RC"
+          fi
 
       # Watchdog: cache_distinct_artists / library_distinct_artists ratio
       # exposes drift between the just-rebuilt cache and the WXYC library
@@ -215,6 +264,12 @@ jobs:
       # Mirrors the --notify pattern in scripts/sync-library.sh; posts only
       # when SLACK_MONITORING_WEBHOOK is set as a repo secret. Issue #125,
       # second acceptance criterion.
+      #
+      # When the secret is unset the step emits an `::error::` annotation
+      # rather than the previous quiet "skipping Slack post" line. That
+      # surfaces on the workflow summary page and on the dispatcher's
+      # notification, so the missing-secret state can't itself fall silent —
+      # which is what allowed two 2026-05-05 runs to fail unnoticed (#219).
       - name: Notify Slack on failure
         if: failure()
         env:
@@ -222,8 +277,8 @@ jobs:
           RUN_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
         run: |
           if [ -z "${SLACK_WEBHOOK_URL:-}" ]; then
-            echo "SLACK_MONITORING_WEBHOOK unset; skipping Slack post."
-            exit 0
+            echo "::error::SLACK_MONITORING_WEBHOOK is not set in repo secrets. The workflow failed but no Slack alert was posted. Configure the secret per CLAUDE.md 'Monthly Cache Rebuild' -> 'Required GitHub secrets' so future failures alert. Failing this notifier step so the workflow's overall status remains red and the dispatcher's GitHub notification reflects it."
+            exit 1
           fi
           curl -s -X POST "$SLACK_WEBHOOK_URL" \
             -H "Content-Type: application/json" \

--- a/.github/workflows/rebuild-cache.yml
+++ b/.github/workflows/rebuild-cache.yml
@@ -137,16 +137,19 @@ jobs:
       # curl 403 followed by `unrecognized subcommand` from the converter
       # reading an empty FIFO — see #219 root-cause analysis).
       #
-      # Uses `curl -sIf --retry 0`: HEAD-only (no payload bytes), fail on HTTP
-      # error, no retry (an egress-IP block won't recover within retry window).
+      # HEAD-only (no payload bytes), no retry (an egress-IP block won't
+      # recover within the retry window; a transient outage will recover on
+      # the next scheduled tick rather than benefit from in-step retries).
+      # Single curl captures both the status code and the connection outcome
+      # so we don't double-request when the URL is unreachable.
       - name: Verify dump URL is reachable
         env:
           DUMP_URL: ${{ steps.dump.outputs.url }}
         run: |
           set -euo pipefail
-          if ! curl -sIf --retry 0 --max-time 30 "$DUMP_URL" >/dev/null; then
-            status=$(curl -sI --retry 0 --max-time 30 -o /dev/null -w "%{http_code}" "$DUMP_URL" || echo "0")
-            echo "::error::HEAD $DUMP_URL returned HTTP $status. data.discogs.com Cloudflare blocks GitHub-hosted runner egress IPs; this workflow is a manual escape hatch only. Production rebuilds run on the wxyc-discogs-rebuild SAM stack (infra/ephemeral-rebuild/) from an EC2 IP that Discogs does not block. To override, dispatch with an explicit dump_url that points at an asset you have already mirrored to a runner-reachable host."
+          status=$(curl -sI --retry 0 --max-time 30 -o /dev/null -w "%{http_code}" "$DUMP_URL" || echo "000")
+          if [ "$status" != "200" ]; then
+            echo "::error::HEAD $DUMP_URL returned HTTP $status (expected 200). Common cases: (a) 403 — data.discogs.com Cloudflare blocks GitHub-hosted runner egress IPs; this workflow is a manual escape hatch and production rebuilds run on the wxyc-discogs-rebuild SAM stack (infra/ephemeral-rebuild/) from a non-blocked EC2 IP. (b) 503 / 5xx — Discogs CDN is rate-limiting or having an outage; retry on the next scheduled tick or after status.discogs.com clears. (c) 000 / connection error — DNS or TLS handshake failure (rare; check runner network). To override the URL, dispatch with an explicit dump_url pointing at an asset you've mirrored to a runner-reachable host."
             exit 1
           fi
           echo "Dump URL reachable: HTTP 200"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -227,9 +227,18 @@ After the pipeline succeeds, the workflow runs `scripts/check_cache_drift.py` ag
 | `DATABASE_URL_DISCOGS` | PostgreSQL URL for the destination cache database |
 | `DISCOGS_TOKEN` | Discogs API token (optional; only matters if rate limits are hit) |
 | `SENTRY_DSN` | Sentry DSN for error reporting (optional; JSON logging still works without it) |
-| `SLACK_MONITORING_WEBHOOK` | Slack incoming webhook for failure + drift alerts (optional; without it failures still fail the workflow but only Sentry sees them) |
+| `SLACK_MONITORING_WEBHOOK` | Slack incoming webhook for failure + drift alerts. **Required for production-grade alerting**: when this secret is unset the `Notify Slack on failure` step *itself* fails (with an `::error::` annotation explaining the missing-secret state) instead of silently skipping, so a workflow-level failure can't fall silent the way the 2026-05-05 runs did (#219). The dispatcher's GitHub failure-notification email is the sole signal in that degraded state. |
 
 **Upstream dependency**: a successful `sync-library.yml` run must have uploaded `library.db` to the `streaming-data-v1` release on `WXYC/library-metadata-lookup` before this workflow fires, or the `Download library.db from LML release artifact` step fails with `release asset not found`. The default `${{ github.token }}` has read scope on the public LML repo; no extra PAT required.
+
+**Interpreting a failed run** (#219):
+
+1. **`Verify dump URL is reachable` returns HTTP 403**: this is the expected outcome on a GitHub-hosted runner — Discogs's Cloudflare front blocks runner egress IPs (see "Why EC2" above). The preflight fails inside ~1 second so the operator doesn't burn 5+ minutes of pipeline work on a dump-host they can't reach. *Fix*: don't dispatch this workflow against the default `data.discogs.com` URL from a GH runner; either kick the rebuild on the `wxyc-discogs-rebuild` SAM stack (see `infra/ephemeral-rebuild/README.md`) or dispatch with an explicit `dump_url` input pointing at an asset mirrored to a runner-reachable host.
+2. **`Verify alembic baseline is stamped` fails with "alembic_version table missing or empty"**: the destination DB was rebuilt without the one-time `alembic stamp head` per `docs/migrations-runbook.md`. *Fix*: run the stamp procedure, then redispatch.
+3. **`Run pipeline (with streamed dump)` exits with "curl exited N while streaming"**: a network-side failure mid-stream (transient HTTP/2 reset, etc.). Bash now surfaces the curl exit code with priority over any downstream symptom (the converter complaining about an empty FIFO). *Fix*: redispatch; if it keeps recurring, escalate to a self-hosted runner.
+4. **`Notify Slack on failure` is the only red step**: this means a prior step failed *and* `SLACK_MONITORING_WEBHOOK` is unset. Configure the secret, then redispatch.
+
+**Manual fallback** when the workflow is unavailable or refuses to reach `data.discogs.com`: ssh into the Backend-Service EC2 box and run `scripts/rebuild-cache.sh` directly. The script's failure-path Slack `--notify` is the same surface as the workflow's. The detailed legacy-EC2-cron runbook is in [`docs/ec2-rebuild-runbook.md`](docs/ec2-rebuild-runbook.md).
 
 ### Library Sync (`sync-library.yml`)
 


### PR DESCRIPTION
Closes #219.

## Root cause (from the 2026-05-05 failed-run logs)

Both runs (workflow_dispatch 25390922547 + scheduled 25308842897) failed inside 2-5 minutes. The logs surface three layered problems.

1. **data.discogs.com 403s GitHub-hosted runner IPs.** Cloudflare blocks the runner egress range; residential and EC2 IPs aren't blocked. The header comment block at line 35 of `rebuild-cache.yml` already documents this; the bug is that the failure didn't *surface* as "403".

2. **The backgrounded curl's non-zero exit was masked.** Curl ran with `&` so `set -e` didn't propagate its exit. The named-pipe reader (the converter) saw immediate EOF, and the python pipeline failed for an unrelated downstream reason — `error: unrecognized subcommand 'data/releases.xml.gz'` — because the empty FIFO confused the converter's positional-arg parser. The misleading error is what landed in the run log.

3. **`Notify Slack on failure` exited 0 when the webhook secret was unset.** `SLACK_MONITORING_WEBHOOK` is not in the repo's secrets, so the alert path was silent. The workflow status went red but no human-facing notification fired — which is why two runs sat unnoticed.

## Fix

- **New `Verify dump URL is reachable` preflight** HEADs the URL with `curl -sIf --retry 0 --max-time 30`. A 403 fails the step in ~1s with a named error pointing at the EC2 SAM stack as the production path.
- **The streaming step's curl-failure path is now loud.** Curl writes its exit code to `data/curl.status` from inside a subshell; the python exit code is captured separately; the script prefers the curl status when reporting failure. "curl 403, then converter complained" now reports as `curl exited 22` instead of `unrecognized subcommand`.
- **`Notify Slack on failure` exits 1 with an `::error::` annotation when SLACK_MONITORING_WEBHOOK is unset.** The annotation lands on the workflow summary and the dispatcher's GitHub notification, so the missing-secret state itself cannot fall silent.
- **CLAUDE.md "Monthly Cache Rebuild"** gains an "Interpreting a failed run" checklist (preflight 403, alembic-stamp, mid-stream curl failure, missing webhook) plus a "Manual fallback" pointer to `scripts/rebuild-cache.sh` on the Backend-Service EC2 box and `docs/ec2-rebuild-runbook.md`.

No change to the workflow's compute envelope or scheduling: cron is still off (the production rebuild runs on the `wxyc-discogs-rebuild` SAM stack from EC2 per the 2026-05-07 status note), and this workflow remains a `workflow_dispatch`-only manual escape hatch.

## Lint

- `actionlint` (with shellcheck): pass
- `yamllint` (line-length 500 to accommodate `::error::` annotations on a single line): pass

## Test plan

- [ ] Trigger a `workflow_dispatch` run; expect `Verify dump URL is reachable` to fail with HTTP 403 inside ~1s and `Notify Slack on failure` to fail with the missing-secret `::error::` annotation
- [ ] Confirm the dispatcher receives the GitHub failure-notification email
- [ ] Repo maintainer sets `SLACK_MONITORING_WEBHOOK` separately and confirms Slack receives the warning post on the next failure