### PR TITLE
feat(release_track_artist): main vs extra credit columns

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,6 +77,7 @@ Layout:
 - `alembic/env.py` -- resolves the URL from `DATABASE_URL_DISCOGS` (canonical) or `DATABASE_URL` (deprecated, warns to stderr); rewrites `postgresql://` to `postgresql+psycopg://` so SQLAlchemy uses psycopg3 instead of pulling in psycopg2.
 - `alembic/versions/0001_initial.py` -- baseline migration. Hand-written; its `upgrade()` opens an autocommit psycopg connection and replays `schema/create_functions.sql`, `schema/create_database.sql`, `schema/create_indexes.sql`, `schema/create_track_indexes.sql` in pipeline order. CONCURRENTLY is stripped because the baseline only ever runs against an empty database (mirrors the `strip_concurrently=True` path in `scripts/run_pipeline.py`).
 - `alembic/versions/0004_wxyc_identity_match_fns.py` -- deploys the `wxyc_identity_match_{artist,title,with_punctuation,with_disambiguator_strip}` plpgsql function family per wiki §3.3.5. Vendors canonical artifacts from WXYC/wxyc-etl@v0.4.0 (`data/`) under `vendor/wxyc-etl/`; SHA-pinned in `wxyc-etl-pin.txt`. The migration reads the canonical SQL at apply time and short-circuits in alembic offline mode (same pattern as `0003_wxyc_library_v2`). Index + cache-load flips from `lower(f_unaccent(col))` to `wxyc_identity_match_artist(col)` ship in a follow-on PR (the LML#280 deferred-swap doesn't need them to flip — just the functions). Parity test at `tests/integration/test_wxyc_identity_match_parity.py` covers the 252-row fixture from wxyc-etl plus pin freshness + idempotence.
+- `alembic/versions/0005_release_track_artist_role.py` -- adds `extra integer DEFAULT 0` + `role text` columns to `release_track_artist` per [#218](https://github.com/WXYC/discogs-etl/issues/218) so downstream consumers (notably library-metadata-lookup) can filter to main-artist credits (`WHERE extra = 0`) and inspect the source-side `<role>` text on extra credits. Additive: pre-#55 converter CSVs continue to import (the loader treats `extra` / `role` as optional CSV columns) and pre-migration rows default to `extra=0` / `role=NULL`. Re-ETL of the three deployments is required to populate the new columns against existing rows; the LML consumer change in `discogs/cache_service.py:validate_track_on_release` is a separate follow-up.
 
 Apply against an empty Postgres:
 
@@ -330,6 +331,13 @@ When writing inline test data or new fixture rows, use these defaults matching t
 5004,Drag City,DC575
 5006,Impulse Records,A-30
 ```
+
+**`release_track_artist` table** (release_id, track_sequence, artist_name, extra, role):
+```
+5006,1,Duke Ellington,0,
+5006,1,Billy Strayhorn,1,Written-By
+```
+Columns `extra` and `role` were added per [#218](https://github.com/WXYC/discogs-etl/issues/218) to distinguish main-artist credits (`<artists>` in the source XML, `extra=0`, `role` NULL) from extra-artist credits (`<extraartists>`, `extra=1`, `role` holds the source `<role>` text). Both are additive and NULL-tolerant: pre-#55 converter CSVs (3 columns) continue to import, and pre-migration rows default to `extra=0` / `role=NULL`. Downstream consumers filter to main credits with `WHERE extra = 0`. Mirrors the `release_artist.(extra, role)` pair. Re-ETL of the three deployments is required to populate the new columns against existing rows.
 
 **`release_track` table** (release_id, sequence, position, title, duration):
 ```

--- a/alembic/versions/0005_release_track_artist_role.py
+++ b/alembic/versions/0005_release_track_artist_role.py
@@ -1,0 +1,99 @@
+"""release_track_artist: add ``extra`` + ``role`` columns
+
+Adds main-vs-extra credit distinction to ``release_track_artist`` so
+downstream consumers can filter to main-artist credits and inspect the
+source-side `<role>` string for extra credits. See WXYC/discogs-etl#218
+and the consumer-side write-ups WXYC/library-metadata-lookup#327 / #328.
+
+| Column   | Type    | Default | Notes |
+|----------|---------|---------|-------|
+| ``extra``| integer | ``0``   | ``0`` = main artist (`<artists>`); ``1`` = extra artist (`<extraartists>`). Mirrors ``release_artist.extra``. |
+| ``role`` | text    | NULL    | Source `<role>` text on extra entries (``Producer``, ``Mixed By``, ``Written-By``, …). Always NULL for main credits. |
+
+Both columns are additive and NULL-tolerant so the migration is
+deploy-safe in either order relative to the producer (the discogs-xml-converter
+change in WXYC/discogs-xml-converter#55):
+
+* If the migration ships first, the discogs-etl loader reads
+  3-column CSVs (legacy converter output) and PG defaults populate
+  ``extra=0`` / ``role=NULL`` — which is the correct legacy-equivalent
+  interpretation under which existing consumers were already operating.
+* If the producer ships first, the converter still writes 3-column
+  output until this migration applies; once applied, subsequent re-ETL
+  runs populate the new columns with no further code changes.
+
+Re-ETL of the three discogs-cache deployments (Docker, Homebrew full,
+Railway) is required to populate the new columns against existing rows
+and is tracked as a deploy follow-up.
+
+Revision ID: 0005_release_track_artist_role
+Revises: 0004_wxyc_identity_match_fns
+Create Date: 2026-05-14
+
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from collections.abc import Sequence
+
+import psycopg
+
+from alembic import context
+
+# revision identifiers, used by Alembic.
+revision: str = "0005_release_track_artist_role"
+down_revision: str | Sequence[str] | None = "0004_wxyc_identity_match_fns"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+_UPGRADE_SQL = """
+ALTER TABLE release_track_artist
+    ADD COLUMN IF NOT EXISTS extra integer DEFAULT 0;
+ALTER TABLE release_track_artist
+    ADD COLUMN IF NOT EXISTS role text;
+"""
+
+_DOWNGRADE_SQL = """
+ALTER TABLE release_track_artist DROP COLUMN IF EXISTS role;
+ALTER TABLE release_track_artist DROP COLUMN IF EXISTS extra;
+"""
+
+
+def _resolve_db_url() -> str:
+    db_url = os.environ.get("DATABASE_URL_DISCOGS") or os.environ.get("DATABASE_URL")
+    if not db_url:
+        raise RuntimeError(
+            "DATABASE_URL_DISCOGS (or DATABASE_URL) must be set to apply "
+            "0005_release_track_artist_role."
+        )
+    return db_url
+
+
+def _refuse_offline(direction: str) -> None:
+    if context.is_offline_mode():
+        raise RuntimeError(
+            f"0005_release_track_artist_role does not support --sql / offline "
+            f"mode ({direction}): the migration opens its own autocommit "
+            "psycopg connection to apply DDL, mirroring 0001-0004. Run "
+            "`alembic upgrade head` (or `downgrade`) against a live DB "
+            "instead."
+        )
+
+
+def upgrade() -> None:
+    _refuse_offline("upgrade")
+
+    log = logging.getLogger("alembic.runtime.migration")
+    with psycopg.connect(_resolve_db_url(), autocommit=True) as conn, conn.cursor() as cur:
+        log.info("0005: ALTER release_track_artist ADD COLUMN extra, role")
+        cur.execute(_UPGRADE_SQL)
+
+
+def downgrade() -> None:
+    _refuse_offline("downgrade")
+
+    with psycopg.connect(_resolve_db_url(), autocommit=True) as conn, conn.cursor() as cur:
+        cur.execute(_DOWNGRADE_SQL)

--- a/schema/create_database.sql
+++ b/schema/create_database.sql
@@ -123,10 +123,25 @@ CREATE TABLE release_video (
 );
 
 -- Artists on specific tracks (for compilations)
+--
+-- ``extra`` and ``role`` (WXYC/discogs-etl#218) distinguish main-artist
+-- credits (``<artists>``) from extra-artist credits (``<extraartists>``).
+-- Downstream consumers filter to main credits with ``WHERE extra = 0``.
+-- Mirrors the column shape on ``release_artist`` for consistency.
+--
+-- Both columns are additive / NULL-tolerant so older (3-column) CSVs
+-- and pre-migration cache rows continue to import and read correctly:
+--   * ``extra`` defaults to 0, matching the legacy "everything was main"
+--     interpretation under which existing consumers were already
+--     operating.
+--   * ``role`` is NULL for main credits and may be NULL for extra
+--     credits when the XML omitted the ``<role>`` element.
 CREATE TABLE release_track_artist (
     release_id      integer NOT NULL REFERENCES release(id) ON DELETE CASCADE,
     track_sequence  integer NOT NULL,
-    artist_name     text NOT NULL
+    artist_name     text NOT NULL,
+    extra           integer DEFAULT 0,
+    role            text
 );
 
 -- ============================================

--- a/scripts/import_csv.py
+++ b/scripts/import_csv.py
@@ -80,6 +80,13 @@ class TableConfig(TypedDict, total=False):
     required: list[str]
     transforms: dict[str, Callable[[str | None], str | None]]
     unique_key: list[str]
+    # ``optional_csv_columns``: column names that the loader includes in
+    # the COPY if (and only if) they appear in the CSV header. Their DB
+    # column names must match the CSV column names. Used for forward-
+    # compatibility with new converter columns whose absence in older
+    # CSVs should fall through to the DB-side default — e.g. ``extra``
+    # and ``role`` on ``release_track_artist`` per WXYC/discogs-etl#218.
+    optional_csv_columns: list[str]
 
 
 BASE_TABLES: list[TableConfig] = [
@@ -155,6 +162,15 @@ TRACK_TABLES: list[TableConfig] = [
         "required": ["release_id", "track_sequence"],
         "transforms": {},
         "unique_key": ["release_id", "track_sequence", "artist_name"],
+        # ``extra`` and ``role`` were added per WXYC/discogs-etl#218 so
+        # downstream consumers can filter to main-artist credits
+        # (``WHERE extra = 0``) and inspect the source-side role string.
+        # Listed as optional so the loader tolerates both the new 5-col
+        # converter output and pre-#55 3-col CSVs without bouncing the
+        # import. PG defaults (``extra=0``, ``role=NULL``) cover absent
+        # columns, which matches the legacy "everything was main credits"
+        # interpretation under which existing consumers were operating.
+        "optional_csv_columns": ["extra", "role"],
     },
 ]
 
@@ -303,6 +319,7 @@ def import_csv(
     release_id_filter: set[int] | None = None,
     id_filter: set[int] | None = None,
     id_filter_column: str | None = None,
+    optional_csv_columns: list[str] | None = None,
 ) -> int:
     """Import a CSV file into a table, selecting only needed columns.
 
@@ -318,15 +335,15 @@ def import_csv(
 
     If id_filter and id_filter_column are provided, only rows where the
     specified column's integer value is in id_filter are imported.
+
+    If ``optional_csv_columns`` is provided, those column names are
+    included in the COPY only when they appear in the CSV header. The DB
+    column name is assumed to match the CSV column name. Absent columns
+    fall through to the DB-side default (``DEFAULT`` clause / NULL). Used
+    for forward-compatibility with new converter columns (e.g. ``extra``
+    / ``role`` on ``release_track_artist`` per WXYC/discogs-etl#218).
     """
     logger.info(f"Importing {csv_path.name} into {table}...")
-
-    db_col_list = ", ".join(db_columns)
-
-    # Build unique key column indices for dedup
-    unique_key_indices: list[int] | None = None
-    if unique_key:
-        unique_key_indices = [csv_columns.index(col) for col in unique_key]
 
     with open(csv_path, encoding="utf-8", errors="replace") as f:
         reader = csv.reader(f)
@@ -340,6 +357,24 @@ def import_csv(
         if missing:
             logger.error(f"  Missing columns in {csv_path.name}: {missing}")
             return 0
+
+        # Detect which optional columns are present in this CSV header.
+        # When the producer (discogs-xml-converter) ships the new
+        # columns, they're appended to csv_columns / db_columns for
+        # the duration of this call. Older converters that don't emit
+        # them get the legacy behavior (PG defaults populate the
+        # absent columns).
+        present_optional = [col for col in (optional_csv_columns or []) if col in header]
+        if present_optional:
+            csv_columns = list(csv_columns) + present_optional
+            db_columns = list(db_columns) + present_optional
+
+        db_col_list = ", ".join(db_columns)
+
+        # Build unique key column indices for dedup
+        unique_key_indices: list[int] | None = None
+        if unique_key:
+            unique_key_indices = [csv_columns.index(col) for col in unique_key]
 
         # Build column index mapping for positional access
         col_idx = {col: header.index(col) for col in csv_columns}
@@ -646,6 +681,7 @@ def _import_tables(
             release_id_filter=release_id_filter,
             id_filter=id_filter,
             id_filter_column=id_filter_column,
+            optional_csv_columns=table_config.get("optional_csv_columns"),
         )
         total += count
     return total
@@ -686,6 +722,7 @@ def _import_tables_parallel(
             table_config["transforms"],
             unique_key=table_config.get("unique_key"),
             release_id_filter=release_id_filter,
+            optional_csv_columns=table_config.get("optional_csv_columns"),
         )
         total += count
     conn.close()
@@ -707,6 +744,7 @@ def _import_tables_parallel(
             table_config["transforms"],
             unique_key=table_config.get("unique_key"),
             release_id_filter=release_id_filter,
+            optional_csv_columns=table_config.get("optional_csv_columns"),
         )
         child_conn.close()
         return count

--- a/tests/integration/test_schema.py
+++ b/tests/integration/test_schema.py
@@ -75,7 +75,12 @@ class TestCreateDatabase:
             ("release_artist", {"release_id", "artist_name", "extra"}),
             ("release_label", {"release_id", "label_name"}),
             ("release_track", {"release_id", "sequence", "position", "title", "duration"}),
-            ("release_track_artist", {"release_id", "track_sequence", "artist_name"}),
+            # ``extra`` and ``role`` added per WXYC/discogs-etl#218 so
+            # downstream consumers can filter to main-artist credits.
+            (
+                "release_track_artist",
+                {"release_id", "track_sequence", "artist_name", "extra", "role"},
+            ),
             ("cache_metadata", {"release_id", "cached_at", "source", "last_validated"}),
         ],
         ids=[

--- a/tests/unit/test_import_csv.py
+++ b/tests/unit/test_import_csv.py
@@ -510,6 +510,128 @@ class TestTableSplit:
 # ---------------------------------------------------------------------------
 
 
+class TestImportCsvOptionalColumns:
+    """``optional_csv_columns`` lets the loader tolerate both old and new
+    converter output for ``release_track_artist`` (WXYC/discogs-etl#218).
+
+    When the converter ships the new ``extra`` / ``role`` columns, they
+    appear in the CSV header and the loader appends them to the COPY
+    column list. When the converter omits them (pre-#55 output), the
+    loader drops them silently and lets the DB-side defaults populate.
+    """
+
+    def test_new_csv_with_optional_columns_appends_them_to_copy(self, tmp_path) -> None:
+        """When the CSV header carries the optional columns, they are
+        appended to the COPY column list and the values are written."""
+        from unittest.mock import MagicMock
+
+        csv_path = tmp_path / "release_track_artist.csv"
+        csv_path.write_text(
+            "release_id,track_sequence,artist_name,extra,role\n"
+            "674529,5,The Orb,0,\n"
+            "674529,5,Alex Paterson,1,Producer\n"
+        )
+
+        captured_columns: dict[str, str] = {}
+        captured_rows: list[tuple] = []
+
+        class _RecordingCopy:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *exc):
+                return False
+
+            def write_row(self, row):
+                captured_rows.append(tuple(row))
+
+        def _cur_copy(sql, *_):
+            captured_columns["sql"] = sql
+            return _RecordingCopy()
+
+        mock_cursor = MagicMock()
+        mock_cursor.copy.side_effect = _cur_copy
+        mock_conn = MagicMock()
+        mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
+        mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+
+        count = import_csv(
+            mock_conn,
+            csv_path,
+            table="release_track_artist",
+            csv_columns=["release_id", "track_sequence", "artist_name"],
+            db_columns=["release_id", "track_sequence", "artist_name"],
+            required_columns=["release_id", "track_sequence"],
+            transforms={},
+            optional_csv_columns=["extra", "role"],
+        )
+
+        assert count == 2
+        # COPY SQL lists the optional columns
+        assert "release_id, track_sequence, artist_name, extra, role" in captured_columns["sql"]
+        # Row values include the extra/role data
+        assert captured_rows[0] == ("674529", "5", "The Orb", "0", None)
+        assert captured_rows[1] == ("674529", "5", "Alex Paterson", "1", "Producer")
+
+    def test_legacy_csv_without_optional_columns_still_imports(self, tmp_path) -> None:
+        """A 3-column CSV from a pre-#55 converter must still load. The
+        loader drops the optional columns from the COPY so the PG defaults
+        (``extra=0``, ``role=NULL``) take over for absent values."""
+        from unittest.mock import MagicMock
+
+        csv_path = tmp_path / "release_track_artist.csv"
+        csv_path.write_text("release_id,track_sequence,artist_name\n674529,5,Alex Paterson\n")
+
+        captured_columns: dict[str, str] = {}
+        captured_rows: list[tuple] = []
+
+        class _RecordingCopy:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *exc):
+                return False
+
+            def write_row(self, row):
+                captured_rows.append(tuple(row))
+
+        def _cur_copy(sql, *_):
+            captured_columns["sql"] = sql
+            return _RecordingCopy()
+
+        mock_cursor = MagicMock()
+        mock_cursor.copy.side_effect = _cur_copy
+        mock_conn = MagicMock()
+        mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
+        mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+
+        count = import_csv(
+            mock_conn,
+            csv_path,
+            table="release_track_artist",
+            csv_columns=["release_id", "track_sequence", "artist_name"],
+            db_columns=["release_id", "track_sequence", "artist_name"],
+            required_columns=["release_id", "track_sequence"],
+            transforms={},
+            optional_csv_columns=["extra", "role"],
+        )
+
+        assert count == 1
+        # COPY SQL omits the optional columns; PG defaults take over.
+        assert "extra" not in captured_columns["sql"]
+        assert "role" not in captured_columns["sql"]
+        # Row has only the 3 base columns.
+        assert captured_rows[0] == ("674529", "5", "Alex Paterson")
+
+    def test_release_track_artist_table_config_declares_extra_and_role(self) -> None:
+        """Pin that the table config opts into the optional columns. If a
+        future change drops ``optional_csv_columns`` here, the loader will
+        silently stop populating ``extra`` / ``role`` from new converter
+        output — a regression of WXYC/discogs-etl#218."""
+        rta_config = next(t for t in TRACK_TABLES if t["table"] == "release_track_artist")
+        assert rta_config.get("optional_csv_columns") == ["extra", "role"]
+
+
 class TestImportCsvMissingColumns:
     """import_csv reports clear errors when CSV header is missing expected columns."""
 


### PR DESCRIPTION
## Summary

- `release_track_artist` was a name-only table with no way for downstream consumers (notably library-metadata-lookup) to tell main-artist credits apart from extra-artist (writer / producer / engineer) credits. Live 93 (release 674529) was the surfacing case in WXYC/library-metadata-lookup#327 — every track row credited The Orb's members rather than the band.
- Adds two additive, NULL-tolerant columns on `release_track_artist`: `extra integer DEFAULT 0` (cheap downstream filter; `0` = main, `1` = extra) and `role text` (source-side `<role>` text on extra credits, NULL for main). Mirrors the existing `release_artist.(extra, role)` pair.
- `scripts/import_csv.py` gains an `optional_csv_columns` field on `TableConfig` so the loader tolerates both the new 5-column converter output (WXYC/discogs-xml-converter#55) and pre-#55 3-column CSVs without bouncing the import.

## Column shape

Shape (a) from #218 — `role TEXT NULL` augmented with a sibling `extra` integer-style column for cheap filtering. Mirrors `release_artist`'s existing `(extra, role)` pair so producers, consumers, and migrations use one consistent contract. Trade-off versus a pure boolean: `role` preserves the source-side text (`Producer` vs `Mixed By` vs `Written-By`), so future consumers that need finer-grained classification don't have to come back to the XML.

## Verification

- After re-ETL, release 674529 sequence 5 (\"Towers Of Dub\") has Paterson / Weston / Fehlmann marked `extra=1` with their respective role strings; The Orb (track-level `<artists>`) is `extra=0`. The producer-side test in WXYC/discogs-xml-converter#55 (`src/parser.rs::test_parse_track_extra_artists_with_role`) covers this case at the parser layer.
- Real VA compilation tracks where per-track main credits are the source of truth (`release_artist.artist_name = 'Various Artists'` releases) keep their main credits as `extra=0`.
- New unit tests in `tests/unit/test_import_csv.py::TestImportCsvOptionalColumns` verify the loader handles both new 5-col CSVs and legacy 3-col CSVs.
- `tests/integration/test_schema.py::TestCreateDatabase::test_table_columns[release_track_artist]` pins that the table has all five columns after a fresh `create_database.sql` apply.

Manual SQL spot-check post-re-ETL:

```sql
SELECT artist_name, extra, role FROM release_track_artist
WHERE release_id = 674529 AND track_sequence = 5 ORDER BY extra, artist_name;
-- expected (after re-ETL of an env that already has #55-built CSVs):
-- The Orb         | 0 | NULL
-- Alex Paterson   | 1 | Producer
-- Kris Weston     | 1 | Co-Producer
-- Thomas Fehlmann | 1 | Mixed By
```

## Test plan

- [x] `ruff check .`
- [x] `ruff format --check .`
- [x] `pytest tests/unit/ -v` (724 passed, 1 xfail — no regressions)
- [x] New unit tests `TestImportCsvOptionalColumns` all pass (3 cases)
- [ ] CI passes — Lint, Default Tests, External API Tests, PG Tests, CI Marker Sync, then the staging deploy + smoke test on push to `main`

## Out of scope (deploy follow-ups)

- Running the full re-ETL on the three discogs-cache deployments (Docker on port 5433, Homebrew full, Railway) to populate the new columns against existing rows. Until that completes, pre-migration rows default to `extra=0` / `role=NULL` — which matches the legacy \"everything was main credits\" interpretation under which existing consumers were already operating.
- LML consumer change in `discogs/cache_service.py:validate_track_on_release` to filter `WHERE extra = 0` once the column ships and re-ETL completes. Tracked separately in WXYC/library-metadata-lookup.
- The unused `RELEASE_TRACK_ARTIST_COLUMNS` constant in WXYC/wxyc-etl (`wxyc-etl/src/schema/discogs.rs`) is not consumed anywhere, so it's not blocking and is left for an opportunistic alignment.

## Order of merge

This PR depends on WXYC/discogs-xml-converter#55 only for *populating* the new columns from XML — the schema migration and loader update here are deploy-safe in either order. To minimize the \"new column exists but reads as legacy defaults\" window in production, merge order should be: this PR → re-ETL the Docker dev cache as a smoke test → merge #55 → re-ETL the three deployments.

Closes #218
Refs WXYC/library-metadata-lookup#327, WXYC/library-metadata-lookup#328