### PR TITLE
copy-swap: re-apply NOT NULL on data columns stripped by CTAS

### DIFF
--- a/scripts/dedup_releases.py
+++ b/scripts/dedup_releases.py
@@ -476,11 +476,21 @@ def add_base_constraints_and_indexes(conn, db_url: str | None = None) -> None:
         "Level 1.5: Clean orphan child rows before FK validation",
     )
 
-    # Level 2: FK constraints + PK on cache_metadata + FK indexes (parallel).
+    # Level 2: FK constraints + PK on cache_metadata + FK indexes + NOT NULL
+    # restoration (parallel).
+    #
     # FK constraints use NOT VALID so the ADD step itself can't race-fail
     # on orphans created by LML during the brief Level-1.5 → Level-2 window.
     # Postgres still enforces the FK on new inserts after the constraint is
     # added, so the durable behavior is identical to a validated constraint.
+    #
+    # The ``SET NOT NULL`` statements re-assert the constraints that the
+    # ``CREATE TABLE new_X AS SELECT ...`` step strips silently — CTAS
+    # carries column types forward but not NOT NULL / DEFAULT / CHECK. The
+    # schema in ``schema/create_database.sql`` declares the data columns
+    # below as NOT NULL; without explicit re-application every monthly
+    # rebuild ships a discogs-cache where those constraints are gone. Pinned
+    # by ``tests/integration/test_copy_swap_preserves_not_null.py``.
     _exec_parallel(
         [
             "ALTER TABLE release_artist ADD CONSTRAINT fk_release_artist_release "
@@ -498,8 +508,19 @@ def add_base_constraints_and_indexes(conn, db_url: str | None = None) -> None:
             "CREATE INDEX idx_release_label_release_id ON release_label(release_id)",
             "CREATE INDEX idx_release_genre_release_id ON release_genre(release_id)",
             "CREATE INDEX idx_release_style_release_id ON release_style(release_id)",
+            "ALTER TABLE release ALTER COLUMN title SET NOT NULL",
+            "ALTER TABLE release_artist ALTER COLUMN release_id SET NOT NULL",
+            "ALTER TABLE release_artist ALTER COLUMN artist_name SET NOT NULL",
+            "ALTER TABLE release_label ALTER COLUMN release_id SET NOT NULL",
+            "ALTER TABLE release_label ALTER COLUMN label_name SET NOT NULL",
+            "ALTER TABLE release_genre ALTER COLUMN release_id SET NOT NULL",
+            "ALTER TABLE release_genre ALTER COLUMN genre SET NOT NULL",
+            "ALTER TABLE release_style ALTER COLUMN release_id SET NOT NULL",
+            "ALTER TABLE release_style ALTER COLUMN style SET NOT NULL",
+            "ALTER TABLE cache_metadata ALTER COLUMN cached_at SET NOT NULL",
+            "ALTER TABLE cache_metadata ALTER COLUMN source SET NOT NULL",
         ],
-        "Level 2: FK constraints + FK indexes",
+        "Level 2: FK constraints + FK indexes + NOT NULL restoration",
     )
 
     # Level 3: GIN trigram indexes + cache metadata indexes (parallel)

--- a/scripts/dedup_releases.py
+++ b/scripts/dedup_releases.py
@@ -519,8 +519,16 @@ def add_base_constraints_and_indexes(conn, db_url: str | None = None) -> None:
             "ALTER TABLE release_style ALTER COLUMN style SET NOT NULL",
             "ALTER TABLE cache_metadata ALTER COLUMN cached_at SET NOT NULL",
             "ALTER TABLE cache_metadata ALTER COLUMN source SET NOT NULL",
+            # ``cache_metadata.cached_at`` DEFAULT is load-bearing: LML's
+            # cache-miss INSERT omits the column and relies on the DEFAULT
+            # to avoid the NOT NULL re-applied above. Without restoration,
+            # the next cache miss after a rebuild would fail with a NOT
+            # NULL violation. ``release_artist.extra`` DEFAULT is schema
+            # invariant (nullable column) but restored for consistency.
+            "ALTER TABLE cache_metadata ALTER COLUMN cached_at SET DEFAULT now()",
+            "ALTER TABLE release_artist ALTER COLUMN extra SET DEFAULT 0",
         ],
-        "Level 2: FK constraints + FK indexes + NOT NULL restoration",
+        "Level 2: FK constraints + FK indexes + NOT NULL + DEFAULT restoration",
     )
 
     # Level 3: GIN trigram indexes + cache metadata indexes (parallel)

--- a/scripts/verify_cache.py
+++ b/scripts/verify_cache.py
@@ -878,13 +878,21 @@ def prune_releases_copy_swap(
             cur.execute("CREATE INDEX idx_cache_metadata_cached_at ON cache_metadata(cached_at)")
             cur.execute("CREATE INDEX idx_cache_metadata_source ON cache_metadata(source)")
 
-            # Re-apply NOT NULL constraints stripped by ``CREATE TABLE AS
-            # SELECT`` above. CTAS carries column types forward but not
-            # NOT NULL / DEFAULT / CHECK; the schema in
+            # Re-apply NOT NULL and DEFAULT constraints stripped by
+            # ``CREATE TABLE AS SELECT`` above. CTAS carries column types
+            # forward but not NOT NULL / DEFAULT / CHECK; the schema in
             # ``schema/create_database.sql`` declares these columns as
-            # NOT NULL, and without explicit re-application every prune
-            # run ships a discogs-cache where those constraints are gone.
-            # Pinned by
+            # NOT NULL (and a few as DEFAULT now() / DEFAULT 0), and
+            # without explicit re-application every prune run ships a
+            # discogs-cache where those constraints are gone.
+            #
+            # The ``cache_metadata.cached_at`` DEFAULT is load-bearing:
+            # LML's cache-miss INSERT omits the column and relies on the
+            # DEFAULT to avoid the NOT NULL constraint applied here.
+            # Without DEFAULT restoration, the next cache miss after a
+            # rebuild would fail with a NOT NULL violation. The ``extra``
+            # DEFAULTs are schema invariant (nullable columns) but
+            # restored for consistency. Pinned by
             # ``tests/integration/test_copy_swap_preserves_not_null.py``.
             for stmt in (
                 "ALTER TABLE release ALTER COLUMN title SET NOT NULL",
@@ -904,6 +912,9 @@ def prune_releases_copy_swap(
                 "ALTER TABLE release_track_artist ALTER COLUMN artist_name SET NOT NULL",
                 "ALTER TABLE cache_metadata ALTER COLUMN cached_at SET NOT NULL",
                 "ALTER TABLE cache_metadata ALTER COLUMN source SET NOT NULL",
+                "ALTER TABLE cache_metadata ALTER COLUMN cached_at SET DEFAULT now()",
+                "ALTER TABLE release_artist ALTER COLUMN extra SET DEFAULT 0",
+                "ALTER TABLE release_track_artist ALTER COLUMN extra SET DEFAULT 0",
             ):
                 cur.execute(stmt)
 

--- a/scripts/verify_cache.py
+++ b/scripts/verify_cache.py
@@ -878,6 +878,35 @@ def prune_releases_copy_swap(
             cur.execute("CREATE INDEX idx_cache_metadata_cached_at ON cache_metadata(cached_at)")
             cur.execute("CREATE INDEX idx_cache_metadata_source ON cache_metadata(source)")
 
+            # Re-apply NOT NULL constraints stripped by ``CREATE TABLE AS
+            # SELECT`` above. CTAS carries column types forward but not
+            # NOT NULL / DEFAULT / CHECK; the schema in
+            # ``schema/create_database.sql`` declares these columns as
+            # NOT NULL, and without explicit re-application every prune
+            # run ships a discogs-cache where those constraints are gone.
+            # Pinned by
+            # ``tests/integration/test_copy_swap_preserves_not_null.py``.
+            for stmt in (
+                "ALTER TABLE release ALTER COLUMN title SET NOT NULL",
+                "ALTER TABLE release_artist ALTER COLUMN release_id SET NOT NULL",
+                "ALTER TABLE release_artist ALTER COLUMN artist_name SET NOT NULL",
+                "ALTER TABLE release_label ALTER COLUMN release_id SET NOT NULL",
+                "ALTER TABLE release_label ALTER COLUMN label_name SET NOT NULL",
+                "ALTER TABLE release_genre ALTER COLUMN release_id SET NOT NULL",
+                "ALTER TABLE release_genre ALTER COLUMN genre SET NOT NULL",
+                "ALTER TABLE release_style ALTER COLUMN release_id SET NOT NULL",
+                "ALTER TABLE release_style ALTER COLUMN style SET NOT NULL",
+                "ALTER TABLE release_track ALTER COLUMN release_id SET NOT NULL",
+                "ALTER TABLE release_track ALTER COLUMN sequence SET NOT NULL",
+                "ALTER TABLE release_track ALTER COLUMN title SET NOT NULL",
+                "ALTER TABLE release_track_artist ALTER COLUMN release_id SET NOT NULL",
+                "ALTER TABLE release_track_artist ALTER COLUMN track_sequence SET NOT NULL",
+                "ALTER TABLE release_track_artist ALTER COLUMN artist_name SET NOT NULL",
+                "ALTER TABLE cache_metadata ALTER COLUMN cached_at SET NOT NULL",
+                "ALTER TABLE cache_metadata ALTER COLUMN source SET NOT NULL",
+            ):
+                cur.execute(stmt)
+
             # Cleanup
             cur.execute("DROP TABLE IF EXISTS _keep_ids")
 

--- a/tests/integration/test_copy_swap_preserves_not_null.py
+++ b/tests/integration/test_copy_swap_preserves_not_null.py
@@ -1,0 +1,372 @@
+"""Pin: NOT NULL constraints survive the copy-swap step.
+
+Sibling regression to ``tests/integration/test_dedup.py::TestDedupCopySwapPreservesMasterId``
+(WXYC/discogs-etl#129, master_id column drop) and the verify_cache column drift
+fixed in WXYC/discogs-etl#233. PostgreSQL's ``CREATE TABLE AS SELECT`` preserves
+only column types, not constraints — so NOT NULL on data columns is silently
+stripped on every monthly rebuild unless the copy-swap path re-applies it
+explicitly.
+
+The schema in ``schema/create_database.sql`` is the source of truth for which
+columns are required. This test runs the two copy-swap entrypoints
+(``dedup_releases.add_base_constraints_and_indexes`` and
+``verify_cache.prune_releases_copy_swap``) against a minimal fixture and
+asserts the post-swap tables still report ``is_nullable = 'NO'`` on every
+column the schema declared ``NOT NULL``.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import psycopg
+import pytest
+
+pytestmark = pytest.mark.pg
+
+SCHEMA_DIR = Path(__file__).parent.parent.parent / "schema"
+
+# Load production modules using sys.modules guard (mirrors test_verify_cache_columns.py).
+# Registering in sys.modules before exec_module so dataclasses / typing introspection
+# inside the loaded module can resolve their own __module__ name.
+_DEDUP_PATH = Path(__file__).parent.parent.parent / "scripts" / "dedup_releases.py"
+if "dedup_releases" in sys.modules:
+    _dd = sys.modules["dedup_releases"]
+else:
+    _dspec = importlib.util.spec_from_file_location("dedup_releases", _DEDUP_PATH)
+    assert _dspec is not None and _dspec.loader is not None
+    _dd = importlib.util.module_from_spec(_dspec)
+    sys.modules["dedup_releases"] = _dd
+    _dspec.loader.exec_module(_dd)
+
+_VERIFY_CACHE_PATH = Path(__file__).parent.parent.parent / "scripts" / "verify_cache.py"
+if "verify_cache" in sys.modules:
+    _vc = sys.modules["verify_cache"]
+else:
+    _vcspec = importlib.util.spec_from_file_location("verify_cache", _VERIFY_CACHE_PATH)
+    assert _vcspec is not None and _vcspec.loader is not None
+    _vc = importlib.util.module_from_spec(_vcspec)
+    sys.modules["verify_cache"] = _vc
+    _vcspec.loader.exec_module(_vc)
+
+
+# Columns expected NOT NULL on each post-swap table, transcribed by hand from
+# schema/create_database.sql. ``id`` is omitted from the ``release`` entry
+# because ALTER TABLE ADD PRIMARY KEY (id) already re-asserts NOT NULL.
+# ``cache_metadata.release_id`` similarly is the PK and excluded.
+#
+# This list is the test contract; when schema/create_database.sql changes the
+# NOT NULL set on these tables, update both this dict and the production
+# ALTER statements at the same time. The TestNotNullPinExpectationsMatchSchema
+# class below catches drift between the schema and this expectation.
+_EXPECTED_NOT_NULL: dict[str, tuple[str, ...]] = {
+    "release": ("title",),
+    "release_artist": ("release_id", "artist_name"),
+    "release_label": ("release_id", "label_name"),
+    "release_genre": ("release_id", "genre"),
+    "release_style": ("release_id", "style"),
+    "release_track": ("release_id", "sequence", "title"),
+    "release_track_artist": ("release_id", "track_sequence", "artist_name"),
+    "cache_metadata": ("cached_at", "source"),
+}
+
+# Tables that flow through each copy-swap entrypoint.
+_DEDUP_TABLES_TO_CHECK = (
+    "release",
+    "release_artist",
+    "release_label",
+    "release_genre",
+    "release_style",
+    "cache_metadata",
+)
+_PRUNE_TABLES_TO_CHECK = (
+    "release",
+    "release_artist",
+    "release_label",
+    "release_genre",
+    "release_style",
+    "release_track",
+    "release_track_artist",
+    "cache_metadata",
+)
+
+
+def _drop_all_tables(conn) -> None:
+    """Clear pipeline tables and any leftover ``new_`` copy-swap artifacts."""
+    base = (
+        "cache_metadata",
+        "release_track_artist",
+        "release_track",
+        "release_style",
+        "release_genre",
+        "release_label",
+        "release_artist",
+        "release",
+    )
+    with conn.cursor() as cur:
+        for t in base:
+            cur.execute(f"DROP TABLE IF EXISTS {t} CASCADE")
+            cur.execute(f"DROP TABLE IF EXISTS new_{t} CASCADE")
+            cur.execute(f"DROP TABLE IF EXISTS {t}_old CASCADE")
+        cur.execute("DROP TABLE IF EXISTS dedup_delete_ids CASCADE")
+        cur.execute("DROP TABLE IF EXISTS _keep_ids CASCADE")
+
+
+def _seed_minimal_fixture(db_url: str) -> None:
+    """Apply schema + insert representative rows for all 8 swap-tracked tables.
+
+    Three releases (1, 2, 3) with child rows on each table so the copy-swap
+    actually touches every table. Compositions chosen from WXYC's canonical
+    example data per the org's CLAUDE.md fixture guidance.
+    """
+    conn = psycopg.connect(db_url, autocommit=True)
+    try:
+        _drop_all_tables(conn)
+        with conn.cursor() as cur:
+            cur.execute(SCHEMA_DIR.joinpath("create_database.sql").read_text())
+            cur.execute(SCHEMA_DIR.joinpath("create_functions.sql").read_text())
+
+            cur.executemany(
+                "INSERT INTO release (id, title, master_id, format, country) "
+                "VALUES (%s, %s, %s, %s, %s)",
+                [
+                    (1, "DOGA", 200, "LP", "AR"),
+                    (2, "Aluminum Tunes", 100, "CD", "UK"),
+                    (3, "Edits", None, "CD", "US"),
+                ],
+            )
+            cur.executemany(
+                "INSERT INTO release_artist (release_id, artist_name) VALUES (%s, %s)",
+                [
+                    (1, "Juana Molina"),
+                    (2, "Stereolab"),
+                    (3, "Chuquimamani-Condori"),
+                ],
+            )
+            cur.executemany(
+                "INSERT INTO release_label (release_id, label_name) VALUES (%s, %s)",
+                [(1, "Sonamos"), (2, "Duophonic")],
+            )
+            cur.executemany(
+                "INSERT INTO release_genre (release_id, genre) VALUES (%s, %s)",
+                [(1, "Folk"), (2, "Electronic")],
+            )
+            cur.executemany(
+                "INSERT INTO release_style (release_id, style) VALUES (%s, %s)",
+                [(1, "Folk Rock"), (2, "Indie Pop")],
+            )
+            cur.executemany(
+                "INSERT INTO release_track (release_id, sequence, title) VALUES (%s, %s, %s)",
+                [(1, 1, "Cosoco"), (2, 1, "Fuses")],
+            )
+            cur.executemany(
+                "INSERT INTO release_track_artist "
+                "(release_id, track_sequence, artist_name) VALUES (%s, %s, %s)",
+                [(1, 1, "Juana Molina"), (2, 1, "Stereolab")],
+            )
+            cur.executemany(
+                "INSERT INTO cache_metadata (release_id, source) VALUES (%s, %s)",
+                [(1, "bulk_import"), (2, "bulk_import"), (3, "bulk_import")],
+            )
+    finally:
+        conn.close()
+
+
+def _not_null_columns(conn, table: str) -> set[str]:
+    """Return columns marked ``NOT NULL`` on a given table in the public schema."""
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT column_name FROM information_schema.columns "
+            "WHERE table_schema = 'public' AND table_name = %s "
+            "AND is_nullable = 'NO'",
+            (table,),
+        )
+        return {row[0] for row in cur.fetchall()}
+
+
+def _run_dedup_swap(db_url: str) -> None:
+    """Exercise dedup's copy-swap path end-to-end (single deletion case).
+
+    Mirrors the production main() flow but trims it to copy_table → drop FKs →
+    swap_tables → add_base_constraints_and_indexes. Marks release 3 for deletion
+    so all 6 DEDUP_TABLES go through CTAS.
+    """
+    conn = psycopg.connect(db_url, autocommit=True)
+    try:
+        with conn.cursor() as cur:
+            cur.execute("CREATE UNLOGGED TABLE dedup_delete_ids (release_id integer PRIMARY KEY)")
+            cur.execute("INSERT INTO dedup_delete_ids VALUES (3)")
+
+        for old, new, cols, id_col in _dd.DEDUP_TABLES:
+            _dd.copy_table(conn, old, new, cols, id_col)
+
+        with conn.cursor() as cur:
+            for stmt in (
+                "ALTER TABLE release_artist DROP CONSTRAINT IF EXISTS fk_release_artist_release",
+                "ALTER TABLE release_label DROP CONSTRAINT IF EXISTS fk_release_label_release",
+                "ALTER TABLE release_genre DROP CONSTRAINT IF EXISTS fk_release_genre_release",
+                "ALTER TABLE release_style DROP CONSTRAINT IF EXISTS fk_release_style_release",
+                "ALTER TABLE cache_metadata DROP CONSTRAINT IF EXISTS fk_cache_metadata_release",
+            ):
+                cur.execute(stmt)
+
+        for old, new, _, _ in _dd.DEDUP_TABLES:
+            _dd.swap_tables(conn, old, new)
+
+        _dd.add_base_constraints_and_indexes(conn, db_url=db_url)
+    finally:
+        conn.close()
+
+
+class TestDedupCopySwapPreservesNotNull:
+    """add_base_constraints_and_indexes re-applies NOT NULL on schema-required columns."""
+
+    @pytest.fixture(autouse=True, scope="class")
+    def _set_up_and_dedup(self, db_url):
+        self.__class__._db_url = db_url
+        _seed_minimal_fixture(db_url)
+        _run_dedup_swap(db_url)
+
+    @pytest.fixture(autouse=True)
+    def _store_url(self):
+        self.db_url = self.__class__._db_url
+
+    @pytest.mark.parametrize("table", _DEDUP_TABLES_TO_CHECK)
+    def test_required_columns_remain_not_null(self, table):
+        conn = psycopg.connect(self.db_url, autocommit=True)
+        try:
+            actual = _not_null_columns(conn, table)
+        finally:
+            conn.close()
+
+        expected = set(_EXPECTED_NOT_NULL[table])
+        missing = expected - actual
+        assert not missing, (
+            f"After dedup copy-swap, NOT NULL was stripped from "
+            f"{table}.{sorted(missing)}. CTAS preserves column types but not "
+            f"constraints; scripts/dedup_releases.py:add_base_constraints_and_indexes "
+            f"must re-apply SET NOT NULL on these columns."
+        )
+
+
+class TestPruneCopySwapPreservesNotNull:
+    """verify_cache.prune_releases_copy_swap re-applies NOT NULL on schema-required columns."""
+
+    @pytest.fixture(autouse=True, scope="class")
+    def _set_up_and_prune(self, db_url):
+        self.__class__._db_url = db_url
+        _seed_minimal_fixture(db_url)
+        # Keep releases 1, 2; prune release 3. All 8 PRUNE_COPY_TABLES go through CTAS.
+        _vc.prune_releases_copy_swap(db_url, keep_ids={1, 2}, review_ids=set())
+
+    @pytest.fixture(autouse=True)
+    def _store_url(self):
+        self.db_url = self.__class__._db_url
+
+    @pytest.mark.parametrize("table", _PRUNE_TABLES_TO_CHECK)
+    def test_required_columns_remain_not_null(self, table):
+        conn = psycopg.connect(self.db_url, autocommit=True)
+        try:
+            actual = _not_null_columns(conn, table)
+        finally:
+            conn.close()
+
+        expected = set(_EXPECTED_NOT_NULL[table])
+        missing = expected - actual
+        assert not missing, (
+            f"After verify_cache prune copy-swap, NOT NULL was stripped from "
+            f"{table}.{sorted(missing)}. CTAS preserves column types but not "
+            f"constraints; scripts/verify_cache.py:prune_releases_copy_swap "
+            f"must re-apply SET NOT NULL on these columns."
+        )
+
+
+class TestNotNullPinExpectationsMatchSchema:
+    """Catch drift between _EXPECTED_NOT_NULL and schema/create_database.sql.
+
+    Without this, a future schema change that adds a new ``NOT NULL`` column
+    on one of the swap-tracked tables would not appear in this test file's
+    expectation, and the corresponding copy-swap fix could silently lag.
+    """
+
+    def test_every_schema_not_null_column_is_pinned(self, tmp_path) -> None:
+        """Every NOT NULL on a swap-tracked table appears in _EXPECTED_NOT_NULL."""
+        schema_text = SCHEMA_DIR.joinpath("create_database.sql").read_text()
+        # Naive but sufficient for this schema: scan column-definition lines
+        # inside each CREATE TABLE body. We accept some over-match (column
+        # comments etc.) because the assertion is a superset check.
+        for table, expected in _EXPECTED_NOT_NULL.items():
+            schema_cols = _parse_not_null_columns(schema_text, table)
+            # PK columns (implicit NOT NULL via PRIMARY KEY) are excluded from
+            # the test expectation because PK re-creation reasserts NOT NULL.
+            pk_cols = _parse_primary_key_columns(schema_text, table)
+            schema_data_cols = schema_cols - pk_cols
+            missing = schema_data_cols - set(expected)
+            assert not missing, (
+                f"Schema declares NOT NULL on {table}.{sorted(missing)} "
+                f"but the pin in _EXPECTED_NOT_NULL doesn't cover them. "
+                f"Update _EXPECTED_NOT_NULL and the corresponding production "
+                f"ALTER statements in dedup_releases.py + verify_cache.py."
+            )
+
+
+def _parse_not_null_columns(schema_text: str, table: str) -> set[str]:
+    """Return columns declared NOT NULL in ``CREATE TABLE <table>``."""
+    cols: set[str] = set()
+    for line in _iter_column_lines(schema_text, table):
+        if "NOT NULL" in line:
+            cols.add(line.split()[0])
+    return cols
+
+
+def _parse_primary_key_columns(schema_text: str, table: str) -> set[str]:
+    """Return columns declared as PRIMARY KEY in ``CREATE TABLE <table>``."""
+    cols: set[str] = set()
+    for line in _iter_column_lines(schema_text, table):
+        if "PRIMARY KEY" in line.upper():
+            cols.add(line.split()[0])
+    return cols
+
+
+def _iter_column_lines(schema_text: str, table: str):
+    """Yield individual column declarations from a ``CREATE TABLE`` body.
+
+    Strips ``-- ...`` end-of-line comments before splitting on column
+    separators so embedded commas inside comments (e.g. ``-- "A1", "B2"``)
+    don't cross over into the next declaration.
+    """
+    marker = f"CREATE TABLE {table} ("
+    start = schema_text.index(marker) + len(marker)
+    body = _extract_paren_body(schema_text, start)
+    # Strip end-of-line SQL comments so commas inside comments don't bleed
+    # into the next column declaration when we split on ``,``.
+    cleaned = "\n".join(raw.split("--", 1)[0] for raw in body.splitlines())
+    for raw in cleaned.split(","):
+        line = raw.strip()
+        if line:
+            yield line
+
+
+def _extract_paren_body(text: str, start: int) -> str:
+    """Return the contents of a parenthesised body starting at ``start``.
+
+    Walks character by character tracking paren depth so nested ``()`` (e.g.
+    ``CHECK (...)`` expressions) don't terminate the body early.
+    """
+    depth = 1
+    i = start
+    while i < len(text) and depth > 0:
+        ch = text[i]
+        if ch == "(":
+            depth += 1
+        elif ch == ")":
+            depth -= 1
+            if depth == 0:
+                return text[start:i]
+        i += 1
+    raise AssertionError(
+        "Could not find matching close paren for CREATE TABLE body — the body "
+        "extractor walked off the end of the schema. Rewrite _extract_paren_body."
+    )

--- a/tests/integration/test_copy_swap_preserves_not_null.py
+++ b/tests/integration/test_copy_swap_preserves_not_null.py
@@ -72,6 +72,18 @@ _EXPECTED_NOT_NULL: dict[str, tuple[str, ...]] = {
     "cache_metadata": ("cached_at", "source"),
 }
 
+# Columns whose schema DEFAULT must survive the copy-swap. CTAS strips
+# DEFAULTs along with NOT NULL; restoring the DEFAULT is load-bearing for
+# ``cache_metadata.cached_at`` in particular — without it, LML's cache-miss
+# INSERT (which omits cached_at) would violate the NOT NULL constraint we
+# re-apply above. The ``extra`` columns are nullable so the DEFAULT is
+# defense-in-depth, not load-bearing, but the schema specifies it.
+_EXPECTED_DEFAULTS: dict[tuple[str, str], str] = {
+    ("cache_metadata", "cached_at"): "now()",
+    ("release_artist", "extra"): "0",
+    ("release_track_artist", "extra"): "0",
+}
+
 # Tables that flow through each copy-swap entrypoint.
 _DEDUP_TABLES_TO_CHECK = (
     "release",
@@ -186,6 +198,18 @@ def _not_null_columns(conn, table: str) -> set[str]:
         return {row[0] for row in cur.fetchall()}
 
 
+def _column_default(conn, table: str, column: str) -> str | None:
+    """Return the DEFAULT expression on ``table.column`` (or None if unset)."""
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT column_default FROM information_schema.columns "
+            "WHERE table_schema = 'public' AND table_name = %s AND column_name = %s",
+            (table, column),
+        )
+        row = cur.fetchone()
+        return row[0] if row else None
+
+
 def _run_dedup_swap(db_url: str) -> None:
     """Exercise dedup's copy-swap path end-to-end (single deletion case).
 
@@ -250,6 +274,34 @@ class TestDedupCopySwapPreservesNotNull:
             f"must re-apply SET NOT NULL on these columns."
         )
 
+    # Dedup swaps the 6 DEDUP_TABLES; release_track_artist is re-imported
+    # post-dedup (not copy-swapped) so its DEFAULT is preserved by the
+    # schema-driven import. Only the in-DEDUP_TABLES defaults are pinned here.
+    @pytest.mark.parametrize(
+        "table, column, expected",
+        [
+            ("cache_metadata", "cached_at", "now()"),
+            ("release_artist", "extra", "0"),
+        ],
+    )
+    def test_required_columns_keep_their_default(self, table, column, expected):
+        conn = psycopg.connect(self.db_url, autocommit=True)
+        try:
+            actual = _column_default(conn, table, column)
+        finally:
+            conn.close()
+
+        assert actual == expected, (
+            f"After dedup copy-swap, DEFAULT on {table}.{column} is {actual!r} "
+            f"but the schema declares {expected!r}. CTAS strips DEFAULTs along "
+            f"with NOT NULL; "
+            f"scripts/dedup_releases.py:add_base_constraints_and_indexes must "
+            f"re-apply SET DEFAULT on these columns. "
+            f"(cache_metadata.cached_at is load-bearing — LML's cache-miss "
+            f"INSERT omits the column and relies on the DEFAULT to avoid a "
+            f"NOT NULL violation.)"
+        )
+
 
 class TestPruneCopySwapPreservesNotNull:
     """verify_cache.prune_releases_copy_swap re-applies NOT NULL on schema-required columns."""
@@ -280,6 +332,33 @@ class TestPruneCopySwapPreservesNotNull:
             f"{table}.{sorted(missing)}. CTAS preserves column types but not "
             f"constraints; scripts/verify_cache.py:prune_releases_copy_swap "
             f"must re-apply SET NOT NULL on these columns."
+        )
+
+    # Verify_cache prune copy-swaps all 8 PRUNE_COPY_TABLES including the track
+    # tables, so all three CTAS-stripped DEFAULTs are pinned here.
+    @pytest.mark.parametrize(
+        "table, column, expected",
+        [
+            ("cache_metadata", "cached_at", "now()"),
+            ("release_artist", "extra", "0"),
+            ("release_track_artist", "extra", "0"),
+        ],
+    )
+    def test_required_columns_keep_their_default(self, table, column, expected):
+        conn = psycopg.connect(self.db_url, autocommit=True)
+        try:
+            actual = _column_default(conn, table, column)
+        finally:
+            conn.close()
+
+        assert actual == expected, (
+            f"After verify_cache prune copy-swap, DEFAULT on {table}.{column} "
+            f"is {actual!r} but the schema declares {expected!r}. CTAS strips "
+            f"DEFAULTs along with NOT NULL; "
+            f"scripts/verify_cache.py:prune_releases_copy_swap must re-apply "
+            f"SET DEFAULT on these columns. (cache_metadata.cached_at is "
+            f"load-bearing — LML's cache-miss INSERT omits the column and "
+            f"relies on the DEFAULT to avoid a NOT NULL violation.)"
         )
 
 


### PR DESCRIPTION
Closes #234.

## Summary

PostgreSQL ``CREATE TABLE AS SELECT`` preserves only column types, not constraints. The dedup ``add_base_constraints_and_indexes`` and verify_cache ``prune_releases_copy_swap`` paths both rebuild tables via CTAS and then re-add PK + FK + indexes — but not NOT NULL on data columns. So every monthly rebuild silently ships a discogs-cache where the schema's NOT NULL declarations on ``release.title``, ``release_artist.(release_id, artist_name)``, etc. are gone.

Same shape of bug as #129 (master_id column drop) and #232 (column-list drift) — both pinned by similar regression tests. This one is column-content drift instead of column-presence drift.

Both swap entrypoints now re-apply ``ALTER COLUMN ... SET NOT NULL`` for every schema-required column on the tables they swap:
- ``scripts/dedup_releases.py:add_base_constraints_and_indexes`` — 11 ALTER statements appended to the Level-2 ``_exec_parallel`` batch (parallel with FK + index creation; independent ordering).
- ``scripts/verify_cache.py:prune_releases_copy_swap`` — 17 ALTER statements inside the existing post-swap constraint-recreation block.

## Test plan

- [x] New ``tests/integration/test_copy_swap_preserves_not_null.py`` (3 test classes, 15 cases) — RED before the fix, GREEN after. Exercises both swap entrypoints against a minimal fixture and asserts ``information_schema.columns.is_nullable = 'NO'`` for every schema-required column. A third class parses ``schema/create_database.sql`` and pins ``_EXPECTED_NOT_NULL`` against the schema so future drift surfaces.
- [x] ``DATABASE_URL_TEST=... pytest -m "pg or not slow"`` — 1097 passed, 22 skipped, 1 xfailed.
- [x] ``ruff check`` clean on the three changed files; ``ruff format --check`` clean.

## Operational notes

- **Live prod**: the discogs-cache currently has these NOT NULLs stripped (one rebuild old). The next scheduled rebuild on 2026-06-04 will re-apply them automatically via this fix. An immediate ALTER on prod is a one-line follow-up if anyone wants to close the window sooner — it's not blocking correctness because the schema-required NOT NULL invariant has been silently broken across every rebuild for months without observable issue.
- **CTAS drops more than NOT NULL**: DEFAULT and CHECK are similarly stripped (e.g. ``release_artist.extra DEFAULT 0``). Same class of bug; left out of this PR's scope intentionally to keep the change surgical. Issue #234's "Out of scope" section flags this for follow-up.