### PR TITLE
Bump wxyc-etl to 0.5.0 (anchored is_compilation_artist)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ dependencies = [
     "psycopg[binary]>=3.1.0",
     "asyncpg>=0.29.0",
     "rapidfuzz>=3.0.0",
-    "wxyc-etl>=0.3.0",
+    "wxyc-etl>=0.5.0",
     "wxyc-catalog>=0.1.1",
     "sentry-sdk>=2.0",
 ]

--- a/tests/fixtures/create_fixtures.py
+++ b/tests/fixtures/create_fixtures.py
@@ -433,7 +433,8 @@ def create_library_db() -> None:
         # production WXYC catalog (tubafrenzy + staging Postgres dump):
         #   bare, genre + alphabetical sub-bucket, single-segment genre,
         #   bracketed group form. All trigger is_compilation_artist() via
-        #   the substring match on "various".
+        #   the leading "various artists" prefix rule (terminated by EOS
+        #   or a non-alphanumeric boundary; see WXYC/wxyc-etl#129/#130).
         ("Various Artists", "Nordic Roots: A Northside Collection", "CD"),
         ("Various Artists - Rock - A", "All Tomorrow's Parties 5.0", "LP"),
         ("Various Artists - Hiphop", "Stones Throw Ten Years", "CD"),

--- a/tests/unit/test_wxyc_etl_parity.py
+++ b/tests/unit/test_wxyc_etl_parity.py
@@ -37,18 +37,43 @@ pytestmark = pytest.mark.filterwarnings("ignore::DeprecationWarning")
 
 
 class TestIsCompilationArtistParity:
-    """Same cases as the deleted test_matching.py TestIsCompilationArtist."""
+    """Cases for the anchored `is_compilation_artist` contract.
+
+    wxyc-etl 0.5.0 (WXYC/wxyc-etl#129/#130) tightened the matcher from a
+    substring scan to two rules:
+
+    - LEADING prefix terminated by end-of-string or a non-alphanumeric
+      boundary: "various artists", "v/a", "v.a", "soundtracks".
+    - EXACT match (case-insensitive equality): "various", "soundtrack",
+      "compilation".
+
+    The "Original Motion Picture Soundtrack" / "Compilation Hits" cases
+    that the old substring rule routed to True now classify as real
+    artists; the test matrix locks that in alongside the WXYC false-
+    positive regressions ("The Soundtrack of Our Lives", "Various
+    Production") flagged in the PR.
+    """
 
     @pytest.mark.parametrize(
         "artist, expected",
         [
+            # Leading-prefix matches (the WXYC catalog V/A shapes)
             ("Various Artists", True),
-            ("various", True),
-            ("Soundtrack", True),
-            ("Original Motion Picture Soundtrack", True),
+            ("Various Artists - Hiphop", True),
             ("V/A", True),
             ("v.a.", True),
-            ("Compilation Hits", True),
+            ("Soundtracks", True),
+            # Exact-only matches
+            ("various", True),
+            ("Various", True),
+            ("Soundtrack", True),
+            ("Compilation", True),
+            # Old substring-rule false positives that are now real artists
+            ("Original Motion Picture Soundtrack", False),
+            ("Compilation Hits", False),
+            ("The Soundtrack of Our Lives", False),
+            ("Various Production", False),
+            # Plain real artists
             ("Stereolab", False),
             ("Juana Molina", False),
             ("Cat Power", False),
@@ -56,12 +81,18 @@ class TestIsCompilationArtistParity:
         ],
         ids=[
             "various-artists",
-            "various-lowercase",
-            "soundtrack",
-            "soundtrack-in-phrase",
+            "various-artists-genre-suffix",
             "v-slash-a",
             "v-dot-a",
-            "compilation-keyword",
+            "soundtracks-prefix",
+            "various-lowercase",
+            "various-titlecase",
+            "soundtrack-exact",
+            "compilation-exact",
+            "soundtrack-in-phrase-now-false",
+            "compilation-keyword-now-false",
+            "the-soundtrack-of-our-lives",
+            "various-production",
             "stereolab",
             "juana-molina",
             "cat-power",


### PR DESCRIPTION
## Summary

- Bumps the `wxyc-etl` pin from `>=0.3.0` to `>=0.5.0` so the resolver can't backslide to a release that still has the substring `is_compilation_artist`.
- Re-locks the `TestIsCompilationArtistParity` matrix against the anchored contract shipped in [WXYC/wxyc-etl#129](https://github.com/WXYC/wxyc-etl/pull/129) / [#130](https://github.com/WXYC/wxyc-etl/pull/130): LEADING prefix terminated by end-of-string or non-alphanumeric boundary (`"various artists"`, `"v/a"`, `"v.a"`, `"soundtracks"`), plus EXACT-only matches (`"various"`, `"soundtrack"`, `"compilation"`).
- Refreshes the `create_fixtures.py` comment that still described the rule as a "substring match on 'various'".

## Behavior deltas

| Input | Was | Now |
|---|---|---|
| `"Various Artists"` | True | True |
| `"Various Artists - Hiphop"` | True | True |
| `"Soundtrack"` | True | True |
| `"Original Motion Picture Soundtrack"` | True | **False** |
| `"Compilation"` | True | True |
| `"Compilation Hits"` | True | **False** |
| `"Various Production"` | True | **False** |
| `"The Soundtrack of Our Lives"` | True | **False** |

The four V/A shapes in `tests/fixtures/create_fixtures.py` still classify as compilations via the leading-prefix rule, so `verify_cache.py`'s KEEP/PRUNE split is unchanged on the prod catalog. The flip is the prior false-positive class: real bands whose names contained the keywords as substrings ("The Soundtrack of Our Lives", "Various Production") were being routed to V/A. The safer error direction is now one extra real-artist lookup vs. dropping identity for a real band.

## Files changed

- `pyproject.toml` — `wxyc-etl>=0.3.0` -> `wxyc-etl>=0.5.0`.
- `tests/unit/test_wxyc_etl_parity.py` — rewrote the parity matrix against the anchored contract; added regression cases for the WXYC-real false positives flagged upstream.
- `tests/fixtures/create_fixtures.py` — comment refresh; no fixture data change.

## Test plan

- [x] `ruff check .` — clean
- [x] `ruff format --check .` — clean
- [x] `pytest tests/unit/` — 743 passed, 3 deselected, 1 xfailed
- [ ] CI green on the PR

Closes #236