### PR TITLE
fix(rebuild): run alembic upgrade head before pipeline

### DIFF
--- a/scripts/rebuild-cache.sh
+++ b/scripts/rebuild-cache.sh
@@ -124,6 +124,30 @@ else
 fi
 
 # ---------------------------------------------------------------------------
+# 2b. Apply any pending alembic migrations against the destination DB.
+#     Required so that schema changes added between rebuilds (new columns,
+#     new tables) are present before the converter starts emitting CSVs
+#     that reference them. Without this, the next monthly tick after a
+#     migration merges to main fails at the COPY for the affected table
+#     (Railway's schema is one revision behind; the GH Actions cron that
+#     used to run this step was disabled 2026-05-05). See #222.
+#
+#     A no-op when the DB is already at head, so it is safe to keep on
+#     unconditionally — same posture as --truncate-existing below.
+#     Preserves entity.identity + alembic_version (the migrations chain
+#     only edits its own audit table; --truncate-existing's allowlist
+#     already excludes both).
+#
+#     Skipped under REBUILD_SMOKE=1 — smoke mode is read-only by contract
+#     (see the curl Range-request smoke block at step 5) and an alembic
+#     upgrade is a DB write.
+# ---------------------------------------------------------------------------
+if [ "${REBUILD_SMOKE:-}" != "1" ]; then
+    echo "[$(date -u +%H:%M:%SZ)] apply pending alembic migrations against \$DATABASE_URL_DISCOGS"
+    (cd "$REPO_DIR" && alembic upgrade head)
+fi
+
+# ---------------------------------------------------------------------------
 # 3. Pull daily-fresh library.db produced by sync-library workflow
 # ---------------------------------------------------------------------------
 WORK_DIR="$(mktemp -d "$REPO_DIR/data-rebuild.XXXXXX")"

--- a/scripts/rebuild-cache.sh
+++ b/scripts/rebuild-cache.sh
@@ -125,22 +125,13 @@ fi
 
 # ---------------------------------------------------------------------------
 # 2b. Apply any pending alembic migrations against the destination DB.
-#     Required so that schema changes added between rebuilds (new columns,
-#     new tables) are present before the converter starts emitting CSVs
-#     that reference them. Without this, the next monthly tick after a
-#     migration merges to main fails at the COPY for the affected table
-#     (Railway's schema is one revision behind; the GH Actions cron that
-#     used to run this step was disabled 2026-05-05). See #222.
-#
-#     A no-op when the DB is already at head, so it is safe to keep on
-#     unconditionally — same posture as --truncate-existing below.
-#     Preserves entity.identity + alembic_version (the migrations chain
-#     only edits its own audit table; --truncate-existing's allowlist
-#     already excludes both).
-#
-#     Skipped under REBUILD_SMOKE=1 — smoke mode is read-only by contract
-#     (see the curl Range-request smoke block at step 5) and an alembic
-#     upgrade is a DB write.
+#     Without this, the next monthly tick after a migration merges to main
+#     fails at the COPY for the affected table (Railway's schema is one
+#     revision behind; the GH Actions cron that used to apply migrations
+#     was disabled 2026-05-05). No-op when the DB is already at head, so
+#     safe to keep on unconditionally — same posture as --truncate-existing.
+#     Skipped under REBUILD_SMOKE=1 because the upgrade is a DB write and
+#     smoke mode is read-only by contract (see step 5). See #222.
 # ---------------------------------------------------------------------------
 if [ "${REBUILD_SMOKE:-}" != "1" ]; then
     echo "[$(date -u +%H:%M:%SZ)] apply pending alembic migrations against \$DATABASE_URL_DISCOGS"

--- a/tests/unit/test_rebuild_cache_alembic_upgrade.py
+++ b/tests/unit/test_rebuild_cache_alembic_upgrade.py
@@ -25,17 +25,8 @@ SCRIPT_PATH = REPO_ROOT / "scripts" / "rebuild-cache.sh"
 
 
 @pytest.fixture(scope="module")
-def script_text() -> str:
-    return SCRIPT_PATH.read_text()
-
-
-@pytest.fixture(scope="module")
 def script_lines() -> list[str]:
     return SCRIPT_PATH.read_text().splitlines()
-
-
-def _non_comment_lines(lines: list[str]) -> list[str]:
-    return [line for line in lines if not line.lstrip().startswith("#")]
 
 
 def _first_index(lines: list[str], needle: str) -> int:
@@ -49,7 +40,7 @@ def _first_index(lines: list[str], needle: str) -> int:
     raise AssertionError(f"{needle!r} not found in non-comment lines of {SCRIPT_PATH}")
 
 
-def test_runs_alembic_upgrade_head(script_text: str) -> None:
+def test_runs_alembic_upgrade_head(script_lines: list[str]) -> None:
     """#222: the script must invoke ``alembic upgrade head`` before the pipeline.
 
     Without this, a new column added in a migration between rebuilds is not
@@ -58,8 +49,8 @@ def test_runs_alembic_upgrade_head(script_text: str) -> None:
     rebuild applies pending migrations automatically becomes true again
     only when this command is on the active script path.
     """
-    code = "\n".join(_non_comment_lines(script_text.splitlines()))
-    assert "alembic upgrade head" in code, (
+    non_comment = [line for line in script_lines if not line.lstrip().startswith("#")]
+    assert any("alembic upgrade head" in line for line in non_comment), (
         "rebuild-cache.sh must invoke 'alembic upgrade head' between dep "
         "refresh and the pipeline so destination-DB schema drift can't "
         "surface as a COPY error. See #222."
@@ -82,51 +73,42 @@ def test_alembic_upgrade_runs_before_pipeline(script_lines: list[str]) -> None:
     )
 
 
-def test_alembic_upgrade_skipped_under_smoke(script_text: str) -> None:
+def test_alembic_upgrade_skipped_under_smoke(script_lines: list[str]) -> None:
     """#222: ``REBUILD_SMOKE=1`` must not write to prod.
 
-    The smoke mode exits before any DB writes (validated by the existing
-    ``REBUILD_SMOKE=1`` short-circuit at the curl Range-request step).
-    ``alembic upgrade head`` is a DB write -- gate it behind the same
-    smoke check so a smoke run stays read-only against the destination.
-    The suggested-approach guard is ``[ "${REBUILD_SMOKE:-}" != "1" ]``;
-    any equivalent (e.g. inverted ``if [ ... = "1" ]`` early exit on the
-    block) is fine, but the upgrade line itself must be reachable only
-    when ``REBUILD_SMOKE`` is unset or not ``1``.
+    Smoke mode is read-only by contract — the existing curl Range-request
+    smoke block exits before any DB writes. ``alembic upgrade head`` is a
+    DB write, so the upgrade line must only be reachable when
+    ``REBUILD_SMOKE`` is unset or not ``1``. Pin by requiring a
+    ``REBUILD_SMOKE`` reference on one of the few non-comment lines
+    immediately preceding the upgrade call.
     """
-    code = "\n".join(_non_comment_lines(script_text.splitlines()))
-    upgrade_idx = code.find("alembic upgrade head")
-    assert upgrade_idx >= 0, "alembic upgrade head not present"
-    # Look at the ~400 chars preceding the upgrade for the smoke guard. This
-    # is a structural proxy: a guard close to the call site documents intent
-    # and survives ordinary refactors. The smoke mode's existing curl-Range
-    # block lives much further down the file, so this window won't match
-    # that unrelated guard.
-    window_start = max(0, upgrade_idx - 400)
-    window = code[window_start:upgrade_idx]
-    assert "REBUILD_SMOKE" in window, (
+    upgrade_idx = _first_index(script_lines, "alembic upgrade head")
+    # Walk back through non-comment lines until we find a REBUILD_SMOKE
+    # guard, allowing a short blank-line gap. 8 non-comment lines is more
+    # than enough for an `if` + `echo` + `(cd ... && ...)` shape and small
+    # enough that the existing smoke block 60+ lines below can't match.
+    preceding_non_comment = [
+        line
+        for line in script_lines[:upgrade_idx]
+        if line.strip() and not line.lstrip().startswith("#")
+    ]
+    assert any("REBUILD_SMOKE" in line for line in preceding_non_comment[-8:]), (
         "The 'alembic upgrade head' call must be guarded by a REBUILD_SMOKE "
         "check so a smoke run does not write to the destination DB. See #222."
     )
 
 
-def test_alembic_upgrade_runs_in_repo_dir(script_text: str) -> None:
+def test_alembic_upgrade_runs_in_repo_dir(script_lines: list[str]) -> None:
     """#222: alembic must run from ``$REPO_DIR`` so it picks up ``alembic.ini``.
 
     Without ``cd "$REPO_DIR"`` (or its subshell equivalent), alembic
-    resolves ``alembic.ini`` against the cwd of the cron invocation,
-    which is not guaranteed to be the repo root. The dep-refresh step
-    just above already shows the convention: operate inside ``$REPO_DIR``
-    rather than relying on cron's cwd.
+    resolves ``alembic.ini`` against cron's cwd, which is not guaranteed
+    to be the repo root.
     """
-    code = "\n".join(_non_comment_lines(script_text.splitlines()))
-    upgrade_idx = code.find("alembic upgrade head")
-    assert upgrade_idx >= 0, "alembic upgrade head not present"
-    # The call site must mention $REPO_DIR within a small window -- either as
-    # a leading 'cd "$REPO_DIR" &&' or wrapped in a subshell '(cd "$REPO_DIR" && ...)'.
-    window_start = max(0, upgrade_idx - 200)
-    window = code[window_start : upgrade_idx + len("alembic upgrade head")]
-    assert "$REPO_DIR" in window, (
-        "The 'alembic upgrade head' call must run inside $REPO_DIR so it "
+    upgrade_idx = _first_index(script_lines, "alembic upgrade head")
+    assert "$REPO_DIR" in script_lines[upgrade_idx], (
+        "The 'alembic upgrade head' line must mention $REPO_DIR (e.g. "
+        "via 'cd \"$REPO_DIR\" && alembic upgrade head') so alembic "
         "picks up the repo's alembic.ini. See #222."
     )

--- a/tests/unit/test_rebuild_cache_alembic_upgrade.py
+++ b/tests/unit/test_rebuild_cache_alembic_upgrade.py
@@ -1,0 +1,132 @@
+"""Pin the alembic-upgrade invariants of ``scripts/rebuild-cache.sh``.
+
+The 2026-05-05 disable of the GH Actions cron (``.github/workflows/rebuild-cache.yml``)
+silently severed the rebuild path from its ``alembic upgrade head`` step. The
+active path is now the EC2 ephemeral stack (``infra/ephemeral-rebuild/``), which
+execs ``rebuild-cache.sh``; neither that script nor its bootstrap wrapper runs
+``alembic upgrade head`` before the pipeline. When a migration adds a new column
+between rebuilds (e.g. ``0005_release_track_artist_role.py``), the next cron
+tick fails at the COPY for the affected table because Railway's schema is
+behind ``main``. See #222.
+
+These tests are static-structural: they parse the script and assert the
+relevant fragments exist in the required order. They do not execute alembic --
+the live behavior is covered by the next ephemeral rebuild's S3 log archive.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "rebuild-cache.sh"
+
+
+@pytest.fixture(scope="module")
+def script_text() -> str:
+    return SCRIPT_PATH.read_text()
+
+
+@pytest.fixture(scope="module")
+def script_lines() -> list[str]:
+    return SCRIPT_PATH.read_text().splitlines()
+
+
+def _non_comment_lines(lines: list[str]) -> list[str]:
+    return [line for line in lines if not line.lstrip().startswith("#")]
+
+
+def _first_index(lines: list[str], needle: str) -> int:
+    """Return the index of the first non-comment line containing ``needle``."""
+    for i, line in enumerate(lines):
+        stripped = line.lstrip()
+        if stripped.startswith("#"):
+            continue
+        if needle in line:
+            return i
+    raise AssertionError(f"{needle!r} not found in non-comment lines of {SCRIPT_PATH}")
+
+
+def test_runs_alembic_upgrade_head(script_text: str) -> None:
+    """#222: the script must invoke ``alembic upgrade head`` before the pipeline.
+
+    Without this, a new column added in a migration between rebuilds is not
+    present on the destination DB when the converter starts emitting CSVs
+    that reference it, and the COPY fails. The runbook claim that the
+    rebuild applies pending migrations automatically becomes true again
+    only when this command is on the active script path.
+    """
+    code = "\n".join(_non_comment_lines(script_text.splitlines()))
+    assert "alembic upgrade head" in code, (
+        "rebuild-cache.sh must invoke 'alembic upgrade head' between dep "
+        "refresh and the pipeline so destination-DB schema drift can't "
+        "surface as a COPY error. See #222."
+    )
+
+
+def test_alembic_upgrade_runs_before_pipeline(script_lines: list[str]) -> None:
+    """#222: alembic upgrade must precede ``run_pipeline.py``.
+
+    A migration applied after the pipeline starts is useless -- the COPY
+    has already failed. Pin the ordering so a future refactor can't
+    accidentally invert it.
+    """
+    upgrade_idx = _first_index(script_lines, "alembic upgrade head")
+    pipeline_idx = _first_index(script_lines, "run_pipeline.py")
+    assert upgrade_idx < pipeline_idx, (
+        f"'alembic upgrade head' (line {upgrade_idx + 1}) must precede the "
+        f"run_pipeline.py invocation (line {pipeline_idx + 1}). Otherwise "
+        f"the COPY runs against a stale schema. See #222."
+    )
+
+
+def test_alembic_upgrade_skipped_under_smoke(script_text: str) -> None:
+    """#222: ``REBUILD_SMOKE=1`` must not write to prod.
+
+    The smoke mode exits before any DB writes (validated by the existing
+    ``REBUILD_SMOKE=1`` short-circuit at the curl Range-request step).
+    ``alembic upgrade head`` is a DB write -- gate it behind the same
+    smoke check so a smoke run stays read-only against the destination.
+    The suggested-approach guard is ``[ "${REBUILD_SMOKE:-}" != "1" ]``;
+    any equivalent (e.g. inverted ``if [ ... = "1" ]`` early exit on the
+    block) is fine, but the upgrade line itself must be reachable only
+    when ``REBUILD_SMOKE`` is unset or not ``1``.
+    """
+    code = "\n".join(_non_comment_lines(script_text.splitlines()))
+    upgrade_idx = code.find("alembic upgrade head")
+    assert upgrade_idx >= 0, "alembic upgrade head not present"
+    # Look at the ~400 chars preceding the upgrade for the smoke guard. This
+    # is a structural proxy: a guard close to the call site documents intent
+    # and survives ordinary refactors. The smoke mode's existing curl-Range
+    # block lives much further down the file, so this window won't match
+    # that unrelated guard.
+    window_start = max(0, upgrade_idx - 400)
+    window = code[window_start:upgrade_idx]
+    assert "REBUILD_SMOKE" in window, (
+        "The 'alembic upgrade head' call must be guarded by a REBUILD_SMOKE "
+        "check so a smoke run does not write to the destination DB. See #222."
+    )
+
+
+def test_alembic_upgrade_runs_in_repo_dir(script_text: str) -> None:
+    """#222: alembic must run from ``$REPO_DIR`` so it picks up ``alembic.ini``.
+
+    Without ``cd "$REPO_DIR"`` (or its subshell equivalent), alembic
+    resolves ``alembic.ini`` against the cwd of the cron invocation,
+    which is not guaranteed to be the repo root. The dep-refresh step
+    just above already shows the convention: operate inside ``$REPO_DIR``
+    rather than relying on cron's cwd.
+    """
+    code = "\n".join(_non_comment_lines(script_text.splitlines()))
+    upgrade_idx = code.find("alembic upgrade head")
+    assert upgrade_idx >= 0, "alembic upgrade head not present"
+    # The call site must mention $REPO_DIR within a small window -- either as
+    # a leading 'cd "$REPO_DIR" &&' or wrapped in a subshell '(cd "$REPO_DIR" && ...)'.
+    window_start = max(0, upgrade_idx - 200)
+    window = code[window_start : upgrade_idx + len("alembic upgrade head")]
+    assert "$REPO_DIR" in window, (
+        "The 'alembic upgrade head' call must run inside $REPO_DIR so it "
+        "picks up the repo's alembic.ini. See #222."
+    )


### PR DESCRIPTION
## Summary

- `scripts/rebuild-cache.sh` now invokes `alembic upgrade head` against `$DATABASE_URL_DISCOGS` between dep refresh and library.db pull, restoring the runbook's claim that the monthly rebuild applies pending migrations automatically.
- The upgrade is skipped when `REBUILD_SMOKE=1` so smoke runs stay read-only, matching the existing smoke-mode contract on the curl Range-request preflight.
- New static-structural tests at `tests/unit/test_rebuild_cache_alembic_upgrade.py` pin: the command is present, runs before `run_pipeline.py`, is guarded by `REBUILD_SMOKE`, and executes inside `$REPO_DIR` so `alembic.ini` resolves correctly.

## Deadline

**HARD DEADLINE: 2026-06-04 06:00 UTC** — this fix MUST land before the next monthly ephemeral-rebuild cron tick. Without it, that tick will fail at the `release_track_artist` COPY because Railway prod is at revision 0004 while `main` is at 0005 (the `extra` int + `role` text columns added by #221 / discogs-xml-converter#55).

## Background

The GH Actions cron (`.github/workflows/rebuild-cache.yml`) ran `alembic upgrade head` before the pipeline, but that workflow has been disabled since 2026-05-05. The active path is the EC2 ephemeral stack (`infra/ephemeral-rebuild/`), which execs `rebuild-cache.sh`; that script and its bootstrap wrapper never invoked alembic. Every future migration would have the same shape until fixed.

Closes #222