### PR TITLE
feat(rebuild): preserve LML-back-patched artwork across rebuilds (#242)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,6 +66,26 @@ The column survives the dedup + prune-copy-swap paths via the SELECT lists in `s
 
 Partial index `release_artwork_null_idx ON release (id) WHERE artwork_url IS NULL AND artwork_checked_at IS NULL` covers the never-asked tail for [WXYC/library-metadata-lookup#221](https://github.com/WXYC/library-metadata-lookup/issues/221)'s top-up drain — without the index that scan would seq-scan the full `release` table (~82K rows in prod as of 2026-05-29).
 
+### Artwork Preservation Across Rebuilds
+
+The monthly rebuild is incremental by default: `release.artwork_url` and `release.artwork_checked_at` that LML's runtime back-patched between rebuilds (see [WXYC/library-metadata-lookup#423](https://github.com/WXYC/library-metadata-lookup/issues/423)) survive the next rebuild. The plumbing is two structural changes (per [#242](https://github.com/WXYC/discogs-etl/issues/242)):
+
+1. `schema/create_database.sql` is `CREATE TABLE IF NOT EXISTS`-only — safe to apply against a populated DB. The destructive `DROP TABLE … CASCADE` block moved to `schema/drop_core_tables.sql`, invoked only by `--fresh-rebuild`.
+2. `scripts/import_csv.py:import_release_via_upsert` reloads `release` via staging-table COPY + UPSERT with `artwork_url` + `artwork_checked_at` excluded from the SET list. Releases that fall out of the new dump are pruned via `DELETE … WHERE id NOT IN staging`; FK `ON DELETE CASCADE` removes their child rows. Child tables of `release` (`release_artist` + siblings, plus `cache_metadata`) are TRUNCATEd before re-COPY so duplicates don't accumulate.
+3. `scripts/import_csv.py:import_artwork` also stamps `artwork_checked_at = now()` whenever it sets `artwork_url` from the dump — matches the semantics LML's runtime `write_release` applies (LML#423) so freshly-imported rows aren't treated as "never asked" on the first lookup.
+
+Semantics matrix for `scripts/run_pipeline.py`:
+
+| Flag | Schema | Data | LML back-patches |
+| --- | --- | --- | --- |
+| (default) | preserved (`CREATE TABLE IF NOT EXISTS` no-ops) | upserted; children TRUNCATE+re-COPY | preserved |
+| `--truncate-existing` | preserved | wiped via `TRUNCATE CACHE_TABLES_TO_TRUNCATE_BASE` | wiped (re-COPY into empty tables) |
+| `--fresh-rebuild` | dropped + recreated via `drop_core_tables.sql` | wiped via `DROP CASCADE` | wiped |
+
+**Dead-URL edge case the issue calls out**: if a release's image is taken down on Discogs between rebuilds, `release_image.csv` omits the row, the `import_artwork` UPDATE skips the release, and the prior LML-back-patched URL is preserved (potentially a dead URL). LML's runtime path will eventually 404 on the URL and re-fetch, back-patching with the new state. Strictly better than today's "wipe to NULL → serve placeholder" behavior.
+
+**Plan**: [`WXYC/wiki/plans/discogs-etl-242-rebuild-coalesce.md`](https://github.com/WXYC/wiki/blob/main/plans/discogs-etl-242-rebuild-coalesce.md) (PR [wiki#75](https://github.com/WXYC/wiki/pull/75)). Regression coverage: `tests/integration/test_import.py::TestImportArtworkPreservation` (the 5-case acceptance grid), `tests/integration/test_rebuild_idempotent.py` (--truncate-existing + --fresh-rebuild semantics), `tests/integration/test_schema.py::TestSchemaIdempotenceDriftGuards` (drift guards on the schema split).
+
 ### format Column Lifecycle
 
 The `format` column stores the normalized format category (Vinyl, CD, Cassette, 7", Digital). Unlike `master_id`, `format` persists after dedup and is available to consumers. During import, raw Discogs format strings are normalized via `lib/format_normalization.py` (e.g., "2xLP" → "Vinyl", "CD-R" → "CD"). During dedup, releases are partitioned by `(master_id, format)`, so a CD and Vinyl pressing of the same album both survive. During verify/prune, format-aware matching ensures only releases whose format matches the library's are kept (for exact artist+title matches). NULL format on either side is treated as "match anything" for backward compatibility.

--- a/schema/create_database.sql
+++ b/schema/create_database.sql
@@ -41,29 +41,19 @@ CREATE OR REPLACE FUNCTION f_unaccent(text) RETURNS text AS $$
 $$ LANGUAGE sql IMMUTABLE PARALLEL SAFE STRICT;
 
 -- ============================================
--- Core tables (drop + recreate for clean ETL)
+-- Core tables (idempotent — safe to apply against a populated DB)
 -- ============================================
-
--- Drop in FK order: children first, then parent
-DROP TABLE IF EXISTS cache_metadata CASCADE;
-DROP TABLE IF EXISTS master_artist CASCADE;
-DROP TABLE IF EXISTS master CASCADE;
-DROP TABLE IF EXISTS artist_url CASCADE;
-DROP TABLE IF EXISTS artist_member CASCADE;
-DROP TABLE IF EXISTS artist_name_variation CASCADE;
-DROP TABLE IF EXISTS artist_alias CASCADE;
-DROP TABLE IF EXISTS artist CASCADE;
-DROP TABLE IF EXISTS release_video CASCADE;
-DROP TABLE IF EXISTS release_track_artist CASCADE;
-DROP TABLE IF EXISTS release_track CASCADE;
-DROP TABLE IF EXISTS release_style CASCADE;
-DROP TABLE IF EXISTS release_genre CASCADE;
-DROP TABLE IF EXISTS release_label CASCADE;
-DROP TABLE IF EXISTS release_artist CASCADE;
-DROP TABLE IF EXISTS release CASCADE;
+--
+-- Every CREATE here is `IF NOT EXISTS`. On a fresh DB every statement
+-- fires; on a populated cache every statement is a no-op and existing
+-- rows (including LML-back-patched `release.artwork_url` /
+-- `release.artwork_checked_at`) are left alone. The explicit wipe path
+-- lives in `schema/drop_core_tables.sql`, invoked only by the
+-- `--fresh-rebuild` flag on `scripts/run_pipeline.py`
+-- (WXYC/discogs-etl#242).
 
 -- Releases
-CREATE TABLE release (
+CREATE TABLE IF NOT EXISTS release (
     id                  integer PRIMARY KEY,
     title               text NOT NULL,
     release_year        smallint,
@@ -84,7 +74,7 @@ CREATE INDEX IF NOT EXISTS release_artwork_null_idx
     WHERE artwork_url IS NULL AND artwork_checked_at IS NULL;
 
 -- Artists on releases
-CREATE TABLE release_artist (
+CREATE TABLE IF NOT EXISTS release_artist (
     release_id      integer NOT NULL REFERENCES release(id) ON DELETE CASCADE,
     artist_id       integer,             -- Discogs artist ID (nullable for API-fetched releases)
     artist_name     text NOT NULL,
@@ -93,7 +83,7 @@ CREATE TABLE release_artist (
 );
 
 -- Labels on releases
-CREATE TABLE release_label (
+CREATE TABLE IF NOT EXISTS release_label (
     release_id      integer NOT NULL REFERENCES release(id) ON DELETE CASCADE,
     label_id        integer,
     label_name      text NOT NULL,
@@ -101,19 +91,19 @@ CREATE TABLE release_label (
 );
 
 -- Genres on releases
-CREATE TABLE release_genre (
+CREATE TABLE IF NOT EXISTS release_genre (
     release_id      integer NOT NULL REFERENCES release(id) ON DELETE CASCADE,
     genre           text NOT NULL
 );
 
 -- Styles on releases (more specific than genres)
-CREATE TABLE release_style (
+CREATE TABLE IF NOT EXISTS release_style (
     release_id      integer NOT NULL REFERENCES release(id) ON DELETE CASCADE,
     style           text NOT NULL
 );
 
 -- Tracks on releases
-CREATE TABLE release_track (
+CREATE TABLE IF NOT EXISTS release_track (
     release_id      integer NOT NULL REFERENCES release(id) ON DELETE CASCADE,
     sequence        integer NOT NULL,
     position        text,              -- "A1", "B2", etc.
@@ -122,7 +112,7 @@ CREATE TABLE release_track (
 );
 
 -- Videos on releases
-CREATE TABLE release_video (
+CREATE TABLE IF NOT EXISTS release_video (
     release_id integer NOT NULL REFERENCES release(id) ON DELETE CASCADE,
     sequence   integer NOT NULL,
     src        text NOT NULL,
@@ -145,7 +135,7 @@ CREATE TABLE release_video (
 --     operating.
 --   * ``role`` is NULL for main credits and may be NULL for extra
 --     credits when the XML omitted the ``<role>`` element.
-CREATE TABLE release_track_artist (
+CREATE TABLE IF NOT EXISTS release_track_artist (
     release_id      integer NOT NULL REFERENCES release(id) ON DELETE CASCADE,
     track_sequence  integer NOT NULL,
     artist_name     text NOT NULL,
@@ -157,7 +147,7 @@ CREATE TABLE release_track_artist (
 -- Artist detail tables
 -- ============================================
 
-CREATE TABLE artist (
+CREATE TABLE IF NOT EXISTS artist (
     id              integer PRIMARY KEY,
     name            text NOT NULL,
     profile         text,
@@ -165,25 +155,25 @@ CREATE TABLE artist (
     fetched_at      timestamptz NOT NULL DEFAULT now()
 );
 
-CREATE TABLE artist_alias (
+CREATE TABLE IF NOT EXISTS artist_alias (
     artist_id       integer NOT NULL REFERENCES artist(id) ON DELETE CASCADE,
     alias_id        integer,
     alias_name      text NOT NULL
 );
 
-CREATE TABLE artist_name_variation (
+CREATE TABLE IF NOT EXISTS artist_name_variation (
     artist_id       integer NOT NULL REFERENCES artist(id) ON DELETE CASCADE,
     name            text NOT NULL
 );
 
-CREATE TABLE artist_member (
+CREATE TABLE IF NOT EXISTS artist_member (
     artist_id       integer NOT NULL REFERENCES artist(id) ON DELETE CASCADE,
     member_id       integer NOT NULL,
     member_name     text NOT NULL,
     active          boolean DEFAULT true
 );
 
-CREATE TABLE artist_url (
+CREATE TABLE IF NOT EXISTS artist_url (
     artist_id       integer NOT NULL REFERENCES artist(id) ON DELETE CASCADE,
     url             text NOT NULL
 );
@@ -192,14 +182,14 @@ CREATE TABLE artist_url (
 -- Masters (canonical album groupings)
 -- ============================================
 
-CREATE TABLE master (
+CREATE TABLE IF NOT EXISTS master (
     id              integer PRIMARY KEY,
     title           text NOT NULL,
     main_release_id integer,
     year            smallint
 );
 
-CREATE TABLE master_artist (
+CREATE TABLE IF NOT EXISTS master_artist (
     master_id       integer NOT NULL REFERENCES master(id) ON DELETE CASCADE,
     artist_id       integer,
     artist_name     text NOT NULL
@@ -209,7 +199,7 @@ CREATE TABLE master_artist (
 -- Cache metadata (for tracking data freshness)
 -- ============================================
 
-CREATE TABLE cache_metadata (
+CREATE TABLE IF NOT EXISTS cache_metadata (
     release_id      integer PRIMARY KEY REFERENCES release(id) ON DELETE CASCADE,
     cached_at       timestamptz NOT NULL DEFAULT now(),
     source          text NOT NULL,  -- 'bulk_import' or 'api_fetch'
@@ -225,8 +215,7 @@ CREATE TABLE cache_metadata (
 -- in-memory + positive PG caches and before the Discogs API. TTL is
 -- enforced by the LML query inline (now() < attempted_at + ttl_seconds *
 -- interval '1 second'); a future cron may sweep expired rows.
-DROP TABLE IF EXISTS lookup_negative CASCADE;
-CREATE TABLE lookup_negative (
+CREATE TABLE IF NOT EXISTS lookup_negative (
     key_hash          bytea PRIMARY KEY,
     artist            text,
     track             text,
@@ -242,8 +231,7 @@ CREATE TABLE lookup_negative (
 -- Mirrored from alembic/versions/0003_wxyc_library_v2.py per the dual-write
 -- convention so a fresh rebuild produces the same end state as the alembic
 -- upgrade chain.
-DROP TABLE IF EXISTS wxyc_library CASCADE;
-CREATE TABLE wxyc_library (
+CREATE TABLE IF NOT EXISTS wxyc_library (
     library_id      integer PRIMARY KEY,
     artist_id       integer,
     artist_name     text NOT NULL,

--- a/schema/drop_core_tables.sql
+++ b/schema/drop_core_tables.sql
@@ -1,0 +1,35 @@
+-- Drop the discogs-cache core-table subgraph.
+--
+-- Used by the explicit `--fresh-rebuild` path in scripts/run_pipeline.py to
+-- wipe the schema before reapplying `schema/create_database.sql`. The
+-- default rebuild path is now incremental (create_database.sql is
+-- `CREATE TABLE IF NOT EXISTS`-only) so LML-back-patched artwork survives
+-- across rebuilds (WXYC/discogs-etl#242). This file is the operator-
+-- visible escape hatch when "I want today's drop+recreate behavior" is
+-- the intent (e.g. recovering from a corrupted cache).
+--
+-- These DROPs were previously embedded in create_database.sql; splitting
+-- them out keeps that file safe to apply against an already-populated DB.
+-- Mirrors the single-job convention already used by create_functions.sql /
+-- create_indexes.sql / create_track_indexes.sql.
+
+-- Drop in FK order: children first, then parent
+DROP TABLE IF EXISTS cache_metadata CASCADE;
+DROP TABLE IF EXISTS master_artist CASCADE;
+DROP TABLE IF EXISTS master CASCADE;
+DROP TABLE IF EXISTS artist_url CASCADE;
+DROP TABLE IF EXISTS artist_member CASCADE;
+DROP TABLE IF EXISTS artist_name_variation CASCADE;
+DROP TABLE IF EXISTS artist_alias CASCADE;
+DROP TABLE IF EXISTS artist CASCADE;
+DROP TABLE IF EXISTS release_video CASCADE;
+DROP TABLE IF EXISTS release_track_artist CASCADE;
+DROP TABLE IF EXISTS release_track CASCADE;
+DROP TABLE IF EXISTS release_style CASCADE;
+DROP TABLE IF EXISTS release_genre CASCADE;
+DROP TABLE IF EXISTS release_label CASCADE;
+DROP TABLE IF EXISTS release_artist CASCADE;
+DROP TABLE IF EXISTS release CASCADE;
+
+DROP TABLE IF EXISTS lookup_negative CASCADE;
+DROP TABLE IF EXISTS wxyc_library CASCADE;

--- a/scripts/import_csv.py
+++ b/scripts/import_csv.py
@@ -259,15 +259,8 @@ TABLES: list[TableConfig] = BASE_TABLES + TRACK_TABLES + VIDEO_TABLES
 # touches track-domain tables, so a tracks-only rerun against an
 # already-populated cache only refreshes the tracks.
 #
-# `release` stays in this list for --truncate-existing's explicit-wipe
-# semantics (operators reach for the flag precisely when they want to
-# wipe and rebuild from scratch). The default incremental path
-# (WXYC/discogs-etl#242) does NOT TRUNCATE release — it goes through
-# import_release_via_upsert, which TRUNCATEs only the child tables of
-# release (release_artist + siblings) and UPSERTs release itself with
-# artwork columns excluded from the SET list, so LML back-patches
-# survive across rebuilds. The two paths are mutually exclusive at the
-# call site (see the `if args.truncate_existing` branch in main()).
+# `release` stays in this list for --truncate-existing only. The default
+# incremental path goes through import_release_via_upsert instead.
 CACHE_TABLES_TO_TRUNCATE_BASE: list[str] = [
     "release",
     "release_artist",
@@ -576,36 +569,24 @@ def create_track_count_table(conn, csv_dir: Path) -> int:
     return len(counts)
 
 
+# Tables wiped by import_release_via_upsert before re-COPY. Derived from
+# the existing config lists so a future child table added to BASE_TABLES /
+# TRACK_TABLES / VIDEO_TABLES is picked up automatically. cache_metadata is
+# the lone non-config entry — it's populated by populate_cache_metadata
+# rather than COPY, but it's still derivative of the current rebuild and
+# stale rows would mismatch release after the upsert's DELETE prunes.
 _RELEASE_CHILD_TABLES: list[str] = [
-    "release_artist",
-    "release_label",
-    "release_genre",
-    "release_style",
-    "release_track",
-    "release_track_artist",
-    "release_video",
-    "cache_metadata",
-]
+    t["table"] for t in BASE_TABLES[1:] + TRACK_TABLES + VIDEO_TABLES
+] + ["cache_metadata"]
 
 
 def import_release_via_upsert(conn, csv_dir: Path) -> int:
     """Reload ``release`` from CSV while preserving artwork columns.
 
-    Today's drop+recreate flow erases any LML-back-patched
-    ``(artwork_url, artwork_checked_at)`` on every rebuild. Option B
-    (WXYC/discogs-etl#242) replaces that with: COPY into a staging table,
-    UPSERT into ``release`` with ``artwork_url`` + ``artwork_checked_at``
-    EXCLUDED from the SET list, then ``DELETE FROM release WHERE id NOT
-    IN staging`` to prune releases that fell out of the new dump (FK
-    ``ON DELETE CASCADE`` handles their child rows).
-
-    Child tables of ``release`` (release_artist, release_label,
-    release_genre, release_style, release_track, release_track_artist,
-    release_video, cache_metadata) are pure derivative data — every row
-    comes from the current dump. They're TRUNCATEd before the upsert so
-    the subsequent COPYs into them don't append duplicates. ``release``
-    itself is NOT in this truncate set; that's what makes preservation
-    work.
+    Staging-table COPY + UPSERT with ``artwork_url`` and
+    ``artwork_checked_at`` excluded from the SET list, plus a DELETE step
+    pruning releases not in the new dump. Child tables of ``release`` are
+    TRUNCATEd first so the subsequent COPYs don't append duplicates.
 
     Returns the staging row count (number of rows COPYed from release.csv).
     """
@@ -618,16 +599,14 @@ def import_release_via_upsert(conn, csv_dir: Path) -> int:
     logger.info("Truncating child tables of release ahead of upsert...")
     with conn.cursor() as cur:
         quoted = ", ".join(f'"{t}"' for t in _RELEASE_CHILD_TABLES)
-        cur.execute(f"TRUNCATE {quoted} RESTART IDENTITY CASCADE")
+        cur.execute(f"TRUNCATE {quoted} CASCADE")
     conn.commit()
 
     logger.info("Creating release_staging temp table...")
     with conn.cursor() as cur:
-        # ON COMMIT PRESERVE ROWS (the default) — `import_csv` below commits
-        # internally, so `ON COMMIT DROP` would wipe the staging table out
-        # from under the subsequent INSERT/DELETE. The temp table is still
-        # session-scoped; it disappears when conn closes (or we DROP it at
-        # the end of this function explicitly).
+        # ON COMMIT PRESERVE ROWS (the default): import_csv() commits
+        # internally, so ON COMMIT DROP would wipe the staging table out
+        # from under the subsequent INSERT/DELETE.
         cur.execute("CREATE TEMP TABLE release_staging (LIKE release INCLUDING DEFAULTS)")
 
     rows = import_csv(
@@ -641,10 +620,24 @@ def import_release_via_upsert(conn, csv_dir: Path) -> int:
         unique_key=release_config.get("unique_key"),
     )
 
+    # Safety floor: refuse to apply an empty rebuild against a populated
+    # cache. A truncated / mid-write release.csv would otherwise DELETE
+    # every release downstream. Operators who *want* an empty cache go
+    # through --fresh-rebuild + DROP CASCADE.
+    if rows == 0:
+        with conn.cursor() as cur:
+            cur.execute("DROP TABLE release_staging")
+        conn.commit()
+        raise RuntimeError(
+            f"release_staging is empty after COPY from {csv_path.name}; "
+            "refusing to DELETE every release. If you intended an empty "
+            "cache, rerun with --fresh-rebuild."
+        )
+
     logger.info(f"Upserting {rows:,} releases (preserving artwork columns)...")
     with conn.cursor() as cur:
         # artwork_url, artwork_checked_at intentionally NOT in the SET
-        # list: preserve prior LML back-patches across rebuilds (#242).
+        # list — the contract of this function.
         cur.execute(
             """
             INSERT INTO release (id, title, country, released, format, master_id)
@@ -666,24 +659,12 @@ def import_release_via_upsert(conn, csv_dir: Path) -> int:
 
 
 def import_artwork(conn, csv_dir: Path) -> int:
-    """Populate release.artwork_url from release_image.csv.
+    """Populate release.artwork_url + stamp release.artwork_checked_at from release_image.csv.
 
-    Reads the release_image CSV and updates the release table with the URI
-    of each release's primary image. Only 'primary' type images are used;
-    if none exists, the first image is used as fallback.
-
-    The UPDATE also stamps ``artwork_checked_at = now()`` on every touched
-    row (WXYC/discogs-etl#242). Populating ``artwork_url`` from the bulk
-    dump is semantically equivalent to LML's runtime "asked Discogs and
-    got an answer" path, so the column must agree across both writers —
-    otherwise LML's predicate (LML#423) would treat dump-imported rows as
-    'never asked' and burn API quota on the first lookup. Rows without an
-    entry in ``release_image.csv`` are not touched by the UPDATE: they
-    retain whatever ``(artwork_url, artwork_checked_at)`` they had going
-    in. For freshly imported releases that's ``(NULL, NULL)`` — the
-    "never asked" state covered by ``release_artwork_null_idx`` for
-    LML#221's drain. For releases preserved across a rebuild (the
-    Option-B UPSERT path), that's the prior LML back-patch.
+    Only 'primary' type images are used; the first image is the fallback.
+    Stamping artwork_checked_at matches LML's runtime write_release semantics
+    so dump-imported rows are treated as cached. See CLAUDE.md →
+    "artwork_checked_at Column Lifecycle".
     """
     csv_path = csv_dir / "release_image.csv"
     if not csv_path.exists():
@@ -1007,19 +988,13 @@ def main():
             release_id_filter=release_ids,
         )
     elif args.base_only:
+        # --truncate-existing wipes release; default path upserts to preserve LML back-patches.
         if args.truncate_existing:
-            # Legacy wipe-and-COPY path: --truncate-existing TRUNCATEd above.
-            # release was wiped, so a plain COPY into the empty table is
-            # the cheapest end state.
             conn.close()
             total = _import_tables_parallel(
                 db_url, csv_dir, parent_tables=BASE_TABLES[:1], child_tables=BASE_TABLES[1:]
             )
         else:
-            # Incremental rebuild (WXYC/discogs-etl#242): upsert release
-            # (preserving artwork_url + artwork_checked_at), then COPY
-            # children. import_release_via_upsert TRUNCATEs the child
-            # tables internally so the subsequent COPY doesn't duplicate.
             conn.close()
             upsert_conn = psycopg.connect(db_url)
             upsert_rows = import_release_via_upsert(upsert_conn, csv_dir)

--- a/scripts/import_csv.py
+++ b/scripts/import_csv.py
@@ -258,6 +258,16 @@ TABLES: list[TableConfig] = BASE_TABLES + TRACK_TABLES + VIDEO_TABLES
 # and find zero release IDs to filter against. The tracks subset only
 # touches track-domain tables, so a tracks-only rerun against an
 # already-populated cache only refreshes the tracks.
+#
+# `release` stays in this list for --truncate-existing's explicit-wipe
+# semantics (operators reach for the flag precisely when they want to
+# wipe and rebuild from scratch). The default incremental path
+# (WXYC/discogs-etl#242) does NOT TRUNCATE release — it goes through
+# import_release_via_upsert, which TRUNCATEs only the child tables of
+# release (release_artist + siblings) and UPSERTs release itself with
+# artwork columns excluded from the SET list, so LML back-patches
+# survive across rebuilds. The two paths are mutually exclusive at the
+# call site (see the `if args.truncate_existing` branch in main()).
 CACHE_TABLES_TO_TRUNCATE_BASE: list[str] = [
     "release",
     "release_artist",
@@ -566,12 +576,114 @@ def create_track_count_table(conn, csv_dir: Path) -> int:
     return len(counts)
 
 
+_RELEASE_CHILD_TABLES: list[str] = [
+    "release_artist",
+    "release_label",
+    "release_genre",
+    "release_style",
+    "release_track",
+    "release_track_artist",
+    "release_video",
+    "cache_metadata",
+]
+
+
+def import_release_via_upsert(conn, csv_dir: Path) -> int:
+    """Reload ``release`` from CSV while preserving artwork columns.
+
+    Today's drop+recreate flow erases any LML-back-patched
+    ``(artwork_url, artwork_checked_at)`` on every rebuild. Option B
+    (WXYC/discogs-etl#242) replaces that with: COPY into a staging table,
+    UPSERT into ``release`` with ``artwork_url`` + ``artwork_checked_at``
+    EXCLUDED from the SET list, then ``DELETE FROM release WHERE id NOT
+    IN staging`` to prune releases that fell out of the new dump (FK
+    ``ON DELETE CASCADE`` handles their child rows).
+
+    Child tables of ``release`` (release_artist, release_label,
+    release_genre, release_style, release_track, release_track_artist,
+    release_video, cache_metadata) are pure derivative data — every row
+    comes from the current dump. They're TRUNCATEd before the upsert so
+    the subsequent COPYs into them don't append duplicates. ``release``
+    itself is NOT in this truncate set; that's what makes preservation
+    work.
+
+    Returns the staging row count (number of rows COPYed from release.csv).
+    """
+    release_config = next(t for t in BASE_TABLES if t["table"] == "release")
+    csv_path = csv_dir / release_config["csv_file"]
+    if not csv_path.exists():
+        logger.warning(f"Skipping {release_config['csv_file']} (not found)")
+        return 0
+
+    logger.info("Truncating child tables of release ahead of upsert...")
+    with conn.cursor() as cur:
+        quoted = ", ".join(f'"{t}"' for t in _RELEASE_CHILD_TABLES)
+        cur.execute(f"TRUNCATE {quoted} RESTART IDENTITY CASCADE")
+    conn.commit()
+
+    logger.info("Creating release_staging temp table...")
+    with conn.cursor() as cur:
+        # ON COMMIT PRESERVE ROWS (the default) — `import_csv` below commits
+        # internally, so `ON COMMIT DROP` would wipe the staging table out
+        # from under the subsequent INSERT/DELETE. The temp table is still
+        # session-scoped; it disappears when conn closes (or we DROP it at
+        # the end of this function explicitly).
+        cur.execute("CREATE TEMP TABLE release_staging (LIKE release INCLUDING DEFAULTS)")
+
+    rows = import_csv(
+        conn,
+        csv_path=csv_path,
+        table="release_staging",
+        csv_columns=release_config["csv_columns"],
+        db_columns=release_config["db_columns"],
+        required_columns=release_config["required"],
+        transforms=release_config["transforms"],
+        unique_key=release_config.get("unique_key"),
+    )
+
+    logger.info(f"Upserting {rows:,} releases (preserving artwork columns)...")
+    with conn.cursor() as cur:
+        # artwork_url, artwork_checked_at intentionally NOT in the SET
+        # list: preserve prior LML back-patches across rebuilds (#242).
+        cur.execute(
+            """
+            INSERT INTO release (id, title, country, released, format, master_id)
+            SELECT id, title, country, released, format, master_id FROM release_staging
+            ON CONFLICT (id) DO UPDATE SET
+                title     = EXCLUDED.title,
+                country   = EXCLUDED.country,
+                released  = EXCLUDED.released,
+                format    = EXCLUDED.format,
+                master_id = EXCLUDED.master_id
+            """
+        )
+        cur.execute("DELETE FROM release WHERE id NOT IN (SELECT id FROM release_staging)")
+        pruned = cur.rowcount
+        cur.execute("DROP TABLE release_staging")
+    conn.commit()
+    logger.info(f"  Upsert complete; pruned {pruned:,} releases not in new dump")
+    return rows
+
+
 def import_artwork(conn, csv_dir: Path) -> int:
     """Populate release.artwork_url from release_image.csv.
 
     Reads the release_image CSV and updates the release table with the URI
     of each release's primary image. Only 'primary' type images are used;
     if none exists, the first image is used as fallback.
+
+    The UPDATE also stamps ``artwork_checked_at = now()`` on every touched
+    row (WXYC/discogs-etl#242). Populating ``artwork_url`` from the bulk
+    dump is semantically equivalent to LML's runtime "asked Discogs and
+    got an answer" path, so the column must agree across both writers —
+    otherwise LML's predicate (LML#423) would treat dump-imported rows as
+    'never asked' and burn API quota on the first lookup. Rows without an
+    entry in ``release_image.csv`` are not touched by the UPDATE: they
+    retain whatever ``(artwork_url, artwork_checked_at)`` they had going
+    in. For freshly imported releases that's ``(NULL, NULL)`` — the
+    "never asked" state covered by ``release_artwork_null_idx`` for
+    LML#221's drain. For releases preserved across a rebuild (the
+    Option-B UPSERT path), that's the prior LML back-patch.
     """
     csv_path = csv_dir / "release_image.csv"
     if not csv_path.exists():
@@ -627,7 +739,8 @@ def import_artwork(conn, csv_dir: Path) -> int:
 
         cur.execute("""
             UPDATE release r
-            SET artwork_url = a.artwork_url
+            SET artwork_url = a.artwork_url,
+                artwork_checked_at = now()
             FROM _artwork a
             WHERE r.id = a.release_id
         """)
@@ -894,11 +1007,26 @@ def main():
             release_id_filter=release_ids,
         )
     elif args.base_only:
-        conn.close()
-        # release is parent; release_artist and release_label are independent children
-        total = _import_tables_parallel(
-            db_url, csv_dir, parent_tables=BASE_TABLES[:1], child_tables=BASE_TABLES[1:]
-        )
+        if args.truncate_existing:
+            # Legacy wipe-and-COPY path: --truncate-existing TRUNCATEd above.
+            # release was wiped, so a plain COPY into the empty table is
+            # the cheapest end state.
+            conn.close()
+            total = _import_tables_parallel(
+                db_url, csv_dir, parent_tables=BASE_TABLES[:1], child_tables=BASE_TABLES[1:]
+            )
+        else:
+            # Incremental rebuild (WXYC/discogs-etl#242): upsert release
+            # (preserving artwork_url + artwork_checked_at), then COPY
+            # children. import_release_via_upsert TRUNCATEs the child
+            # tables internally so the subsequent COPY doesn't duplicate.
+            conn.close()
+            upsert_conn = psycopg.connect(db_url)
+            upsert_rows = import_release_via_upsert(upsert_conn, csv_dir)
+            upsert_conn.close()
+            total = upsert_rows + _import_tables_parallel(
+                db_url, csv_dir, parent_tables=[], child_tables=BASE_TABLES[1:]
+            )
         conn = psycopg.connect(db_url)
         logger.info("Populating artwork URLs...")
         import_artwork(conn, csv_dir)

--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -277,6 +277,17 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "a DB with stale rows from a prior failed attempt. Preserves "
         "entity.identity and alembic_version.",
     )
+    parser.add_argument(
+        "--fresh-rebuild",
+        action="store_true",
+        help="Drop and recreate the discogs-cache schema before importing "
+        "(applies schema/drop_core_tables.sql + create_database.sql). "
+        "Use when the intent is a from-scratch rebuild, e.g. recovering "
+        "from cache corruption. Default is incremental: schema is "
+        "preserved and LML-back-patched release.artwork_url + "
+        "release.artwork_checked_at survive the rebuild via the "
+        "staging-table UPSERT path (WXYC/discogs-etl#242).",
+    )
 
     args = parser.parse_args(argv)
 
@@ -801,6 +812,7 @@ def _run_xml_pipeline(
                 catalog_source=args.catalog_source,
                 catalog_db_url=args.catalog_db_url,
                 truncate_existing=args.truncate_existing,
+                fresh_rebuild=args.fresh_rebuild,
             )
 
     if keep_csv_dir is not None:
@@ -866,6 +878,7 @@ def main() -> None:
             state=state,
             state_file=args.state_file,
             truncate_existing=args.truncate_existing,
+            fresh_rebuild=args.fresh_rebuild,
         )
 
     total = time.monotonic() - pipeline_start
@@ -1018,6 +1031,7 @@ def _run_database_build(
     state: PipelineState | None = None,
     state_file: Path | None = None,
     truncate_existing: bool = False,
+    fresh_rebuild: bool = False,
 ) -> None:
     """Database build: create_schema through vacuum.
 
@@ -1046,6 +1060,15 @@ def _run_database_build(
         # create_functions.sql must run BEFORE create_database.sql:
         # create_database.sql's idx_master_title_trgm index expression
         # references f_unaccent (see #104).
+        if fresh_rebuild:
+            # --fresh-rebuild: wipe the core-table subgraph before recreate
+            # (WXYC/discogs-etl#242). Without this step create_database.sql
+            # is a no-op against a populated DB (every CREATE is IF NOT
+            # EXISTS), which is the incremental default that preserves
+            # LML-back-patched artwork. drop_core_tables.sql does NOT drop
+            # alembic_version, entity.identity, etc.
+            logger.warning("--fresh-rebuild: dropping core-table subgraph")
+            run_sql_file(db_url, SCHEMA_DIR / "drop_core_tables.sql")
         run_sql_file(db_url, SCHEMA_DIR / "create_functions.sql")
         run_sql_file(db_url, SCHEMA_DIR / "create_database.sql")
         if state:

--- a/tests/integration/test_copy_swap_preserves_not_null.py
+++ b/tests/integration/test_copy_swap_preserves_not_null.py
@@ -416,8 +416,14 @@ def _iter_column_lines(schema_text: str, table: str):
     separators so embedded commas inside comments (e.g. ``-- "A1", "B2"``)
     don't cross over into the next declaration.
     """
-    marker = f"CREATE TABLE {table} ("
-    start = schema_text.index(marker) + len(marker)
+    # Tolerate both bare and ``IF NOT EXISTS`` forms — the file flipped to
+    # the latter for the WXYC/discogs-etl#242 schema split.
+    for marker in (f"CREATE TABLE {table} (", f"CREATE TABLE IF NOT EXISTS {table} ("):
+        if marker in schema_text:
+            start = schema_text.index(marker) + len(marker)
+            break
+    else:
+        raise AssertionError(f"CREATE TABLE marker for {table!r} not found in schema")
     body = _extract_paren_body(schema_text, start)
     # Strip end-of-line SQL comments so commas inside comments don't bleed
     # into the next column declaration when we split on ``,``.

--- a/tests/integration/test_error_resilience.py
+++ b/tests/integration/test_error_resilience.py
@@ -111,17 +111,29 @@ def _apply_schema(db_url: str) -> None:
     a multi-statement execute, so we must order setup as:
       1. Create the unaccent + pg_trgm extensions.
       2. Define f_unaccent() (depends on unaccent).
-      3. Run create_database.sql (depends on f_unaccent).
+      3. Drop the core-table subgraph (clean-slate semantic this helper
+         contractually offers — tests in this module share a module-
+         scoped db_url and rely on _apply_schema to wipe between
+         classes).
+      4. Run create_database.sql (depends on f_unaccent).
     psql tolerates out-of-order setup because it continues past per-
     statement errors; psycopg does not, so this ordering is mandatory
     for the integration tests even if production gets away with running
     create_database.sql first.
+
+    Post-WXYC/discogs-etl#242, ``schema/create_database.sql`` is
+    ``CREATE TABLE IF NOT EXISTS``-only (preserves LML-back-patched
+    artwork across rebuilds). The explicit wipe lives in
+    ``drop_core_tables.sql``. This helper composes both — restoring
+    the pre-#242 destructive semantic for tests that need a clean slate
+    between classes sharing the module-scoped ``db_url`` fixture.
     """
     conn = psycopg.connect(db_url, autocommit=True)
     with conn.cursor() as cur:
         cur.execute("CREATE EXTENSION IF NOT EXISTS unaccent")
         cur.execute("CREATE EXTENSION IF NOT EXISTS pg_trgm")
         cur.execute(SCHEMA_DIR.joinpath("create_functions.sql").read_text())
+        cur.execute(SCHEMA_DIR.joinpath("drop_core_tables.sql").read_text())
         cur.execute(SCHEMA_DIR.joinpath("create_database.sql").read_text())
     conn.close()
 

--- a/tests/integration/test_import.py
+++ b/tests/integration/test_import.py
@@ -886,9 +886,7 @@ class TestImportArtworkPreservation:
 
         # Header-only release.csv (no rows). import_csv will COPY 0 rows
         # into release_staging, tripping the safety floor.
-        (tmp_path / "release.csv").write_text(
-            "id,title,country,released,format,master_id\n"
-        )
+        (tmp_path / "release.csv").write_text("id,title,country,released,format,master_id\n")
         (tmp_path / "release_image.csv").write_text("release_id,type,width,height,uri\n")
 
         upsert_conn = psycopg.connect(self.db_url)

--- a/tests/integration/test_import.py
+++ b/tests/integration/test_import.py
@@ -687,25 +687,8 @@ class TestImportArtwork:
 
 
 class TestImportArtworkPreservation:
-    """Verify the rebuild path preserves LML-back-patched artwork across runs
-    (WXYC/discogs-etl#242).
-
-    The five tests pin the acceptance grid the issue calls out:
-      1. `release_image.csv` lacks an entry for X → prior LML back-patch
-         (artwork_url + artwork_checked_at) is preserved.
-      2. `release_image.csv` HAS an entry for X → dump wins (EXCLUDED-first).
-      3. Freshly imported release with image in dump → artwork_checked_at
-         stamped at import time (matches LML's runtime stamping semantics).
-      4. Freshly imported release with NO image in dump → both columns
-         stay NULL ("never asked" — the partial index covers this case for
-         LML#221's drain).
-      5. Release present in last rebuild but not in the new dump → pruned
-         along with its FK-cascaded child rows.
-
-    These exercise ``import_release_via_upsert`` (the staging-table + UPSERT
-    that replaces today's drop+recreate-then-COPY for ``release``) plus
-    ``import_artwork``'s new ``artwork_checked_at = now()`` stamp.
-    """
+    """Acceptance grid for WXYC/discogs-etl#242 — the rebuild preserves
+    LML-back-patched ``(artwork_url, artwork_checked_at)`` across runs."""
 
     @pytest.fixture(autouse=True)
     def _fresh_schema(self, fresh_db_url):
@@ -889,6 +872,37 @@ class TestImportArtworkPreservation:
         conn.close()
         assert release_ids == [505]
         assert artist_release_ids == [505]
+
+    def test_rebuild_refuses_empty_staging(self, tmp_path) -> None:
+        """A truncated / mid-write ``release.csv`` (0 rows after the COPY
+        skip-on-required-null path) would otherwise let the DELETE step
+        wipe every release. Safety floor in
+        ``import_release_via_upsert`` raises instead."""
+        conn = psycopg.connect(self.db_url)
+        with conn.cursor() as cur:
+            cur.execute("INSERT INTO release (id, title) VALUES (507, 'Stays')")
+        conn.commit()
+        conn.close()
+
+        # Header-only release.csv (no rows). import_csv will COPY 0 rows
+        # into release_staging, tripping the safety floor.
+        (tmp_path / "release.csv").write_text(
+            "id,title,country,released,format,master_id\n"
+        )
+        (tmp_path / "release_image.csv").write_text("release_id,type,width,height,uri\n")
+
+        upsert_conn = psycopg.connect(self.db_url)
+        with pytest.raises(RuntimeError, match="release_staging is empty"):
+            import_release_via_upsert(upsert_conn, tmp_path)
+        upsert_conn.close()
+
+        # Pre-existing release survived; nothing was DELETEd.
+        conn = psycopg.connect(self.db_url)
+        with conn.cursor() as cur:
+            cur.execute("SELECT id FROM release ORDER BY id")
+            release_ids = [r[0] for r in cur.fetchall()]
+        conn.close()
+        assert release_ids == [507]
 
 
 class TestImportArtworkMissing:

--- a/tests/integration/test_import.py
+++ b/tests/integration/test_import.py
@@ -21,6 +21,7 @@ _spec.loader.exec_module(_ic)
 
 import_csv_func = _ic.import_csv
 import_artwork = _ic.import_artwork
+import_release_via_upsert = _ic.import_release_via_upsert
 create_track_count_table = _ic.create_track_count_table
 populate_cache_metadata = _ic.populate_cache_metadata
 populate_release_year = _ic.populate_release_year
@@ -683,6 +684,211 @@ class TestImportArtwork:
             "must stay NULL after import_artwork. If this regresses, the "
             "loader is writing speculative URIs to unrelated releases."
         )
+
+
+class TestImportArtworkPreservation:
+    """Verify the rebuild path preserves LML-back-patched artwork across runs
+    (WXYC/discogs-etl#242).
+
+    The five tests pin the acceptance grid the issue calls out:
+      1. `release_image.csv` lacks an entry for X → prior LML back-patch
+         (artwork_url + artwork_checked_at) is preserved.
+      2. `release_image.csv` HAS an entry for X → dump wins (EXCLUDED-first).
+      3. Freshly imported release with image in dump → artwork_checked_at
+         stamped at import time (matches LML's runtime stamping semantics).
+      4. Freshly imported release with NO image in dump → both columns
+         stay NULL ("never asked" — the partial index covers this case for
+         LML#221's drain).
+      5. Release present in last rebuild but not in the new dump → pruned
+         along with its FK-cascaded child rows.
+
+    These exercise ``import_release_via_upsert`` (the staging-table + UPSERT
+    that replaces today's drop+recreate-then-COPY for ``release``) plus
+    ``import_artwork``'s new ``artwork_checked_at = now()`` stamp.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _fresh_schema(self, fresh_db_url):
+        """Each test gets its own DB so seeded back-patches + CSV state are
+        isolated. Cheaper schema-apply than the full ETL setup other classes
+        use, and the per-test isolation is necessary because tests 1, 2, 5
+        mutate the same release_id."""
+        self.db_url = fresh_db_url
+        conn = psycopg.connect(fresh_db_url, autocommit=True)
+        with conn.cursor() as cur:
+            cur.execute(SCHEMA_DIR.joinpath("create_database.sql").read_text())
+        conn.close()
+
+    def _write_release_csv(self, tmp_path: Path, rows: list[tuple]) -> None:
+        """Write a minimal release.csv covering the columns BASE_TABLES['release']
+        expects. Each row: (id, title, country, released, format, master_id)."""
+        lines = ["id,title,country,released,format,master_id"]
+        for row in rows:
+            lines.append(",".join("" if v is None else str(v) for v in row))
+        (tmp_path / "release.csv").write_text("\n".join(lines) + "\n")
+
+    def _write_release_image_csv(self, tmp_path: Path, rows: list[tuple]) -> None:
+        """Write release_image.csv. Each row: (release_id, type, uri)."""
+        lines = ["release_id,type,width,height,uri"]
+        for release_id, img_type, uri in rows:
+            lines.append(f"{release_id},{img_type},600,600,{uri}")
+        (tmp_path / "release_image.csv").write_text("\n".join(lines) + "\n")
+
+    def _rebuild(self, tmp_path: Path) -> None:
+        """Run the post-Option-B base import flow against tmp_path's CSVs:
+        upsert from release_staging, then back-patch artwork."""
+        conn = psycopg.connect(self.db_url)
+        import_release_via_upsert(conn, tmp_path)
+        import_artwork(conn, tmp_path)
+        conn.close()
+
+    def _read_artwork(self, release_id: int) -> tuple:
+        conn = psycopg.connect(self.db_url)
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT artwork_url, artwork_checked_at FROM release WHERE id = %s",
+                (release_id,),
+            )
+            row = cur.fetchone()
+        conn.close()
+        return row
+
+    def test_rebuild_preserves_artwork_when_dump_missing_image(self, tmp_path) -> None:
+        """The issue's verbatim acceptance criterion: a release whose
+        ``release_image.csv`` row is absent retains the prior LML
+        back-patched ``artwork_url`` + ``artwork_checked_at``."""
+        conn = psycopg.connect(self.db_url)
+        with conn.cursor() as cur:
+            cur.execute(
+                "INSERT INTO release (id, title, artwork_url, artwork_checked_at) "
+                "VALUES (501, 'Seed', 'lml-backpatched', '2026-04-01 00:00:00+00')"
+            )
+        conn.commit()
+        conn.close()
+
+        self._write_release_csv(tmp_path, [(501, "Seed", "US", "2024", "LP", None)])
+        # No release_image.csv row for 501.
+        self._write_release_image_csv(tmp_path, [])
+        self._rebuild(tmp_path)
+
+        url, checked_at = self._read_artwork(501)
+        assert url == "lml-backpatched", (
+            "rebuild wiped the prior LML back-patch — Option B's UPSERT must "
+            "exclude artwork_url from the SET list so prior back-patches survive."
+        )
+        assert checked_at is not None
+        assert checked_at.year == 2026 and checked_at.month == 4
+
+    def test_rebuild_overwrites_artwork_when_dump_has_image(self, tmp_path) -> None:
+        """When the bulk dump has a real artwork URL for a previously
+        back-patched release, the dump wins (EXCLUDED-first precedence)
+        and ``artwork_checked_at`` is restamped at rebuild time."""
+        conn = psycopg.connect(self.db_url)
+        with conn.cursor() as cur:
+            cur.execute(
+                "INSERT INTO release (id, title, artwork_url, artwork_checked_at) "
+                "VALUES (502, 'Seed', 'lml-backpatched', '2026-04-01 00:00:00+00')"
+            )
+        conn.commit()
+        conn.close()
+
+        self._write_release_csv(tmp_path, [(502, "Seed", "US", "2024", "LP", None)])
+        self._write_release_image_csv(tmp_path, [(502, "primary", "dump-uri")])
+        # Capture a lower bound for the post-rebuild artwork_checked_at.
+        conn = psycopg.connect(self.db_url)
+        with conn.cursor() as cur:
+            cur.execute("SELECT now()")
+            rebuild_lower_bound = cur.fetchone()[0]
+        conn.close()
+        self._rebuild(tmp_path)
+
+        url, checked_at = self._read_artwork(502)
+        assert url == "dump-uri"
+        assert checked_at is not None and checked_at >= rebuild_lower_bound
+
+    def test_rebuild_stamps_checked_at_for_freshly_imported_release(self, tmp_path) -> None:
+        """A first-time-imported release whose dump carries an image gets
+        ``artwork_checked_at`` stamped at import time. Matches the semantics
+        LML's runtime ``write_release`` already applies (LML#423)."""
+        self._write_release_csv(tmp_path, [(503, "Fresh", "US", "2024", "LP", None)])
+        self._write_release_image_csv(tmp_path, [(503, "primary", "dump-uri")])
+        self._rebuild(tmp_path)
+
+        url, checked_at = self._read_artwork(503)
+        assert url == "dump-uri"
+        assert checked_at is not None, (
+            "import_artwork must stamp artwork_checked_at = now() when it "
+            "sets artwork_url from the dump — otherwise LML's predicate "
+            "(LML#423) treats the row as 'never asked' and burns API quota."
+        )
+
+    def test_rebuild_leaves_checked_at_null_when_no_dump_image_on_fresh_release(
+        self, tmp_path
+    ) -> None:
+        """A first-time-imported release with no dump image stays in the
+        'never asked' state (both columns NULL). LML#221's partial index
+        ``release_artwork_null_idx`` is what covers this case for the
+        drain."""
+        self._write_release_csv(tmp_path, [(504, "Imageless", "US", "2024", "LP", None)])
+        self._write_release_image_csv(tmp_path, [])
+        self._rebuild(tmp_path)
+
+        url, checked_at = self._read_artwork(504)
+        assert url is None
+        assert checked_at is None
+
+    def test_rebuild_purges_releases_not_in_dump(self, tmp_path) -> None:
+        """When a release falls out of the new dump (artist removed from
+        the library, etc.), the rebuild path removes it and its child
+        rows. With Option B, child cleanup is via the §3a TRUNCATE step
+        (TRUNCATE release_artist + siblings before re-COPY); the parent
+        is removed by ``DELETE FROM release WHERE id NOT IN staging``.
+        End state: 506 absent from release; absent from release_artist
+        (was wiped by TRUNCATE and never re-COPYed because its row isn't
+        in the new dump's release_artist.csv); 505 present in both."""
+        conn = psycopg.connect(self.db_url)
+        with conn.cursor() as cur:
+            cur.execute("INSERT INTO release (id, title) VALUES (505, 'Stays'), (506, 'Goes')")
+            cur.execute(
+                "INSERT INTO release_artist (release_id, artist_name, extra) "
+                "VALUES (505, 'Old Artist A', 0), (506, 'Old Artist B', 0)"
+            )
+        conn.commit()
+        conn.close()
+
+        # Only 505 in the new dump.
+        self._write_release_csv(tmp_path, [(505, "Stays", "US", "2024", "LP", None)])
+        self._write_release_image_csv(tmp_path, [])
+        (tmp_path / "release_artist.csv").write_text(
+            "release_id,artist_id,artist_name,extra\n505,,Artist A,0\n"
+        )
+        self._rebuild(tmp_path)
+        # Re-COPY the children the way the full base step would. The
+        # rebuild's TRUNCATE has already cleared them.
+        conn = psycopg.connect(self.db_url)
+        artist_cfg = next(t for t in BASE_TABLES if t["table"] == "release_artist")
+        import_csv_func(
+            conn,
+            tmp_path / artist_cfg["csv_file"],
+            artist_cfg["table"],
+            artist_cfg["csv_columns"],
+            artist_cfg["db_columns"],
+            artist_cfg["required"],
+            artist_cfg["transforms"],
+            unique_key=artist_cfg.get("unique_key"),
+        )
+        conn.commit()
+        conn.close()
+
+        conn = psycopg.connect(self.db_url)
+        with conn.cursor() as cur:
+            cur.execute("SELECT id FROM release ORDER BY id")
+            release_ids = [r[0] for r in cur.fetchall()]
+            cur.execute("SELECT release_id FROM release_artist ORDER BY release_id")
+            artist_release_ids = [r[0] for r in cur.fetchall()]
+        conn.close()
+        assert release_ids == [505]
+        assert artist_release_ids == [505]
 
 
 class TestImportArtworkMissing:

--- a/tests/integration/test_rebuild_idempotent.py
+++ b/tests/integration/test_rebuild_idempotent.py
@@ -1,0 +1,178 @@
+"""Pipeline-level rebuild semantics for WXYC/discogs-etl#242.
+
+Tests 6 and 7 from the Option-B plan: confirm that ``--truncate-existing``
+and ``--fresh-rebuild`` retain their explicit-wipe semantics when invoked
+through the pipeline-level seams. Companion to
+``TestImportArtworkPreservation`` in ``test_import.py``, which covers the
+default-incremental path.
+
+These are heavier than the test_import.py tests (they exercise the schema
+DDL + run subprocesses or apply SQL files), so they live in their own file
+with a slightly higher per-test cost budget.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import psycopg
+import pytest
+
+pytestmark = pytest.mark.pg
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCHEMA_DIR = REPO_ROOT / "schema"
+SCRIPT_DIR = REPO_ROOT / "scripts"
+
+# Load run_pipeline so we can call its private helpers without spawning a
+# subprocess.  _run_database_build is the seam --fresh-rebuild affects.
+_RP_SPEC = importlib.util.spec_from_file_location("run_pipeline", SCRIPT_DIR / "run_pipeline.py")
+assert _RP_SPEC is not None and _RP_SPEC.loader is not None
+run_pipeline = importlib.util.module_from_spec(_RP_SPEC)
+_RP_SPEC.loader.exec_module(run_pipeline)
+
+
+def _apply_schema(db_url: str) -> None:
+    conn = psycopg.connect(db_url, autocommit=True)
+    with conn.cursor() as cur:
+        cur.execute(SCHEMA_DIR.joinpath("create_database.sql").read_text())
+    conn.close()
+
+
+def _seed_back_patched_release(db_url: str, release_id: int) -> None:
+    conn = psycopg.connect(db_url)
+    with conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO release (id, title, artwork_url, artwork_checked_at) "
+            "VALUES (%s, 'Seed', 'lml-backpatched', '2026-04-01 00:00:00+00')",
+            (release_id,),
+        )
+    conn.commit()
+    conn.close()
+
+
+def _read_artwork(db_url: str, release_id: int) -> tuple:
+    conn = psycopg.connect(db_url)
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT artwork_url, artwork_checked_at FROM release WHERE id = %s",
+            (release_id,),
+        )
+        row = cur.fetchone()
+    conn.close()
+    return row
+
+
+class TestTruncateExistingWipesArtwork:
+    """--truncate-existing is the operator-visible escape hatch for "wipe
+    the cache data". After Option B the default incremental path
+    preserves artwork; --truncate-existing must NOT — otherwise the
+    flag's contract changes and operators using it for stale-data
+    recovery get unexpected behavior."""
+
+    def test_truncate_existing_wipes_back_patched_artwork(self, fresh_db_url, tmp_path) -> None:
+        _apply_schema(fresh_db_url)
+        _seed_back_patched_release(fresh_db_url, release_id=601)
+
+        # Fixture: release.csv contains 601 with no row in release_image.csv.
+        (tmp_path / "release.csv").write_text(
+            "id,title,country,released,format,master_id\n601,Seed,US,2024,LP,\n"
+        )
+        (tmp_path / "release_image.csv").write_text("release_id,type,width,height,uri\n")
+        # Empty children CSVs so --base-only's child COPY succeeds.
+        for child in (
+            "release_artist",
+            "release_label",
+            "release_genre",
+            "release_style",
+        ):
+            (tmp_path / f"{child}.csv").write_text("")
+
+        env = {
+            **os.environ,
+            "DATABASE_URL_DISCOGS": fresh_db_url,
+            "DATABASE_URL_TEST": fresh_db_url,
+        }
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT_DIR / "import_csv.py"),
+                "--base-only",
+                "--truncate-existing",
+                str(tmp_path),
+                fresh_db_url,
+            ],
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, result.stderr
+
+        url, checked_at = _read_artwork(fresh_db_url, 601)
+        # --truncate-existing wiped the row; the re-COPY put 601 back with
+        # NULL artwork (no row in release_image.csv → import_artwork did
+        # not stamp it).
+        assert url is None, (
+            "--truncate-existing must wipe artwork to preserve its 'reset "
+            "everything' contract. Preserving back-patches here would "
+            "break operators using the flag to recover from stale rows."
+        )
+        assert checked_at is None
+
+
+class TestFreshRebuildDropsAndRecreates:
+    """--fresh-rebuild applies schema/drop_core_tables.sql before
+    create_database.sql, restoring today's drop+recreate semantics.
+    Anchors operator intent: "I want a from-scratch rebuild" stays
+    available as an explicit flag, even though the default path now
+    preserves artwork."""
+
+    def test_fresh_rebuild_drops_release_table_and_artwork(self, fresh_db_url) -> None:
+        _apply_schema(fresh_db_url)
+        _seed_back_patched_release(fresh_db_url, release_id=701)
+
+        # Apply drop_core_tables.sql + create_database.sql the way
+        # _run_database_build does when fresh_rebuild=True.
+        run_pipeline.run_sql_file(fresh_db_url, SCHEMA_DIR / "drop_core_tables.sql")
+        run_pipeline.run_sql_file(fresh_db_url, SCHEMA_DIR / "create_functions.sql")
+        run_pipeline.run_sql_file(fresh_db_url, SCHEMA_DIR / "create_database.sql")
+
+        # release table now empty (recreated). 701's back-patch is gone.
+        conn = psycopg.connect(fresh_db_url)
+        with conn.cursor() as cur:
+            cur.execute("SELECT count(*) FROM release")
+            count = cur.fetchone()[0]
+        conn.close()
+        assert count == 0
+
+    def test_fresh_rebuild_preserves_alembic_version(self, fresh_db_url) -> None:
+        """drop_core_tables.sql intentionally does NOT touch
+        alembic_version — migration history must survive a fresh
+        rebuild. Pin so a future edit to drop_core_tables.sql doesn't
+        silently drop the table and leave the cache un-stamped on the
+        next workflow run."""
+        _apply_schema(fresh_db_url)
+        # Stand in for the alembic_version table the workflow's stamping
+        # step creates. drop_core_tables.sql must not touch it.
+        conn = psycopg.connect(fresh_db_url, autocommit=True)
+        with conn.cursor() as cur:
+            cur.execute(
+                "CREATE TABLE alembic_version (version_num varchar(32) NOT NULL PRIMARY KEY)"
+            )
+            cur.execute("INSERT INTO alembic_version (version_num) VALUES ('0008')")
+        conn.close()
+
+        run_pipeline.run_sql_file(fresh_db_url, SCHEMA_DIR / "drop_core_tables.sql")
+        run_pipeline.run_sql_file(fresh_db_url, SCHEMA_DIR / "create_functions.sql")
+        run_pipeline.run_sql_file(fresh_db_url, SCHEMA_DIR / "create_database.sql")
+
+        conn = psycopg.connect(fresh_db_url)
+        with conn.cursor() as cur:
+            cur.execute("SELECT version_num FROM alembic_version")
+            version = cur.fetchone()[0]
+        conn.close()
+        assert version == "0008"

--- a/tests/integration/test_schema.py
+++ b/tests/integration/test_schema.py
@@ -193,8 +193,13 @@ class TestCreateDatabase:
             cur.execute(SCHEMA_DIR.joinpath("create_database.sql").read_text())
         conn.close()
 
-    def test_schema_clears_stale_data_on_rerun(self) -> None:
-        """Re-running the schema drops old data so import doesn't hit UniqueViolation."""
+    def test_schema_preserves_data_on_rerun(self) -> None:
+        """Re-running ``create_database.sql`` against a populated DB must
+        be a no-op on existing rows. Pre-#242 the file had a DROP block
+        that wiped everything; Option B moved the DROPs to
+        ``drop_core_tables.sql`` (invoked only by ``--fresh-rebuild``) so
+        LML-back-patched ``release.artwork_url`` survives across rebuilds.
+        Drift here would silently re-break preservation."""
         conn = psycopg.connect(self.db_url, autocommit=True)
 
         # Insert data as if a previous pipeline run completed
@@ -207,16 +212,17 @@ class TestCreateDatabase:
             cur.execute("SELECT count(*) FROM release")
             assert cur.fetchone()[0] == 1
 
-        # Re-run schema (simulates a fresh pipeline run)
+        # Re-run create_database.sql (simulates the default incremental
+        # rebuild path — every CREATE is IF NOT EXISTS).
         with conn.cursor() as cur:
             cur.execute(SCHEMA_DIR.joinpath("create_database.sql").read_text())
 
-        # Tables should be empty — no stale data to conflict with new imports
+        # Tables should still have the seeded rows — the file is idempotent.
         with conn.cursor() as cur:
             cur.execute("SELECT count(*) FROM release")
-            assert cur.fetchone()[0] == 0
+            assert cur.fetchone()[0] == 1
             cur.execute("SELECT count(*) FROM release_artist")
-            assert cur.fetchone()[0] == 0
+            assert cur.fetchone()[0] == 1
 
         conn.close()
 
@@ -589,3 +595,78 @@ class TestSchemaProductionOrdering:
                 assert cur.fetchone()[0] == "Nilufer Yanya"
         finally:
             conn.close()
+
+
+class TestSchemaIdempotenceDriftGuards:
+    """Pure-text drift guards for the WXYC/discogs-etl#242 schema split.
+
+    ``schema/create_database.sql`` must be idempotent (safe to apply against
+    a populated DB) so the default rebuild path preserves LML-back-patched
+    artwork. ``schema/drop_core_tables.sql`` exists as the explicit-wipe
+    escape hatch invoked only by ``--fresh-rebuild``. Both files are
+    operator-visible and silent reverts would re-break artwork
+    preservation, so we pin their contents."""
+
+    def test_create_database_sql_uses_if_not_exists(self) -> None:
+        """Every ``CREATE TABLE`` in ``schema/create_database.sql`` must be
+        ``CREATE TABLE IF NOT EXISTS``. A bare ``CREATE TABLE`` would
+        fail on second-and-later rebuilds (table already exists) — but
+        more importantly it signals the file has been reverted toward
+        the pre-#242 drop-and-recreate convention, which silently
+        wipes ``release.artwork_url`` + ``release.artwork_checked_at``
+        on every rebuild and re-breaks the LML#221 preservation
+        guarantee."""
+        sql_text = SCHEMA_DIR.joinpath("create_database.sql").read_text()
+        bare_creates: list[str] = []
+        for raw in sql_text.splitlines():
+            line = raw.strip()
+            if line.startswith("CREATE TABLE ") and not line.startswith(
+                "CREATE TABLE IF NOT EXISTS"
+            ):
+                bare_creates.append(raw)
+        assert bare_creates == [], (
+            "create_database.sql has bare CREATE TABLE statements: "
+            f"{bare_creates}. WXYC/discogs-etl#242 requires every CREATE "
+            "TABLE here to be IF NOT EXISTS so the file is safe to apply "
+            "against a populated DB. The explicit-wipe path lives in "
+            "schema/drop_core_tables.sql."
+        )
+
+    def test_drop_core_tables_sql_covers_full_release_subgraph(self) -> None:
+        """Every table that the pre-#242 ``create_database.sql`` dropped
+        must have a DROP TABLE entry in ``schema/drop_core_tables.sql``.
+        Without this, ``--fresh-rebuild`` would silently leave stale
+        rows under the freshly-CREATE-IF-NOT-EXISTS tables and operators
+        relying on the flag for cache-corruption recovery would see
+        unexpected data."""
+        drop_sql = SCHEMA_DIR.joinpath("drop_core_tables.sql").read_text()
+        expected_dropped = [
+            "cache_metadata",
+            "master_artist",
+            "master",
+            "artist_url",
+            "artist_member",
+            "artist_name_variation",
+            "artist_alias",
+            "artist",
+            "release_video",
+            "release_track_artist",
+            "release_track",
+            "release_style",
+            "release_genre",
+            "release_label",
+            "release_artist",
+            "release",
+            "lookup_negative",
+            "wxyc_library",
+        ]
+        missing = [
+            table
+            for table in expected_dropped
+            if f"DROP TABLE IF EXISTS {table} CASCADE" not in drop_sql
+        ]
+        assert missing == [], (
+            f"drop_core_tables.sql is missing DROPs for: {missing}. These "
+            "tables were dropped by pre-#242 create_database.sql and must "
+            "still be dropped under --fresh-rebuild for parity."
+        )

--- a/tests/integration/test_verify_cache_columns.py
+++ b/tests/integration/test_verify_cache_columns.py
@@ -61,9 +61,7 @@ def _parse_create_table_columns(table_name: str) -> list[str]:
     # WXYC/discogs-etl#242 flipped these to ``CREATE TABLE IF NOT EXISTS``;
     # tolerate both forms so the regex doesn't silently miss the body.
     pattern = re.compile(
-        r"CREATE TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?"
-        + re.escape(table_name)
-        + r"\s*\((.*?)\)\s*;",
+        r"CREATE TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?" + re.escape(table_name) + r"\s*\((.*?)\)\s*;",
         re.DOTALL | re.IGNORECASE,
     )
     match = pattern.search(sql)

--- a/tests/integration/test_verify_cache_columns.py
+++ b/tests/integration/test_verify_cache_columns.py
@@ -58,8 +58,12 @@ def _parse_create_table_columns(table_name: str) -> list[str]:
     catches that case as a loud failure instead of a silently-wrong column list.
     """
     sql = SCHEMA_DIR.joinpath("create_database.sql").read_text()
+    # WXYC/discogs-etl#242 flipped these to ``CREATE TABLE IF NOT EXISTS``;
+    # tolerate both forms so the regex doesn't silently miss the body.
     pattern = re.compile(
-        r"CREATE TABLE\s+" + re.escape(table_name) + r"\s*\((.*?)\)\s*;",
+        r"CREATE TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?"
+        + re.escape(table_name)
+        + r"\s*\((.*?)\)\s*;",
         re.DOTALL | re.IGNORECASE,
     )
     match = pattern.search(sql)

--- a/tests/unit/test_import_csv.py
+++ b/tests/unit/test_import_csv.py
@@ -727,7 +727,12 @@ class TestMainArgParsing:
         assert call_args[0][2] == TABLES
 
     def test_base_only_mode_calls_parallel(self, tmp_path) -> None:
-        """--base-only mode calls _import_tables_parallel with base tables."""
+        """``--base-only`` (default, no --truncate-existing): the release
+        parent is loaded via ``import_release_via_upsert`` to preserve
+        LML-back-patched artwork columns (WXYC/discogs-etl#242), then
+        children are COPYed via ``_import_tables_parallel`` with empty
+        ``parent_tables`` (release is already in place from the upsert).
+        """
         from unittest.mock import MagicMock, patch
 
         csv_dir = tmp_path / "csv"
@@ -742,6 +747,7 @@ class TestMainArgParsing:
             ),
             patch.object(_ic.psycopg, "connect", return_value=mock_conn),
             patch.object(_ic, "_import_tables_parallel", return_value=100) as mock_parallel,
+            patch.object(_ic, "import_release_via_upsert", return_value=50) as mock_upsert,
             patch.object(_ic, "import_artwork", return_value=10),
             patch.object(_ic, "populate_release_year", return_value=50),
             patch.object(_ic, "populate_cache_metadata", return_value=50),
@@ -750,11 +756,59 @@ class TestMainArgParsing:
         ):
             _ic.main()
 
+        mock_upsert.assert_called_once()
+        upsert_args = mock_upsert.call_args
+        assert upsert_args[0][1] == csv_dir
+
         mock_parallel.assert_called_once()
         call_args = mock_parallel.call_args
         assert call_args[0][0] == "postgresql:///test"
         assert call_args[0][1] == csv_dir
-        # Parent tables are BASE_TABLES[:1], child tables are BASE_TABLES[1:]
+        # Default incremental path: release is loaded by import_release_via_upsert
+        # (so parent_tables is empty); children COPY in parallel as before.
+        assert call_args[1]["parent_tables"] == []
+        assert call_args[1]["child_tables"] == BASE_TABLES[1:]
+
+    def test_base_only_with_truncate_existing_uses_legacy_parallel(self, tmp_path) -> None:
+        """``--base-only --truncate-existing`` (operator-visible escape
+        hatch): TRUNCATE wiped release, so the legacy straight-COPY path
+        runs — release goes through ``_import_tables_parallel`` as the
+        sole parent, and ``import_release_via_upsert`` is NOT called.
+        Pins the contract that --truncate-existing's wipe-and-reload
+        semantics survive Option B."""
+        from unittest.mock import MagicMock, patch
+
+        csv_dir = tmp_path / "csv"
+        csv_dir.mkdir()
+
+        mock_conn = MagicMock()
+
+        with (
+            patch(
+                "sys.argv",
+                [
+                    "import_csv.py",
+                    "--base-only",
+                    "--truncate-existing",
+                    str(csv_dir),
+                    "postgresql:///test",
+                ],
+            ),
+            patch.object(_ic.psycopg, "connect", return_value=mock_conn),
+            patch.object(_ic, "_import_tables_parallel", return_value=100) as mock_parallel,
+            patch.object(_ic, "import_release_via_upsert") as mock_upsert,
+            patch.object(_ic, "_truncate_tables"),
+            patch.object(_ic, "import_artwork", return_value=10),
+            patch.object(_ic, "populate_release_year", return_value=50),
+            patch.object(_ic, "populate_cache_metadata", return_value=50),
+            patch.object(_ic, "create_track_count_table", return_value=20),
+            patch.object(_ic, "import_artist_details", return_value=20),
+        ):
+            _ic.main()
+
+        mock_upsert.assert_not_called()
+        mock_parallel.assert_called_once()
+        call_args = mock_parallel.call_args
         assert call_args[1]["parent_tables"] == BASE_TABLES[:1]
         assert call_args[1]["child_tables"] == BASE_TABLES[1:]
 

--- a/tests/unit/test_run_pipeline.py
+++ b/tests/unit/test_run_pipeline.py
@@ -544,11 +544,12 @@ class TestPipelineTables:
         schema_sql = (
             Path(__file__).parent.parent.parent / "schema" / "create_database.sql"
         ).read_text()
-        # Find every "CREATE TABLE <name> (" header followed by a body
-        # containing "REFERENCES release(id)". This is intentionally
-        # forgiving of whitespace.
+        # Find every "CREATE TABLE [IF NOT EXISTS] <name> (" header
+        # followed by a body containing "REFERENCES release(id)". The
+        # ``IF NOT EXISTS`` form is required by WXYC/discogs-etl#242.
+        # Forgiving of whitespace.
         table_pattern = re.compile(
-            r"CREATE\s+TABLE\s+(\w+)\s*\((.*?)\n\);",
+            r"CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?(\w+)\s*\((.*?)\n\);",
             re.DOTALL | re.IGNORECASE,
         )
         referrers: set[str] = set()


### PR DESCRIPTION
## Summary

- Make the monthly rebuild idempotent against `release.artwork_url` + `release.artwork_checked_at`: prior LML back-patches survive the next rebuild (Option B per [WXYC/wiki#75](https://github.com/WXYC/wiki/pull/75)).
- `schema/create_database.sql` becomes `CREATE TABLE IF NOT EXISTS`-only; DROPs moved to new `schema/drop_core_tables.sql` invoked only by `--fresh-rebuild`.
- `scripts/import_csv.py:import_release_via_upsert` reloads `release` via staging-table COPY + UPSERT with `artwork_url` + `artwork_checked_at` excluded from the SET list. Releases not in the new dump are pruned via `DELETE … WHERE id NOT IN staging`; FK `ON DELETE CASCADE` removes their child rows. Child tables of `release` are TRUNCATEd before re-COPY so duplicates don't accumulate.
- `scripts/import_csv.py:import_artwork` also stamps `artwork_checked_at = now()` when setting `artwork_url` from the dump — matches the semantics LML#423 applies in `write_release`.

## Semantics matrix

| Flag | Schema | Data | LML back-patches |
| --- | --- | --- | --- |
| (default) | preserved | upsert; children TRUNCATE+re-COPY | preserved |
| `--truncate-existing` | preserved | wiped via TRUNCATE | wiped |
| `--fresh-rebuild` | dropped + recreated | wiped via DROP CASCADE | wiped |

## Test plan

- [x] `TestImportArtworkPreservation` (5-case acceptance grid)
- [x] `tests/integration/test_rebuild_idempotent.py` (`--truncate-existing` wipes; `--fresh-rebuild` drops + preserves `alembic_version`)
- [x] `TestSchemaIdempotenceDriftGuards` (static-text guards on the schema split)
- [x] Existing `test_schema_clears_stale_data_on_rerun` inverted → `test_schema_preserves_data_on_rerun` to pin the new preservation contract
- [x] Full integration sweep: 289 passed (no regressions in `test_dedup`, `test_prune`, `test_copy_to_target`, `test_unlogged_tables`, etc.)
- [x] Full unit sweep: 748 passed
- [x] `ruff check` + `ruff format --check` clean

## Related

- Plan: [WXYC/wiki#75](https://github.com/WXYC/wiki/pull/75) (`plans/discogs-etl-242-rebuild-coalesce.md`)
- Prereqs (already on `main`): #239 (`artwork_checked_at` column + partial index, `ad5c267`), #240 (import_artwork parity tests, `0a1e355`)
- Companion LML change: [WXYC/library-metadata-lookup#423](https://github.com/WXYC/library-metadata-lookup/issues/423) (predicate honors `artwork_checked_at`; `write_release` stamps `now()`) — merged 2026-05-29
- Follow-ups: re-run the monthly cache rebuild against this branch's schema in place; then #241 (NULL-share monitoring); then LML#221 top-up drain

Closes #242.