### PR TITLE
ci: switch ephemeral-rebuild deploy to OIDC

### DIFF
--- a/.github/workflows/deploy-ephemeral-rebuild.yml
+++ b/.github/workflows/deploy-ephemeral-rebuild.yml
@@ -53,8 +53,7 @@ jobs:
           use-installer: true
       - uses: aws-actions/configure-aws-credentials@v6
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ vars.AWS_ROLE_TO_ASSUME }}
           aws-region: ${{ vars.AWS_REGION || 'us-east-1' }}
       - name: SAM build
         working-directory: infra/ephemeral-rebuild


### PR DESCRIPTION
Closes #248.

## Summary

- Workflow now assumes \`vars.AWS_ROLE_TO_ASSUME\` instead of failing on missing static keys.
- AWS-side state (OIDC provider + IAM role with trust restricted to \`repo:WXYC/discogs-etl:ref:refs/heads/main\`) is already in place in account 503977661500.
- Repo variable \`AWS_ROLE_TO_ASSUME\` is set to the role ARN.

## Test plan

- [ ] CI lint+typecheck+test green.
- [ ] After merge: workflow_dispatch \`Deploy Ephemeral Rebuild Stack\` against \`main\` succeeds end-to-end (\`sam build\` + \`sam deploy\`).
- [ ] \`aws cloudformation describe-stacks --stack-name wxyc-discogs-rebuild\` returns \`CREATE_COMPLETE\`.
- [ ] Follow-up: invoke \`discogs-rebuild-launcher\` Lambda for the first ephemeral rebuild run.