### PR TITLE
fix(rebuild): drop --truncate-existing from rebuild-cache.sh (#252)

### DIFF
--- a/scripts/rebuild-cache.sh
+++ b/scripts/rebuild-cache.sh
@@ -218,17 +218,18 @@ curl -fL --continue-at - --retry 5 --retry-delay 30 --retry-all-errors \
 echo "    download complete ($(du -h "$WORK_DIR/releases.xml.gz" | cut -f1))"
 
 echo "[$(date -u +%H:%M:%SZ)] start pipeline"
-# --truncate-existing wipes the cache tables before COPY so a rerun after a
-# prior failed rebuild doesn't hit a duplicate-key violation on the first
-# table (the failure mode from WXYC/discogs-etl#188's 2026-05-13 run). The
-# flag is a no-op on a freshly-stamped DB, so it's safe to keep on
-# unconditionally — the only cost is ~1s of TRUNCATE DDL on empty tables.
-# Preserves entity.identity and alembic_version.
+# Default mode (no --truncate-existing): the import path is idempotent via
+# `import_release_via_upsert` (staging-table COPY + UPSERT excluding the
+# artwork columns from the SET list), so a rerun against a populated DB
+# preserves LML's runtime artwork back-patches. Adding --truncate-existing
+# here would force the legacy destructive path and wipe those back-patches —
+# the failure mode WXYC/discogs-etl#252 documents from the 2026-05-30 run.
+# The duplicate-key failure mode from #188 that originally motivated the
+# flag is no longer reachable on the default path (ON CONFLICT skips it).
 python "$REPO_DIR/scripts/run_pipeline.py" \
     --xml "$WORK_DIR/releases.xml.gz" \
     --xml-type releases \
-    --library-db "$WORK_DIR/library.db" \
-    --truncate-existing
+    --library-db "$WORK_DIR/library.db"
 
 # ---------------------------------------------------------------------------
 # 6. Drift watchdog — same library.db the pipeline just filtered against

--- a/tests/unit/test_rebuild_cache_flags.py
+++ b/tests/unit/test_rebuild_cache_flags.py
@@ -1,0 +1,59 @@
+"""Pin the flags `scripts/rebuild-cache.sh` passes to `run_pipeline.py`.
+
+The monthly rebuild's pipeline invocation is operator config that's easy to
+diverge from the in-tree semantics. Two pins in this file:
+
+1. `--truncate-existing` must NOT be in the invocation. Per #252:
+   the flag forces the legacy destructive code path, defeating the
+   artwork-preservation upsert added in #242. The first prod rebuild
+   after #242 wiped the 46,047 LML-back-patched artwork URLs because the
+   script still passed this flag. Pin the absence.
+
+2. `--library-db` and `--xml` must be in the invocation. These are the
+   load-bearing arguments — without them the run_pipeline.py call goes
+   off the canonical path entirely. (Defensive pin to catch refactors.)
+"""
+
+from __future__ import annotations
+
+import shlex
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "rebuild-cache.sh"
+
+
+def _run_pipeline_invocation_tokens() -> list[str]:
+    """Return the tokens of the ``run_pipeline.py`` invocation in rebuild-cache.sh.
+
+    Joins continuation lines (``\\``) so a multi-line invocation parses as a
+    single shell command, then tokenizes via shlex so quoted arguments and
+    bare flags are handled the same way bash would handle them.
+    """
+    source = SCRIPT_PATH.read_text()
+    # Strip backslash-continuations so the call spans one logical line.
+    joined = source.replace("\\\n", " ")
+    for line in joined.splitlines():
+        stripped = line.lstrip()
+        if "scripts/run_pipeline.py" in stripped and stripped.startswith("python"):
+            return shlex.split(stripped)
+    raise AssertionError("Could not find run_pipeline.py invocation in rebuild-cache.sh")
+
+
+class TestRebuildCacheFlags:
+    def test_does_not_pass_truncate_existing(self) -> None:
+        # See #252: passing --truncate-existing defeats #242's artwork
+        # preservation by forcing the destructive code path. The default
+        # is the upsert path; the flag must stay off.
+        tokens = _run_pipeline_invocation_tokens()
+        assert "--truncate-existing" not in tokens, (
+            "rebuild-cache.sh must not pass --truncate-existing; see #252 / #242."
+        )
+
+    def test_passes_xml_dump_path(self) -> None:
+        tokens = _run_pipeline_invocation_tokens()
+        assert "--xml" in tokens, "rebuild-cache.sh must pass --xml to run_pipeline.py."
+
+    def test_passes_library_db_path(self) -> None:
+        tokens = _run_pipeline_invocation_tokens()
+        assert "--library-db" in tokens, "rebuild-cache.sh must pass --library-db."


### PR DESCRIPTION
Closes #252.

## Summary

- Remove \`--truncate-existing\` from \`scripts/rebuild-cache.sh\`'s pipeline invocation. Per #242's semantics matrix, the default path (no flag) is the artwork-preserving \`import_release_via_upsert\` route. The flag forced the legacy destructive path and wiped LML's runtime back-patches.
- Update the surrounding comment block to document why the flag stays OFF: ON CONFLICT in the upsert path subsumes the duplicate-key failure mode #188 originally motivated the flag for.
- New regression test \`tests/unit/test_rebuild_cache_flags.py\` parses the \`run_pipeline.py\` invocation in the script and pins the absence of \`--truncate-existing\` (plus the presence of \`--xml\` and \`--library-db\` as a defensive guardrail).

## Reproduction this PR closes

First post-#242 production rebuild (2026-05-30T04:49Z, instance \`i-0dd36ef797a7c78a0\`):

| | Before rebuild | After rebuild |
|---|---|---|
| \`release\` rows | 84,405 | 80,575 |
| \`artwork_url IS NOT NULL\` | 44,974 | 71 |
| \`api_fetch\` in \`cache_metadata\` | 46,047 | 0 |

Bootstrap log recorded \`--truncate-existing: TRUNCATE 16 cache tables\`. Recovered from a pre-rebuild \`pg_dump\`.

## Doesn't fix

This PR is necessary but not sufficient for #34 (re-run rebuild with new schema). A separate dedup race-condition bug — \`cache_metadata.cached_at\` NULL-violation between table swap and constraint addition — also fails the rebuild and needs a companion PR before \`#34\` can succeed end-to-end.

## Test plan

- [x] \`pytest tests/unit/test_rebuild_cache_flags.py\` green (3/3, including red-phase confirmation against the bug).
- [x] \`ruff check\` + \`ruff format --check\` + \`shellcheck\` clean.
- [ ] CI green on lint, test, pg, marker-sync.
- [ ] After merge: dedup-race fix lands, then re-trigger ephemeral rebuild; \`artwork_url IS NOT NULL\` count survives.