### PR TITLE
fix(dedup): seal cache_metadata.cached_at race window

### DIFF
--- a/scripts/dedup_releases.py
+++ b/scripts/dedup_releases.py
@@ -349,6 +349,17 @@ DEDUP_TABLES: list[tuple[str, str, str, str]] = [
 ]
 
 
+# Column DEFAULTs to re-apply on each new_X table *before* swap_tables() makes
+# it live. CTAS strips DEFAULTs along with NOT NULL/CHECK; restoring DEFAULT
+# *before* the swap closes the race window where an LML cache-miss insert
+# (which omits cached_at) could land NULL between the swap and the
+# Level-2 SET DEFAULT, then trip the Level-2 SET NOT NULL. See #254.
+PRE_SWAP_COLUMN_DEFAULTS: dict[str, dict[str, str]] = {
+    "new_cache_metadata": {"cached_at": "now()"},
+    "new_release_artist": {"extra": "0"},
+}
+
+
 def copy_table(conn, old_table: str, new_table: str, columns: str, id_col: str) -> int:
     """Copy rows NOT in dedup_delete_ids to a new table.
 
@@ -366,6 +377,8 @@ def copy_table(conn, old_table: str, new_table: str, columns: str, id_col: str) 
                 SELECT 1 FROM dedup_delete_ids d WHERE d.release_id = t.{id_col}
             )
         """)
+        for column, default_sql in PRE_SWAP_COLUMN_DEFAULTS.get(new_table, {}).items():
+            cur.execute(f"ALTER TABLE {new_table} ALTER COLUMN {column} SET DEFAULT {default_sql}")
         cur.execute(f"SELECT count(*) FROM {new_table}")
         count = int(cur.fetchone()[0])
     conn.commit()
@@ -476,6 +489,20 @@ def add_base_constraints_and_indexes(conn, db_url: str | None = None) -> None:
         "Level 1.5: Clean orphan child rows before FK validation",
     )
 
+    # Level 1.75: Backfill race-window NULLs before SET NOT NULL runs.
+    #
+    # ``PRE_SWAP_COLUMN_DEFAULTS`` is supposed to seal the race by setting
+    # the DEFAULT on ``new_X`` before swap_tables(), so any LML insert that
+    # lands after the swap inherits ``cached_at = now()``. This UPDATE is
+    # the belt-and-suspenders: any row that slipped through (e.g. an LML
+    # transaction that started before the pre-swap ALTER landed and
+    # committed against the renamed table) gets a non-NULL stamp before
+    # Level-2 SET NOT NULL would reject it. See #254.
+    _exec_one(
+        db_url,
+        "UPDATE cache_metadata SET cached_at = now() WHERE cached_at IS NULL",
+    )
+
     # Level 2: FK constraints + PK on cache_metadata + FK indexes + NOT NULL
     # restoration (parallel).
     #
@@ -489,8 +516,12 @@ def add_base_constraints_and_indexes(conn, db_url: str | None = None) -> None:
     # carries column types forward but not NOT NULL / DEFAULT / CHECK. The
     # schema in ``schema/create_database.sql`` declares the data columns
     # below as NOT NULL; without explicit re-application every monthly
-    # rebuild ships a discogs-cache where those constraints are gone. Pinned
-    # by ``tests/integration/test_copy_swap_preserves_not_null.py``.
+    # rebuild ships a discogs-cache where those constraints are gone. The
+    # corresponding DEFAULTs are re-applied earlier — in copy_table() via
+    # ``PRE_SWAP_COLUMN_DEFAULTS``, before swap_tables() makes the new
+    # table live — so LML's cache-miss INSERT (which omits ``cached_at``)
+    # never lands a NULL during the swap window. Pinned by
+    # ``tests/integration/test_copy_swap_preserves_not_null.py``.
     _exec_parallel(
         [
             "ALTER TABLE release_artist ADD CONSTRAINT fk_release_artist_release "
@@ -519,16 +550,8 @@ def add_base_constraints_and_indexes(conn, db_url: str | None = None) -> None:
             "ALTER TABLE release_style ALTER COLUMN style SET NOT NULL",
             "ALTER TABLE cache_metadata ALTER COLUMN cached_at SET NOT NULL",
             "ALTER TABLE cache_metadata ALTER COLUMN source SET NOT NULL",
-            # ``cache_metadata.cached_at`` DEFAULT is load-bearing: LML's
-            # cache-miss INSERT omits the column and relies on the DEFAULT
-            # to avoid the NOT NULL re-applied above. Without restoration,
-            # the next cache miss after a rebuild would fail with a NOT
-            # NULL violation. ``release_artist.extra`` DEFAULT is schema
-            # invariant (nullable column) but restored for consistency.
-            "ALTER TABLE cache_metadata ALTER COLUMN cached_at SET DEFAULT now()",
-            "ALTER TABLE release_artist ALTER COLUMN extra SET DEFAULT 0",
         ],
-        "Level 2: FK constraints + FK indexes + NOT NULL + DEFAULT restoration",
+        "Level 2: FK constraints + FK indexes + NOT NULL",
     )
 
     # Level 3: GIN trigram indexes + cache metadata indexes (parallel)

--- a/tests/integration/test_copy_swap_preserves_not_null.py
+++ b/tests/integration/test_copy_swap_preserves_not_null.py
@@ -303,6 +303,129 @@ class TestDedupCopySwapPreservesNotNull:
         )
 
 
+_RACE_INSERT_RELEASE_ID = 4
+
+
+def _seed_extra_release_for_race(db_url: str) -> None:
+    """Add a `release` row with no `cache_metadata` row, ready for the race INSERT.
+
+    Picks an id (`_RACE_INSERT_RELEASE_ID`) outside the seeded set so the post-swap
+    race INSERT into `cache_metadata` (which still has no PK at that point) can't
+    collide with a sibling row, and so the FK validation against `release` passes
+    when Level 2 runs.
+    """
+    conn = psycopg.connect(db_url, autocommit=True)
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                "INSERT INTO release (id, title, master_id, format, country) "
+                "VALUES (%s, %s, %s, %s, %s)",
+                (_RACE_INSERT_RELEASE_ID, "Moon Pix", 300, "LP", "US"),
+            )
+    finally:
+        conn.close()
+
+
+def _run_dedup_swap_with_race_insert(db_url: str) -> None:
+    """Exercise dedup but inject an LML-style INSERT in the race window.
+
+    Mirrors `_run_dedup_swap` but between `swap_tables()` and
+    `add_base_constraints_and_indexes()` issues:
+
+        INSERT INTO cache_metadata (release_id, source) VALUES (...)
+
+    which is what library-metadata-lookup's cache-miss path does in steady
+    state — relying on the table DEFAULT to supply `cached_at = now()`. If
+    CTAS strips the DEFAULT and the dedup path doesn't restore it before the
+    swap, the insert lands with `cached_at = NULL`, and the subsequent
+    `ALTER COLUMN cached_at SET NOT NULL` fails with NotNullViolation —
+    aborting the entire rebuild. See WXYC/discogs-etl#254.
+    """
+    conn = psycopg.connect(db_url, autocommit=True)
+    try:
+        with conn.cursor() as cur:
+            cur.execute("CREATE UNLOGGED TABLE dedup_delete_ids (release_id integer PRIMARY KEY)")
+            cur.execute("INSERT INTO dedup_delete_ids VALUES (3)")
+
+        for old, new, cols, id_col in _dd.DEDUP_TABLES:
+            _dd.copy_table(conn, old, new, cols, id_col)
+
+        with conn.cursor() as cur:
+            for stmt in (
+                "ALTER TABLE release_artist DROP CONSTRAINT IF EXISTS fk_release_artist_release",
+                "ALTER TABLE release_label DROP CONSTRAINT IF EXISTS fk_release_label_release",
+                "ALTER TABLE release_genre DROP CONSTRAINT IF EXISTS fk_release_genre_release",
+                "ALTER TABLE release_style DROP CONSTRAINT IF EXISTS fk_release_style_release",
+                "ALTER TABLE cache_metadata DROP CONSTRAINT IF EXISTS fk_cache_metadata_release",
+            ):
+                cur.execute(stmt)
+
+        for old, new, _, _ in _dd.DEDUP_TABLES:
+            _dd.swap_tables(conn, old, new)
+
+        # Race insert — what LML does in steady state. Omits cached_at,
+        # relying on the table DEFAULT. The release_id is one that's already
+        # in `release` (seeded above) so Level 1.5 orphan cleanup leaves it
+        # alone; and it's not yet in `cache_metadata` so there's no clash
+        # when Level 2 adds the PK on release_id.
+        with conn.cursor() as cur:
+            cur.execute(
+                "INSERT INTO cache_metadata (release_id, source) VALUES (%s, %s)",
+                (_RACE_INSERT_RELEASE_ID, "api_fetch"),
+            )
+
+        _dd.add_base_constraints_and_indexes(conn, db_url=db_url)
+    finally:
+        conn.close()
+
+
+class TestDedupCopySwapToleratesRaceWindowInsert:
+    """The race-window LML insert survives add_base_constraints_and_indexes.
+
+    Pin for [#254](https://github.com/WXYC/discogs-etl/issues/254). The 2026-05-30
+    rebuild failed when an LML cache-miss INSERT landed between `swap_tables()`
+    and `ALTER COLUMN cached_at SET DEFAULT now()`, writing NULL `cached_at`
+    and tripping the subsequent SET NOT NULL.
+
+    Fix is structural — apply DEFAULTs on the NEW table inside `copy_table()`
+    so the live table already has the DEFAULT at the moment of swap. The
+    sibling pin `TestDedupCopySwapPreservesNotNull` covers end-state; this
+    one covers the race window itself.
+    """
+
+    @pytest.fixture(autouse=True, scope="class")
+    def _set_up_and_dedup(self, db_url):
+        self.__class__._db_url = db_url
+        _seed_minimal_fixture(db_url)
+        _seed_extra_release_for_race(db_url)
+        _run_dedup_swap_with_race_insert(db_url)
+
+    @pytest.fixture(autouse=True)
+    def _store_url(self):
+        self.db_url = self.__class__._db_url
+
+    def test_race_insert_has_non_null_cached_at(self):
+        """The race-window INSERT gets a non-NULL cached_at via the table DEFAULT."""
+        conn = psycopg.connect(self.db_url, autocommit=True)
+        try:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "SELECT cached_at FROM cache_metadata WHERE release_id = %s",
+                    (_RACE_INSERT_RELEASE_ID,),
+                )
+                row = cur.fetchone()
+        finally:
+            conn.close()
+
+        assert row is not None, "race-window INSERT row missing from cache_metadata"
+        assert row[0] is not None, (
+            "Race-window INSERT landed with NULL cached_at. CTAS strips the "
+            "DEFAULT on cache_metadata.cached_at; copy_table() must re-apply "
+            "the DEFAULT on new_cache_metadata before swap_tables() so the "
+            "live table has the DEFAULT at the moment of swap."
+        )
+
+
 class TestPruneCopySwapPreservesNotNull:
     """verify_cache.prune_releases_copy_swap re-applies NOT NULL on schema-required columns."""
 


### PR DESCRIPTION
## Summary

- Restore CTAS-stripped DEFAULTs on `new_X` tables inside `copy_table()` so they're live at the moment `swap_tables()` swaps them in — closes the race window where LML's cache-miss `INSERT (release_id, source)` lands `cached_at = NULL` and trips Level-2 `SET NOT NULL`.
- Add a Level 1.75 backfill `UPDATE cache_metadata SET cached_at = now() WHERE cached_at IS NULL` as belt-and-suspenders.
- Drop the now-redundant `SET DEFAULT` statements from Level 2's parallel batch.
- New `TestDedupCopySwapToleratesRaceWindowInsert` pin reproduces the failure path by injecting an LML-style insert between swap and constraint application.

Closes #254.

## Test plan

- [x] `pytest tests/integration/test_copy_swap_preserves_not_null.py -m pg` — 21 passed
- [x] `pytest tests/integration/test_dedup.py tests/integration/test_copy_swap_preserves_not_null.py tests/integration/test_verify_cache_columns.py -m pg` — 68 passed
- [x] `pytest -m "pg or not slow"` — 1151 passed, 22 skipped, 1 xfailed, no regressions
- [x] `ruff check` + `ruff format --check` clean
- [ ] After merge: re-trigger the ephemeral rebuild and verify it makes it past dedup
