### PR TITLE
feat(topup): accept OAuth consumer pair alongside personal token

### DIFF
--- a/docs/topup-artwork-runbook.md
+++ b/docs/topup-artwork-runbook.md
@@ -15,8 +15,17 @@ Environment:
 | Variable | Required | Notes |
 |---|---|---|
 | `DATABASE_URL_DISCOGS` | yes | Cache PG URL. `--database-url` overrides. |
-| `DISCOGS_TOKEN` | yes | Same token LML uses. `DISCOGS_API_TOKEN` also accepted. |
+| Discogs auth (one shape) | yes | See below — either personal token *or* OAuth consumer pair. |
 | `SENTRY_DSN` | optional | Stderr logger works without it. |
+
+Discogs auth accepts either shape (matches LML's `DiscogsService`):
+
+| Variable(s) | Shape | Source |
+|---|---|---|
+| `DISCOGS_TOKEN` (or legacy `DISCOGS_API_TOKEN`) | Personal access token | LML's runtime env on Railway |
+| `DISCOGS_API_KEY` + `DISCOGS_API_SECRET` | OAuth consumer pair | `WXYC/secrets/secrets.txt` (look for the `_V2_5` variant if present) |
+
+If both are exported the token wins. The script fails fast at startup if neither is set.
 
 The script depends only on `psycopg`, stdlib `urllib`, and `lib.observability` — installable from `pip install -e .`.
 

--- a/scripts/topup_artwork.py
+++ b/scripts/topup_artwork.py
@@ -13,12 +13,27 @@ a full sequential read. This script walks that tail, asks Discogs
 — stamping ``artwork_checked_at`` even when no image exists collapses the
 "never asked vs asked-but-imageless" ambiguity at the schema level.
 
+Auth
+----
+
+Accepts either Discogs auth shape (matches LML's ``DiscogsService``):
+
+* Personal access token — ``DISCOGS_TOKEN`` (or legacy ``DISCOGS_API_TOKEN``).
+* OAuth consumer pair — ``DISCOGS_API_KEY`` + ``DISCOGS_API_SECRET``.
+
+If both are exported the token wins. The WXYC shared secrets file ships the
+OAuth-pair shape; LML's runtime env on Railway carries the personal token.
+Using a different shape from LML's runtime gives the drain its own Discogs
+identity (and therefore its own rate-limit quota), which is the design point
+behind the conservative default rate below.
+
 Pacing
 ------
 
-LML's runtime caller shares the same Discogs token + ~60/min ceiling. The
-default ``--rate 10`` rate keeps headroom under LML's running 50/min so the
-drain doesn't trip 429s for live traffic. Off-hours operators can raise it.
+LML's runtime caller pulls against Discogs's ~60/min ceiling per token. The
+default ``--rate 10`` rate keeps headroom under LML's running 50/min when
+this drain shares an identity, and is over-conservative when it doesn't.
+Off-hours operators can raise it.
 
 Idempotence
 -----------
@@ -174,28 +189,57 @@ def write_artwork_result(
 # ---------------------------------------------------------------------------
 
 
+def _build_auth_header(
+    token: str | None,
+    api_key: str | None,
+    api_secret: str | None,
+) -> str:
+    """Return the ``Authorization`` value for the Discogs API.
+
+    Mirrors LML's two-mode selector at
+    ``library-metadata-lookup/discogs/service.py:254``. ``token`` takes
+    precedence over the OAuth pair when both are supplied — matches LML
+    and lets an operator who exports both shapes pick the simpler one
+    without surprises.
+    """
+    if token:
+        return f"Discogs token={token}"
+    if api_key and api_secret:
+        return f"Discogs key={api_key}, secret={api_secret}"
+    if api_key or api_secret:
+        raise ValueError("OAuth-pair auth requires both api_key and api_secret; got only one")
+    raise ValueError("Provide either token or api_key + api_secret")
+
+
 def make_discogs_client(
-    token: str,
+    token: str | None = None,
     *,
+    api_key: str | None = None,
+    api_secret: str | None = None,
     user_agent: str = DEFAULT_USER_AGENT,
     timeout_s: float = HTTP_TIMEOUT_S,
 ) -> Callable[[int], dict[str, Any] | None]:
     """Return ``fetch(release_id) -> dict | None``.
 
+    Auth modes (mutually exclusive, ``token`` wins when both supplied):
+        * Personal access token: ``make_discogs_client(token="abc")``
+        * OAuth consumer pair: ``make_discogs_client(api_key="k", api_secret="s")``
+
     Return value contract:
         * ``dict`` — Discogs returned 200 with JSON.
-        * ``None`` with sentinel attribute ``deleted=True`` — Discogs
-          returned 404 (release withdrawn). Caller stamps ``artwork_url=NULL``.
+        * ``None`` — Discogs returned 404 (release withdrawn). Caller
+          stamps ``artwork_url=NULL`` + ``artwork_checked_at=now()``.
         * Raises on transient errors so the orchestrator can record a
           ``failed`` count without writing back.
     """
+    auth_header = _build_auth_header(token, api_key, api_secret)
 
     def fetch(release_id: int) -> dict[str, Any] | None:
         url = f"{DISCOGS_API_BASE}/releases/{release_id}"
         req = urllib.request.Request(
             url,
             headers={
-                "Authorization": f"Discogs token={token}",
+                "Authorization": auth_header,
                 "User-Agent": user_agent,
                 "Accept": "application/json",
             },
@@ -339,6 +383,24 @@ def _build_parser() -> argparse.ArgumentParser:
     return p
 
 
+def _credentials_from_env() -> tuple[str | None, str | None, str | None]:
+    """Return ``(token, api_key, api_secret)`` from environment.
+
+    Accepts either auth shape supported by ``make_discogs_client``:
+      * ``DISCOGS_TOKEN`` (or legacy alias ``DISCOGS_API_TOKEN``) — personal token.
+      * ``DISCOGS_API_KEY`` + ``DISCOGS_API_SECRET`` — OAuth consumer pair
+        (matches the WXYC secrets-file shape).
+
+    Precedence is concentrated in ``_build_auth_header`` so this helper
+    stays a thin env reader: it returns whatever is present and lets the
+    factory decide which mode to use.
+    """
+    token = os.environ.get("DISCOGS_TOKEN") or os.environ.get("DISCOGS_API_TOKEN")
+    api_key = os.environ.get("DISCOGS_API_KEY")
+    api_secret = os.environ.get("DISCOGS_API_SECRET")
+    return token, api_key, api_secret
+
+
 def main(argv: list[str] | None = None) -> int:
     init_logger(repo="discogs-etl", tool="discogs-etl topup_artwork")
     args = _build_parser().parse_args(argv)
@@ -347,9 +409,15 @@ def main(argv: list[str] | None = None) -> int:
         logger.error("missing --database-url / $DATABASE_URL_DISCOGS / $DATABASE_URL")
         return 2
 
-    token = os.environ.get("DISCOGS_TOKEN") or os.environ.get("DISCOGS_API_TOKEN")
-    if not token:
-        logger.error("missing $DISCOGS_TOKEN (or $DISCOGS_API_TOKEN)")
+    token, api_key, api_secret = _credentials_from_env()
+    try:
+        client = make_discogs_client(token=token, api_key=api_key, api_secret=api_secret)
+    except ValueError as exc:
+        logger.error(
+            "Discogs credentials missing: %s. "
+            "Export $DISCOGS_TOKEN, or $DISCOGS_API_KEY + $DISCOGS_API_SECRET.",
+            exc,
+        )
         return 2
 
     summary = run_topup(
@@ -358,7 +426,7 @@ def main(argv: list[str] | None = None) -> int:
         rate_per_minute=args.rate,
         batch_size=args.batch_size,
         dry_run=args.dry_run,
-        discogs_client=make_discogs_client(token),
+        discogs_client=client,
     )
     logger.info(
         "drain complete",

--- a/tests/unit/test_topup_artwork.py
+++ b/tests/unit/test_topup_artwork.py
@@ -9,7 +9,13 @@ from __future__ import annotations
 
 import pytest
 
-from scripts.topup_artwork import TokenBucket, extract_artwork_uri
+from scripts.topup_artwork import (
+    TokenBucket,
+    _build_auth_header,
+    _credentials_from_env,
+    extract_artwork_uri,
+    make_discogs_client,
+)
 
 
 class TestExtractArtworkUri:
@@ -90,3 +96,124 @@ class TestTokenBucket:
     def test_rate_per_minute_zero_rejected(self) -> None:
         with pytest.raises(ValueError):
             TokenBucket(rate_per_minute=0)
+
+
+class TestBuildAuthHeader:
+    """``_build_auth_header(token, api_key, api_secret)``.
+
+    Mirrors LML's two-mode auth selector at
+    ``library-metadata-lookup/discogs/service.py:254`` so this script can
+    drink from the same secrets store (the WXYC secrets file ships the
+    OAuth-pair shape; personal access tokens are only in some operators'
+    individual setups).
+    """
+
+    def test_token_only_builds_token_header(self) -> None:
+        assert _build_auth_header(token="abc", api_key=None, api_secret=None) == (
+            "Discogs token=abc"
+        )
+
+    def test_key_and_secret_build_oauth_header(self) -> None:
+        assert _build_auth_header(token=None, api_key="k", api_secret="s") == (
+            "Discogs key=k, secret=s"
+        )
+
+    def test_token_takes_precedence_over_oauth_pair(self) -> None:
+        """When both are supplied, token wins — same precedence rule as LML.
+
+        Matters when an operator exports both env shapes by accident; we
+        deterministically pick one rather than failing closed.
+        """
+        assert _build_auth_header(token="abc", api_key="k", api_secret="s") == ("Discogs token=abc")
+
+    def test_no_credentials_rejected(self) -> None:
+        with pytest.raises(ValueError, match="token.*api_key"):
+            _build_auth_header(token=None, api_key=None, api_secret=None)
+
+    def test_key_without_secret_rejected(self) -> None:
+        """OAuth pair is all-or-nothing — partial config indicates a deploy mistake."""
+        with pytest.raises(ValueError, match="api_key.*api_secret"):
+            _build_auth_header(token=None, api_key="k", api_secret=None)
+
+    def test_secret_without_key_rejected(self) -> None:
+        with pytest.raises(ValueError, match="api_key.*api_secret"):
+            _build_auth_header(token=None, api_key=None, api_secret="s")
+
+
+class TestMakeDiscogsClient:
+    """``make_discogs_client`` wires the auth header into the fetch closure.
+
+    The HTTP layer itself is exercised end-to-end by integration tests via
+    a fake client; these tests assert only the header-construction wiring,
+    which is the part that can silently regress when the function signature
+    changes.
+    """
+
+    def test_token_kwarg_accepted(self) -> None:
+        fetch = make_discogs_client(token="abc")
+        assert callable(fetch)
+
+    def test_oauth_pair_kwargs_accepted(self) -> None:
+        fetch = make_discogs_client(api_key="k", api_secret="s")
+        assert callable(fetch)
+
+    def test_no_credentials_rejected_at_factory(self) -> None:
+        """Surface the auth error at factory time, not at first fetch call."""
+        with pytest.raises(ValueError):
+            make_discogs_client()
+
+
+class TestCredentialsFromEnv:
+    """``_credentials_from_env()`` reads both auth shapes off the environment.
+
+    The WXYC secrets file (``$WXYC_SECRETS_FILE``) ships the OAuth-pair
+    shape — ``DISCOGS_API_KEY`` + ``DISCOGS_API_SECRET`` — so operators
+    sourcing from there don't have a personal-access ``DISCOGS_TOKEN`` to
+    set. This helper picks whichever shape is present, returning the
+    triple ``(token, api_key, api_secret)`` for direct splat into
+    ``make_discogs_client``.
+    """
+
+    def _clear_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        for name in (
+            "DISCOGS_TOKEN",
+            "DISCOGS_API_TOKEN",
+            "DISCOGS_API_KEY",
+            "DISCOGS_API_SECRET",
+        ):
+            monkeypatch.delenv(name, raising=False)
+
+    def test_token_only_env_returns_token(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        self._clear_env(monkeypatch)
+        monkeypatch.setenv("DISCOGS_TOKEN", "abc")
+        assert _credentials_from_env() == ("abc", None, None)
+
+    def test_legacy_api_token_alias(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """``DISCOGS_API_TOKEN`` is the legacy env name for the personal token."""
+        self._clear_env(monkeypatch)
+        monkeypatch.setenv("DISCOGS_API_TOKEN", "abc")
+        assert _credentials_from_env() == ("abc", None, None)
+
+    def test_oauth_pair_env_returns_pair(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        self._clear_env(monkeypatch)
+        monkeypatch.setenv("DISCOGS_API_KEY", "k")
+        monkeypatch.setenv("DISCOGS_API_SECRET", "s")
+        assert _credentials_from_env() == (None, "k", "s")
+
+    def test_both_shapes_returns_both_for_factory_to_resolve(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Don't pre-resolve in the env helper; let ``_build_auth_header`` arbitrate.
+
+        Keeps the helper a thin env reader and concentrates the precedence
+        rule in one place.
+        """
+        self._clear_env(monkeypatch)
+        monkeypatch.setenv("DISCOGS_TOKEN", "abc")
+        monkeypatch.setenv("DISCOGS_API_KEY", "k")
+        monkeypatch.setenv("DISCOGS_API_SECRET", "s")
+        assert _credentials_from_env() == ("abc", "k", "s")
+
+    def test_empty_env_returns_all_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        self._clear_env(monkeypatch)
+        assert _credentials_from_env() == (None, None, None)


### PR DESCRIPTION
## Summary

Mirror LML's two-mode auth selector ([``DiscogsService`` at ``discogs/service.py:254``](https://github.com/WXYC/library-metadata-lookup/blob/main/discogs/service.py#L254)) so the drain can drink from either credential shape:

- ``DISCOGS_TOKEN`` (or legacy alias ``DISCOGS_API_TOKEN``) — personal access token.
- ``DISCOGS_API_KEY`` + ``DISCOGS_API_SECRET`` — OAuth consumer pair.

When both are exported, the token wins — matches LML's precedence rule. The WXYC shared secrets file ships only the OAuth-pair shape; LML's runtime env on Railway carries the personal token. Pre-this-change, an operator sourcing from the secrets file had no way to authenticate the drain without copying LML's token out of band.

There's a hidden benefit: using a different auth shape from LML's runtime gives the drain a distinct Discogs identity (and rate-limit quota), which raises the safe ceiling for the runbook's "off-hours --rate" note.

### Internal shape

- ``_build_auth_header`` is the single point that picks the mode and constructs the header (one place to enforce precedence).
- ``_credentials_from_env`` is a thin env reader; it returns whatever shapes are present without resolving precedence.
- ``make_discogs_client`` now accepts either shape and surfaces validation errors at factory time (not at first fetch).

Closes neither — surfaced organically during the LML#221 drain when the secrets file's OAuth-pair shape proved to be the only available credential.

## Test plan

- [x] ``pytest tests/unit/test_topup_artwork.py`` — 22 passed (8 prior + 6 ``_build_auth_header`` + 3 ``make_discogs_client`` factory + 5 ``_credentials_from_env``)
- [x] ``pytest -m "pg or not slow"`` — 1183 passed, 22 skipped, 1 xfailed, no regressions
- [x] ``ruff check`` + ``ruff format --check`` clean
- [ ] After merge: drop the ``/tmp/topup_drain_local.py`` wrapper, run drains via ``python -m scripts.topup_artwork`` with either env shape

## Related

- PR [#260](https://github.com/WXYC/discogs-etl/pull/260) — original drain script
- [WXYC/library-metadata-lookup#221](https://github.com/WXYC/library-metadata-lookup/issues/221) — the upstream issue this drain serves