### PR TITLE
chore: add Dependabot for pip with wxyc-* grouping

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      wxyc:
+        patterns:
+          - "wxyc-*"


### PR DESCRIPTION
## Summary

Adds `.github/dependabot.yml` so future wxyc-* package bumps (wxyc-etl, wxyc-catalog) land here as weekly grouped PRs instead of having to be chased manually.

The current pin (`wxyc-etl>=0.5.0`, `wxyc-catalog>=0.1.1`) already resolves to the latest at install time, so this is purely about catching forward motion — no version bump in this PR.

## Test plan

- [ ] CI green (no behavior change to runtime code)