### PR TITLE
feat(import-csv): load artist_url.csv into artist_url table

### DIFF
--- a/scripts/import_csv.py
+++ b/scripts/import_csv.py
@@ -218,6 +218,21 @@ ARTIST_TABLES: list[TableConfig] = [
         "transforms": {},
         "unique_key": ["group_artist_id", "member_artist_id"],
     },
+    {
+        # WXYC/discogs-xml-converter#68 extends the converter to extract
+        # Discogs `<urls>` (Wikipedia, official sites, social) into
+        # artist_url.csv. Without this entry the file would silently drop on
+        # the floor at rebuild time, leaving `artist_url` empty and the LML
+        # `cache_service.get_artist_details` join returning no external URLs.
+        # Step 3 of WXYC/library-metadata-lookup#497.
+        "csv_file": "artist_url.csv",
+        "table": "artist_url",
+        "csv_columns": ["artist_id", "url"],
+        "db_columns": ["artist_id", "url"],
+        "required": ["artist_id", "url"],
+        "transforms": {},
+        "unique_key": ["artist_id", "url"],
+    },
 ]
 
 MASTER_TABLES: list[TableConfig] = [

--- a/tests/unit/test_import_csv.py
+++ b/tests/unit/test_import_csv.py
@@ -1124,6 +1124,26 @@ class TestArtistTablesConfig:
         assert "name" in config["required"]
         assert config["unique_key"] == ["artist_id", "name"]
 
+    def test_artist_url_entry_exists(self) -> None:
+        """ARTIST_TABLES must include artist_url.
+
+        WXYC/discogs-xml-converter#68 extends the converter to extract Discogs
+        `<urls>` (Wikipedia, official sites, social) into `artist_url.csv`.
+        Without a matching ARTIST_TABLES entry, the file would silently drop
+        on the floor at rebuild time. Step 3 of WXYC/library-metadata-lookup#497.
+        """
+        config = next((t for t in ARTIST_TABLES if t["table"] == "artist_url"), None)
+        assert config is not None, (
+            "ARTIST_TABLES is missing an entry for artist_url — "
+            "see WXYC/library-metadata-lookup#497 + WXYC/discogs-xml-converter#68"
+        )
+        assert config["csv_file"] == "artist_url.csv"
+        assert config["csv_columns"] == ["artist_id", "url"]
+        assert config["db_columns"] == ["artist_id", "url"]
+        assert "artist_id" in config["required"]
+        assert "url" in config["required"]
+        assert config["unique_key"] == ["artist_id", "url"]
+
 
 class TestReleaseTrackUniqueKey:
     """release_track must have unique_key for dedup."""


### PR DESCRIPTION
## Summary

Adds an `ARTIST_TABLES` entry for `artist_url.csv` → `artist_url`, completing **step 3** of WXYC/library-metadata-lookup#497.

WXYC/discogs-xml-converter#68 (already merged) extended the converter to extract Discogs `<urls>` from `<artist>` bodies (Wikipedia, official sites, social) and emit `artist_url.csv` with header `artist_id,url`. The downstream loader was the missing link: without an `ARTIST_TABLES` entry, the rebuild would silently drop the CSV on the floor and `artist_url` would stay empty, leaving LML's `cache_service.get_artist_details` join returning no external URLs.

The entry mirrors the sibling `artist_alias` / `artist_name_variation` / `artist_member` shape:

- `csv_columns` / `db_columns` = `["artist_id", "url"]`
- Both columns `required`
- `unique_key = ["artist_id", "url"]` for CSV-side dedup (same as siblings; the `artist_url` table itself has no unique constraint, matching the rest of the artist-children family)
- No `transforms`

Schema (`artist_url` table at `schema/create_database.sql:176`) and the truncate list (`CACHE_TABLES_TO_TRUNCATE_BASE`) already included this table — only the loader config was missing.

After the next monthly EC2 rebuild (cron: 06:00 UTC on 2026-07-04) the `artist_url` table will be populated for every artist whose id appears in `release_artist` and whose Discogs dump record has a non-empty `<urls>` block. Rotation-scoped backfill for between-rebuilds gaps remains blocked on WXYC/library-metadata-lookup#498 (L1 cache invalidate).

## Test plan

- [x] TDD: `tests/unit/test_import_csv.py::TestArtistTablesConfig::test_artist_url_entry_exists` — added red, then green
- [x] `pytest tests/unit/` — 797 passed, 3 deselected, 1 xfailed (no regressions)
- [x] `ruff check .` — clean
- [x] `ruff format --check .` — clean (100 files already formatted)
- [x] No schema migration needed (table already exists; PR #265 / earlier work added it)

Closes step 3 of WXYC/library-metadata-lookup#497.