### PR TITLE
fix(rebuild-cache): propagate real exit code through ERR-trap cleanup

### DIFF
--- a/scripts/rebuild-cache.sh
+++ b/scripts/rebuild-cache.sh
@@ -61,8 +61,13 @@ notify_slack() {
 }
 
 # Trap surfaces unexpected exits to Slack with the failing line context.
+# exit_code reads $2 first, falling back to $?. Multi-command ERR traps
+# that need to run cleanup before on_error MUST snapshot $? themselves
+# (the cleanup would otherwise clobber it) and pass it as $2. See #269 —
+# the failure mode this guards against is a silent exit-0 report when a
+# preceding successful `rm -rf` (or similar) hides a real failure.
 on_error() {
-    local exit_code=$?
+    local exit_code=${2:-$?}
     local line=$1
     notify_slack ":warning:" "failed at line ${line} (exit ${exit_code}). Log: ${LOG_FILE}"
     exit "$exit_code"
@@ -150,7 +155,10 @@ fi
 # 3. Pull daily-fresh library.db produced by sync-library workflow
 # ---------------------------------------------------------------------------
 WORK_DIR="$(mktemp -d "$REPO_DIR/data-rebuild.XXXXXX")"
-trap 'rm -rf "$WORK_DIR"; on_error $LINENO' ERR
+# Snapshot $? before `rm -rf` clobbers it, then thread the captured code
+# through to on_error as $2. See #269.
+# shellcheck disable=SC2154  # `rc` is assigned in this trap body, not external
+trap 'rc=$?; rm -rf "$WORK_DIR"; on_error $LINENO "$rc"' ERR
 trap 'rm -rf "$WORK_DIR"' EXIT
 
 echo "[$(date -u +%H:%M:%SZ)] download library.db from LML release artifact"

--- a/tests/unit/test_rebuild_cache_err_trap_exit_code.py
+++ b/tests/unit/test_rebuild_cache_err_trap_exit_code.py
@@ -1,0 +1,129 @@
+"""Pin the ERR-trap exit-code-propagation invariants of ``scripts/rebuild-cache.sh``.
+
+The 2026-06-07 manual jumpstart rebuild (#267) failed at the converter step,
+but the wrapping script exited 0 — so the bootstrap ``on_exit`` logged a clean
+success and no Slack failure ping fired. Root cause: the ERR trap installed
+after ``WORK_DIR`` exists runs ``rm -rf "$WORK_DIR"`` BEFORE calling
+``on_error``, which clobbers ``$?`` to the rm's exit status (~always 0).
+``on_error`` then reads ``$?`` as 0, posts a misleading "exit 0" failure
+warning, and exits 0 — masking the real failure.
+
+The first ERR trap (``trap 'on_error $LINENO' ERR``) is safe today because
+nothing runs between the failing command and ``on_error``. But the same
+regression could re-enter if a future change adds cleanup in front of the
+on_error call.
+
+These tests pin both shapes by asserting every ERR trap either:
+  (a) calls ``on_error`` as its only command (preserving ``$?``), OR
+  (b) captures ``$?`` into a variable as its first command and threads the
+      captured value through to ``on_error`` as a positional arg.
+
+The Python-layer half of the same silent-failure symptom was fixed in
+#180; this is the bash-layer half. See #269.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "rebuild-cache.sh"
+
+# Match ``trap '<body>' ERR``. The script uses single-quoted trap bodies;
+# if that convention ever changes, this regex needs to grow.
+TRAP_ERR_RE = re.compile(r"""trap\s+'([^']+)'\s+ERR""")
+
+# Match a leading ``var=$?`` assignment (optionally prefixed with
+# ``local`` / ``declare``). This is the safe pattern that snapshots the
+# exit code before any cleanup command can overwrite it.
+EXIT_CODE_CAPTURE_RE = re.compile(
+    r"""^\s*(?:local\s+|declare\s+)?[A-Za-z_][A-Za-z0-9_]*=\$\?\s*$"""
+)
+
+
+@pytest.fixture(scope="module")
+def script_text() -> str:
+    return SCRIPT_PATH.read_text()
+
+
+def _split_trap_commands(body: str) -> list[str]:
+    # Bash trap bodies can chain with ``;``. We only care about the
+    # FIRST top-level command, so a simple split is sufficient to
+    # surface the #269 bug pattern.
+    return [c.strip() for c in body.split(";") if c.strip()]
+
+
+def test_err_traps_propagate_real_exit_code(script_text: str) -> None:
+    """#269: every ERR trap must preserve the failing command's ``$?``.
+
+    Each ERR trap is either:
+      - A single-command trap that calls ``on_error`` directly (safe by
+        construction: ``$?`` is unchanged when on_error runs).
+      - A multi-command trap whose FIRST command captures ``$?`` (so the
+        subsequent commands cannot clobber the exit code that on_error
+        ultimately propagates).
+
+    A multi-command trap that runs any non-capturing command before
+    on_error is the bug #269 fixed: the intervening command's exit
+    status (usually 0 from a successful ``rm -rf``) becomes what
+    on_error sees, and the real failure exits 0 silently.
+    """
+    traps = TRAP_ERR_RE.findall(script_text)
+    assert traps, "no ERR trap found in rebuild-cache.sh — test setup is wrong"
+
+    for body in traps:
+        cmds = _split_trap_commands(body)
+        assert cmds, f"empty trap body: {body!r}"
+        first = cmds[0]
+        if len(cmds) == 1:
+            assert "on_error" in first, (
+                f"single-command ERR trap must call on_error; got: {first!r}"
+            )
+        else:
+            assert EXIT_CODE_CAPTURE_RE.match(first), (
+                f"multi-command ERR trap must capture $? as its first "
+                f"command, otherwise on_error reads $? as the exit code of "
+                f"whatever ran between the failure and on_error. "
+                f"Got first command: {first!r}; full trap body: {body!r}. "
+                f"See #269."
+            )
+
+
+def test_on_error_accepts_explicit_exit_code(script_text: str) -> None:
+    """#269: on_error must accept an explicit exit_code arg.
+
+    The fix for the multi-command trap depends on threading the captured
+    ``$?`` through to ``on_error`` as a positional arg (since ``$?`` has
+    already been clobbered by the cleanup command). Pin that on_error's
+    signature reads ``exit_code`` from ``$2`` with a ``$?`` fallback, so
+    both styles of caller — single-command trap (no arg) and
+    multi-command trap (explicit arg) — work correctly.
+    """
+    fn_match = re.search(
+        r"^on_error\s*\(\s*\)\s*\{(.*?)^\}",
+        script_text,
+        re.DOTALL | re.MULTILINE,
+    )
+    assert fn_match, "could not locate on_error function in rebuild-cache.sh"
+    body = fn_match.group(1)
+
+    # The exit_code assignment must be the FIRST statement in the body
+    # (any prior ``local foo=...`` would clobber $? before the fallback
+    # could read it). And it must use the ``${2:-$?}`` shape so an
+    # explicit arg overrides the fallback.
+    first_non_blank = next(
+        (line.strip() for line in body.splitlines() if line.strip()),
+        "",
+    )
+    assert re.match(
+        r"""^local\s+exit_code\s*=\s*"?\$\{2:-\$\?\}"?\s*$""",
+        first_non_blank,
+    ), (
+        "on_error's FIRST statement must be `local exit_code=${2:-$?}` "
+        "so multi-command ERR traps can thread the original exit code "
+        "through cleanly without losing it to a preceding cleanup "
+        f"command. Got first statement: {first_non_blank!r}. See #269."
+    )


### PR DESCRIPTION
Closes #269. Sister fix for #268 (the underlying disk failure that this trap silenced).

## Summary

- ERR trap at `scripts/rebuild-cache.sh:153` ran `rm -rf "$WORK_DIR"` before `on_error`, clobbering `$?` so every failure exited 0 with a misleading "exit 0" Slack warning.
- `on_error` now reads `exit_code` from `${2:-$?}` (positional arg with `$?` fallback); the second ERR trap snapshots `$?` first (`rc=$?; rm -rf ...; on_error $LINENO "$rc"`).
- Same pattern applied to the still-latent single-command trap so a future cleanup addition can't reintroduce the bug.

## Why

The 2026-06-07 manual jumpstart rebuild (#267) failed at the converter step on disk-full (#268). `run_pipeline.py` correctly raised `CalledProcessError` (per the prior #180 fix at the Python layer), but `rebuild-cache.sh` exited 0 to its caller. The 2026-07-04 cron would have failed silently and the rotation operator would not have been paged. This is the bash-layer complement to #180.

## Test plan

- [x] `pytest tests/unit/test_rebuild_cache_err_trap_exit_code.py` — 2/2 pass (red → green confirmed)
- [x] `pytest tests/unit/test_rebuild_cache_*.py tests/unit/test_ephemeral_rebuild_*.py` — 34/34 pass (no sibling regressions)
- [x] `ruff check .` + `ruff format --check .` — clean
- [x] `shellcheck scripts/rebuild-cache.sh` — clean (SC2154 disabled with a directive; `rc` is local to the trap body)
- [ ] End-to-end: a deliberate Python failure in the next ephemeral rebuild → bootstrap `on_exit` logs the non-zero exit code, `notify_slack ":warning:"` fires (will exercise when #268 unblocks the next rebuild)