### PR TITLE
feat(schema): add release.not_found + artist.not_found tombstone column

### DIFF
--- a/alembic/versions/0010_release_not_found.py
+++ b/alembic/versions/0010_release_not_found.py
@@ -1,0 +1,171 @@
+"""release.not_found: tombstone marker for Discogs 404s on get_release.
+
+Adds a ``boolean NOT NULL DEFAULT FALSE`` column. The default makes the
+migration backward-compatible: prod LML running pre-510 code reads
+``not_found = FALSE`` on every existing row and behaves exactly as it
+did before.
+
+Background
+----------
+
+LML's ``DiscogsService.get_release`` re-hits the Discogs API on every
+call for a release id that 404s. The ``_api_fetch`` inner function
+collapses 404 to ``None`` and the fallthrough seam refuses to write
+``None`` to PG, so no row records "we asked Discogs, the answer was
+nothing". Every subsequent call burns rate-limit budget on the same 404.
+
+The principled fix composes on the existing
+``release.artwork_checked_at`` discriminator (this repo's #239 / LML's
+PR #415) rather than introducing a parallel negative-cache surface:
+LML's ``_api_fetch`` returns a tombstone-shaped ``ReleaseMetadataResponse``
+with ``not_found = TRUE``, ``title = ''`` (identifier sentinel), and
+``artwork_checked_at = now()``. The fallthrough seam already writes
+that via the existing ``pg_write`` path; subsequent reads short-circuit
+on ``not_found = TRUE`` before fetching child tables.
+
+LML's tombstone-write UPSERT preserves a hydrated parent row's
+identifier columns (the ``ON CONFLICT DO UPDATE SET`` clause omits
+``title`` / ``release_year`` / etc.) so a 404 after a 200 doesn't lose
+the title. Symmetric: the non-tombstone branch adds
+``not_found = FALSE`` to ``ON CONFLICT DO UPDATE SET`` so a recovered
+200 clears any prior tombstone in one statement.
+
+Rebuild-path symmetry
+---------------------
+
+``scripts/import_csv.py::import_release_via_upsert`` includes
+``not_found = FALSE`` in both the INSERT and the ``ON CONFLICT DO
+UPDATE SET`` so a pipeline refresh clears any prior tombstone. Without
+this, a tombstoned id would survive a rebuild and stay unreachable
+until LML's admin recovery endpoint deletes it.
+
+Empty-string write precondition
+-------------------------------
+
+``release.title`` is ``text NOT NULL`` with no
+``CHECK (title <> '')``. LML's tombstone INSERT writes ``title = ''``
+as a sentinel — the ``not_found = TRUE`` flag is the authoritative
+discriminator, and the empty string is a "this column is intentionally
+unpopulated" marker on the row. The migration probes the write so a
+future-added CHECK trips this migration rather than the prod write.
+
+Dual-write convention
+---------------------
+
+``schema/create_database.sql`` (fresh-rebuild path) adds the column
+alongside the existing ``release`` DDL so a ground-up rebuild produces
+the same end-state as the alembic chain.
+
+Companion tickets
+-----------------
+
+* WXYC/library-metadata-lookup#510 — the consumer.
+* WXYC/library-metadata-lookup#503 — sibling ``artist.fetched_at``
+  discriminator (the prior application of the same pattern).
+* WXYC/discogs-etl#239 / WXYC/library-metadata-lookup#414 — sibling
+  ``release.artwork_checked_at`` discriminator.
+
+Revision ID: 0010_release_not_found
+Revises: 0009_cache_metadata_unique
+Create Date: 2026-06-08
+
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from collections.abc import Sequence
+
+import psycopg
+
+from alembic import context
+
+revision: str = "0010_release_not_found"
+down_revision: str | Sequence[str] | None = "0009_cache_metadata_unique"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+_UPGRADE_SQL = """
+ALTER TABLE release
+    ADD COLUMN IF NOT EXISTS not_found boolean NOT NULL DEFAULT FALSE;
+"""
+
+_DOWNGRADE_SQL = """
+ALTER TABLE release DROP COLUMN IF EXISTS not_found;
+"""
+
+
+# Sentinel id used by the upgrade probe. Out-of-range for any real Discogs
+# release id (negatives never appear in the dump), and rolled back in the
+# same transaction so no row ever lands.
+_PROBE_ID = -2147483648
+
+
+def _resolve_db_url() -> str:
+    db_url = os.environ.get("DATABASE_URL_DISCOGS") or os.environ.get("DATABASE_URL")
+    if not db_url:
+        raise RuntimeError(
+            "DATABASE_URL_DISCOGS (or DATABASE_URL) must be set to apply 0010_release_not_found."
+        )
+    return db_url
+
+
+def _refuse_offline(direction: str) -> None:
+    if context.is_offline_mode():
+        raise RuntimeError(
+            f"0010_release_not_found does not support --sql / offline mode "
+            f"({direction}): the migration opens its own psycopg connection "
+            "to apply DDL and run a precondition probe, mirroring 0008. "
+            "Run `alembic upgrade head` (or `downgrade`) against a live DB "
+            "instead."
+        )
+
+
+def _probe_empty_title_write() -> None:
+    """Verify ``release.title = ''`` can be written.
+
+    LML's tombstone INSERT writes ``title = ''``. If a future CHECK or
+    trigger is added that blocks this, the prod write would fail at
+    runtime with a confused-looking error. Probing here surfaces the
+    incompatibility at migration time, in a message that names the
+    consumer (LML#510). Probe runs in a transaction that is always
+    rolled back, so nothing is persisted.
+    """
+    with psycopg.connect(_resolve_db_url(), autocommit=True) as conn, conn.cursor() as cur:
+        cur.execute("BEGIN")
+        try:
+            cur.execute(
+                "INSERT INTO release (id, title) VALUES (%s, '')",
+                (_PROBE_ID,),
+            )
+        except Exception as e:
+            cur.execute("ROLLBACK")
+            raise RuntimeError(
+                "0010 precondition failed: release.title cannot accept the "
+                "empty-string sentinel that LML#510 writes for tombstone "
+                "rows. A CHECK constraint, trigger, or DEFAULT clause has "
+                "been added that rejects ''. Either drop the constraint or "
+                f"change the tombstone sentinel in LML. Original error: {e}"
+            ) from e
+        else:
+            cur.execute("ROLLBACK")
+
+
+def upgrade() -> None:
+    _refuse_offline("upgrade")
+
+    log = logging.getLogger("alembic.runtime.migration")
+    _probe_empty_title_write()
+
+    with psycopg.connect(_resolve_db_url(), autocommit=True) as conn, conn.cursor() as cur:
+        log.info("0010: ALTER release ADD COLUMN not_found")
+        cur.execute(_UPGRADE_SQL)
+
+
+def downgrade() -> None:
+    _refuse_offline("downgrade")
+
+    with psycopg.connect(_resolve_db_url(), autocommit=True) as conn, conn.cursor() as cur:
+        cur.execute(_DOWNGRADE_SQL)

--- a/alembic/versions/0011_artist_not_found.py
+++ b/alembic/versions/0011_artist_not_found.py
@@ -1,0 +1,128 @@
+"""artist.not_found: tombstone marker for Discogs 404s on get_artist_details.
+
+Parallel to 0010 but for the ``artist`` table. Same rationale: LML's
+``DiscogsService.get_artist_details`` collapses 404 to ``None`` today,
+the fallthrough seam refuses to write ``None``, and every caller
+re-burns the rate-limit budget on the same 404. ``not_found = TRUE``
+becomes the tombstone the existing ``fetched_at``-based ``is_pg_hit``
+predicate (#503) already serves; this column just gives the read side
+something explicit to short-circuit on.
+
+Sibling discriminators on ``artist``:
+
+* ``fetched_at`` (LML#503) — distinguishes ETL stubs (``fetched_at``
+  defaulted at row creation) from rows hydrated by LML's live-API path
+  (``fetched_at`` set by the LML write).
+* ``not_found`` (this migration) — distinguishes hydrated 200-response
+  rows from hydrated 404-response tombstones.
+
+These compose: ``fetched_at IS NOT NULL`` means the row was touched by
+*some* LML write; ``not_found`` then says which side of the 200/404
+split that write came from.
+
+LML's tombstone-write UPSERT preserves a hydrated parent's identifier
+columns (``name`` / ``profile`` / ``image_url``) by intentionally
+omitting them from the ``ON CONFLICT DO UPDATE SET`` clause. The
+non-tombstone branch adds ``not_found = FALSE`` to its update set so a
+recovered 200 clears any prior tombstone in one statement.
+
+Empty-name write precondition probed at upgrade time, matching 0010's
+pattern.
+
+Revision ID: 0011_artist_not_found
+Revises: 0010_release_not_found
+Create Date: 2026-06-08
+
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from collections.abc import Sequence
+
+import psycopg
+
+from alembic import context
+
+revision: str = "0011_artist_not_found"
+down_revision: str | Sequence[str] | None = "0010_release_not_found"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+_UPGRADE_SQL = """
+ALTER TABLE artist
+    ADD COLUMN IF NOT EXISTS not_found boolean NOT NULL DEFAULT FALSE;
+"""
+
+_DOWNGRADE_SQL = """
+ALTER TABLE artist DROP COLUMN IF EXISTS not_found;
+"""
+
+
+_PROBE_ID = -2147483648
+
+
+def _resolve_db_url() -> str:
+    db_url = os.environ.get("DATABASE_URL_DISCOGS") or os.environ.get("DATABASE_URL")
+    if not db_url:
+        raise RuntimeError(
+            "DATABASE_URL_DISCOGS (or DATABASE_URL) must be set to apply 0011_artist_not_found."
+        )
+    return db_url
+
+
+def _refuse_offline(direction: str) -> None:
+    if context.is_offline_mode():
+        raise RuntimeError(
+            f"0011_artist_not_found does not support --sql / offline mode "
+            f"({direction}): the migration opens its own psycopg connection "
+            "to apply DDL and run a precondition probe. Run `alembic "
+            "upgrade head` (or `downgrade`) against a live DB instead."
+        )
+
+
+def _probe_empty_name_write() -> None:
+    """Verify ``artist.name = ''`` can be written.
+
+    LML's tombstone INSERT writes ``name = ''`` + ``not_found = TRUE``.
+    Probing surfaces a future-added CHECK at migration time rather than
+    on the first prod 404.
+    """
+    with psycopg.connect(_resolve_db_url(), autocommit=True) as conn, conn.cursor() as cur:
+        cur.execute("BEGIN")
+        try:
+            cur.execute(
+                "INSERT INTO artist (id, name) VALUES (%s, '')",
+                (_PROBE_ID,),
+            )
+        except Exception as e:
+            cur.execute("ROLLBACK")
+            raise RuntimeError(
+                "0011 precondition failed: artist.name cannot accept the "
+                "empty-string sentinel that LML#510 writes for tombstone "
+                "rows. A CHECK constraint, trigger, or DEFAULT clause has "
+                "been added that rejects ''. Either drop the constraint or "
+                f"change the tombstone sentinel in LML. Original error: {e}"
+            ) from e
+        else:
+            cur.execute("ROLLBACK")
+
+
+def upgrade() -> None:
+    _refuse_offline("upgrade")
+
+    log = logging.getLogger("alembic.runtime.migration")
+    _probe_empty_name_write()
+
+    with psycopg.connect(_resolve_db_url(), autocommit=True) as conn, conn.cursor() as cur:
+        log.info("0011: ALTER artist ADD COLUMN not_found")
+        cur.execute(_UPGRADE_SQL)
+
+
+def downgrade() -> None:
+    _refuse_offline("downgrade")
+
+    with psycopg.connect(_resolve_db_url(), autocommit=True) as conn, conn.cursor() as cur:
+        cur.execute(_DOWNGRADE_SQL)

--- a/schema/create_database.sql
+++ b/schema/create_database.sql
@@ -62,7 +62,8 @@ CREATE TABLE IF NOT EXISTS release (
     released            text,              -- full date string, e.g. "2024-03-15"
     format              text,              -- normalized format category: 'Vinyl', 'CD', etc.
     master_id           integer,           -- Discogs master ID; used by dedup partitioning, persists post-swap (see DEDUP_TABLES in scripts/dedup_releases.py)
-    artwork_checked_at  timestamptz        -- WXYC/discogs-etl#239. NULL = never asked, set = LML asked Discogs at lookup time. LML's predicate honors this so genuinely-imageless releases aren't refetched. Index below covers LML#221's never-asked drain.
+    artwork_checked_at  timestamptz,       -- WXYC/discogs-etl#239. NULL = never asked, set = LML asked Discogs at lookup time. LML's predicate honors this so genuinely-imageless releases aren't refetched. Index below covers LML#221's never-asked drain.
+    not_found           boolean NOT NULL DEFAULT FALSE   -- WXYC/library-metadata-lookup#510. Tombstone marker for Discogs 404s on get_release. LML's read short-circuits on TRUE; rebuild/UPSERT paths clear to FALSE on fresh data. Mirrored in alembic/versions/0010_release_not_found.py.
 );
 
 -- Partial index for LML#221's never-asked top-up drain (WXYC/discogs-etl#239).
@@ -152,7 +153,8 @@ CREATE TABLE IF NOT EXISTS artist (
     name            text NOT NULL,
     profile         text,
     image_url       text,
-    fetched_at      timestamptz NOT NULL DEFAULT now()
+    fetched_at      timestamptz NOT NULL DEFAULT now(),
+    not_found       boolean NOT NULL DEFAULT FALSE   -- WXYC/library-metadata-lookup#510. Tombstone marker for Discogs 404s on get_artist_details. Mirrored in alembic/versions/0011_artist_not_found.py.
 );
 
 CREATE TABLE IF NOT EXISTS artist_alias (

--- a/scripts/dedup_releases.py
+++ b/scripts/dedup_releases.py
@@ -313,7 +313,7 @@ DEDUP_TABLES: list[tuple[str, str, str, str]] = [
     (
         "release",
         "new_release",
-        "id, title, release_year, country, artwork_url, released, format, master_id, artwork_checked_at",
+        "id, title, release_year, country, artwork_url, released, format, master_id, artwork_checked_at, not_found",
         "id",
     ),
     (
@@ -357,6 +357,10 @@ DEDUP_TABLES: list[tuple[str, str, str, str]] = [
 PRE_SWAP_COLUMN_DEFAULTS: dict[str, dict[str, str]] = {
     "new_cache_metadata": {"cached_at": "now()"},
     "new_release_artist": {"extra": "0"},
+    # LML#510: tombstone DEFAULT must be re-applied before swap so a
+    # cache-miss INSERT that omits not_found never lands NULL between the
+    # swap and Level-2 SET NOT NULL.
+    "new_release": {"not_found": "false"},
 }
 
 
@@ -540,6 +544,7 @@ def add_base_constraints_and_indexes(conn, db_url: str | None = None) -> None:
             "CREATE INDEX idx_release_genre_release_id ON release_genre(release_id)",
             "CREATE INDEX idx_release_style_release_id ON release_style(release_id)",
             "ALTER TABLE release ALTER COLUMN title SET NOT NULL",
+            "ALTER TABLE release ALTER COLUMN not_found SET NOT NULL",
             "ALTER TABLE release_artist ALTER COLUMN release_id SET NOT NULL",
             "ALTER TABLE release_artist ALTER COLUMN artist_name SET NOT NULL",
             "ALTER TABLE release_label ALTER COLUMN release_id SET NOT NULL",

--- a/scripts/import_csv.py
+++ b/scripts/import_csv.py
@@ -653,16 +653,22 @@ def import_release_via_upsert(conn, csv_dir: Path) -> int:
     with conn.cursor() as cur:
         # artwork_url, artwork_checked_at intentionally NOT in the SET
         # list — the contract of this function.
+        #
+        # not_found IS in the SET list (LML#510): a fresh dump is
+        # authoritative, so any prior LML 404 tombstone clears here.
+        # Without this, a tombstoned id would survive every rebuild and
+        # stay unreachable until LML's admin recovery endpoint deletes it.
         cur.execute(
             """
-            INSERT INTO release (id, title, country, released, format, master_id)
-            SELECT id, title, country, released, format, master_id FROM release_staging
+            INSERT INTO release (id, title, country, released, format, master_id, not_found)
+            SELECT id, title, country, released, format, master_id, FALSE FROM release_staging
             ON CONFLICT (id) DO UPDATE SET
                 title     = EXCLUDED.title,
                 country   = EXCLUDED.country,
                 released  = EXCLUDED.released,
                 format    = EXCLUDED.format,
-                master_id = EXCLUDED.master_id
+                master_id = EXCLUDED.master_id,
+                not_found = EXCLUDED.not_found
             """
         )
         cur.execute("DELETE FROM release WHERE id NOT IN (SELECT id FROM release_staging)")
@@ -893,18 +899,25 @@ def import_artist_details(conn, csv_dir: Path) -> int:
     Returns total rows imported (stubs + profile updates + child rows).
     """
     # Create stub artist rows from release_artist (id + name only)
+    #
+    # ON CONFLICT clears any prior LML#510 tombstone (`not_found = TRUE`).
+    # `WHERE artist.not_found = TRUE` narrows the rewrite to actual
+    # tombstones so non-tombstone rows aren't disturbed. Without this
+    # branch a tombstoned id would survive every rebuild.
     logger.info("Creating stub artist rows from release_artist...")
     with conn.cursor() as cur:
         cur.execute("""
-            INSERT INTO artist (id, name)
-            SELECT DISTINCT artist_id, artist_name
+            INSERT INTO artist (id, name, not_found)
+            SELECT DISTINCT artist_id, artist_name, FALSE
             FROM release_artist
             WHERE artist_id IS NOT NULL
-            ON CONFLICT (id) DO NOTHING
+            ON CONFLICT (id) DO UPDATE SET
+                not_found = FALSE
+            WHERE artist.not_found = TRUE
         """)
         count = cur.rowcount
     conn.commit()
-    logger.info(f"  Created {count:,} stub artist rows")
+    logger.info(f"  Created or refreshed {count:,} stub artist rows")
 
     total = count
 

--- a/scripts/verify_cache.py
+++ b/scripts/verify_cache.py
@@ -720,6 +720,8 @@ PRUNE_PRE_SWAP_COLUMN_DEFAULTS: dict[str, dict[str, str]] = {
     "new_cache_metadata": {"cached_at": "now()"},
     "new_release_artist": {"extra": "0"},
     "new_release_track_artist": {"extra": "0"},
+    # LML#510: see dedup_releases.PRE_SWAP_COLUMN_DEFAULTS for context.
+    "new_release": {"not_found": "false"},
 }
 
 
@@ -878,6 +880,7 @@ def _prune_add_base_constraints_and_indexes(db_url: str) -> None:
             # ``tests/integration/test_copy_swap_preserves_not_null.py``.
             for stmt in (
                 "ALTER TABLE release ALTER COLUMN title SET NOT NULL",
+                "ALTER TABLE release ALTER COLUMN not_found SET NOT NULL",
                 "ALTER TABLE release_artist ALTER COLUMN release_id SET NOT NULL",
                 "ALTER TABLE release_artist ALTER COLUMN artist_name SET NOT NULL",
                 "ALTER TABLE release_label ALTER COLUMN release_id SET NOT NULL",
@@ -965,7 +968,7 @@ PRUNE_COPY_TABLES = [
     (
         "release",
         "new_release",
-        "id, title, release_year, country, artwork_url, released, format, master_id, artwork_checked_at",
+        "id, title, release_year, country, artwork_url, released, format, master_id, artwork_checked_at, not_found",
         "id",
     ),
     (
@@ -1018,6 +1021,7 @@ COPY_TABLE_SPEC = [
             "format",
             "master_id",
             "artwork_checked_at",
+            "not_found",
         ],
     ),
     (

--- a/tests/integration/test_alembic_0010_release_not_found.py
+++ b/tests/integration/test_alembic_0010_release_not_found.py
@@ -1,0 +1,198 @@
+"""Verify 0010 adds `release.not_found` for LML#510's tombstone discriminator.
+
+`release.not_found` distinguishes two cases that previously collapsed to
+"no cache row":
+
+* **Never asked** — no row in ``release`` at all (the bulk loader hasn't
+  imported it, or LML hasn't fetched it).
+* **Asked, Discogs returned 404** — row exists with
+  ``not_found = TRUE``. LML's negative-cache stays warm so subsequent
+  callers don't re-burn the rate-limit budget on the same 404.
+
+Without this column, LML's ``_api_fetch`` collapses 404 to ``None`` and
+the fallthrough seam refuses to write ``None`` to PG, so every caller
+re-asks Discogs forever. The companion change in LML's
+``cache_service.write_release`` writes a *narrow* tombstone row whose
+identifier columns intentionally stay NULL/empty so that a future
+hydrated 200 response can fill them in without losing them mid-flight.
+
+The default ``FALSE`` makes the migration safe to ship before LML is
+updated: existing prod LML reads the column as ``FALSE`` (no tombstones)
+and behaves exactly as it did pre-migration.
+
+Tracked at WXYC/library-metadata-lookup#510.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import psycopg
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MIGRATION_PATH = REPO_ROOT / "alembic" / "versions" / "0010_release_not_found.py"
+SCHEMA_DIR = REPO_ROOT / "schema"
+
+
+# ---------------------------------------------------------------------------
+# Static (no DB) checks
+# ---------------------------------------------------------------------------
+
+
+def test_migration_file_exists() -> None:
+    assert MIGRATION_PATH.exists(), (
+        f"0010 migration missing at {MIGRATION_PATH}. Per the dual-write "
+        "convention, the alembic chain and schema/create_database.sql must "
+        "agree on the release-table shape."
+    )
+
+
+def test_migration_adds_not_found_column() -> None:
+    body = MIGRATION_PATH.read_text(encoding="utf-8")
+    assert "ADD COLUMN IF NOT EXISTS not_found" in body, (
+        "0010 must ADD COLUMN not_found with IF NOT EXISTS so it's idempotent "
+        "against schema/create_database.sql (which the legacy rebuild path "
+        "applies directly)."
+    )
+    assert "boolean" in body.lower(), (
+        "not_found must be boolean — LML's discriminator is a binary state."
+    )
+    assert "NOT NULL" in body, (
+        "not_found must be NOT NULL so the predicate `not_found = TRUE` is "
+        "unambiguous; a NULL tristate would force every read site to handle "
+        "the third case."
+    )
+    assert "DEFAULT FALSE" in body or "DEFAULT false" in body, (
+        "not_found must default to FALSE so the migration is backward-"
+        "compatible: existing prod LML treats every row as a real row, "
+        "exactly as it did pre-migration."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Live-PG assertions
+# ---------------------------------------------------------------------------
+
+
+def _run_alembic(args: list[str], db_url: str) -> subprocess.CompletedProcess[str]:
+    env = {**os.environ, "DATABASE_URL_DISCOGS": db_url}
+    env.pop("DATABASE_URL", None)
+    return subprocess.run(
+        [sys.executable, "-m", "alembic", *args],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+
+@pytest.fixture()
+def db_with_release_table(fresh_db_url: str) -> str:
+    with psycopg.connect(fresh_db_url, autocommit=True) as conn, conn.cursor() as cur:
+        cur.execute(SCHEMA_DIR.joinpath("create_database.sql").read_text())
+    return fresh_db_url
+
+
+@pytest.mark.pg
+def test_not_found_column_created_at_head(db_with_release_table: str) -> None:
+    db_url = db_with_release_table
+
+    stamp = _run_alembic(["stamp", "0009_cache_metadata_unique"], db_url)
+    assert stamp.returncode == 0, (
+        f"alembic stamp failed:\nstdout: {stamp.stdout}\nstderr: {stamp.stderr}"
+    )
+
+    result = _run_alembic(["upgrade", "0010_release_not_found"], db_url)
+    assert result.returncode == 0, (
+        f"alembic upgrade failed:\nstdout: {result.stdout}\nstderr: {result.stderr}"
+    )
+
+    with psycopg.connect(db_url) as conn, conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT data_type, is_nullable, column_default
+            FROM information_schema.columns
+            WHERE table_schema = 'public'
+              AND table_name = 'release'
+              AND column_name = 'not_found'
+            """
+        )
+        row = cur.fetchone()
+        assert row is not None, "release.not_found column missing after 0010 upgrade"
+        data_type, is_nullable, column_default = row
+        assert data_type == "boolean", (
+            f"not_found must be boolean; got {data_type!r}. A non-boolean type "
+            f"would force LML's predicate into a NULL-or-cast comparison."
+        )
+        assert is_nullable == "NO", (
+            "not_found must be NOT NULL. NULL would force every read site to "
+            "handle a third 'maybe a tombstone' state."
+        )
+        assert column_default is not None and "false" in column_default.lower(), (
+            f"not_found must default to FALSE so the migration is backward-"
+            f"compatible with prod LML running the pre-510 code. Got "
+            f"{column_default!r}."
+        )
+
+
+@pytest.mark.pg
+def test_not_found_round_trip_with_empty_title(db_with_release_table: str) -> None:
+    """Pin the tombstone-write contract: ``title = ''`` + ``not_found = TRUE``.
+
+    LML#510's tombstone INSERT writes ``title = ''`` as a sentinel. ``release.title``
+    is ``text NOT NULL`` with no ``CHECK (title <> '')``, so this works today.
+    The migration's ``upgrade()`` probes the same write so a future-added
+    CHECK trips this test (and the migration) rather than the prod LML write.
+    """
+    db_url = db_with_release_table
+
+    stamp = _run_alembic(["stamp", "0009_cache_metadata_unique"], db_url)
+    assert stamp.returncode == 0
+    result = _run_alembic(["upgrade", "0010_release_not_found"], db_url)
+    assert result.returncode == 0
+
+    with psycopg.connect(db_url, autocommit=True) as conn, conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO release (id, title, not_found, artwork_checked_at)
+            VALUES (-2147483648, '', TRUE, now())
+            """
+        )
+        cur.execute("SELECT title, not_found FROM release WHERE id = -2147483648")
+        row = cur.fetchone()
+        assert row == ("", True), (
+            "Tombstone round-trip failed; tombstone semantics require "
+            "(title='', not_found=TRUE) to persist. The migration probe "
+            "should have caught this."
+        )
+        cur.execute("DELETE FROM release WHERE id = -2147483648")
+
+
+@pytest.mark.pg
+def test_not_found_idempotent_on_reapply(db_with_release_table: str) -> None:
+    """Applying 0010 against a DB already on the dual-written schema must not error."""
+    db_url = db_with_release_table
+
+    with psycopg.connect(db_url) as conn, conn.cursor() as cur:
+        cur.execute(
+            "SELECT 1 FROM information_schema.columns "
+            "WHERE table_name = 'release' AND column_name = 'not_found'"
+        )
+        assert cur.fetchone() is not None, (
+            "Pre-condition: schema/create_database.sql must dual-write "
+            "release.not_found. Without that, this test no longer covers "
+            "the idempotence-against-legacy-schema case."
+        )
+
+    stamp = _run_alembic(["stamp", "0009_cache_metadata_unique"], db_url)
+    assert stamp.returncode == 0
+
+    result = _run_alembic(["upgrade", "0010_release_not_found"], db_url)
+    assert result.returncode == 0, (
+        f"0010 must be idempotent against a pre-existing column. "
+        f"alembic output:\nstdout: {result.stdout}\nstderr: {result.stderr}"
+    )

--- a/tests/integration/test_alembic_0011_artist_not_found.py
+++ b/tests/integration/test_alembic_0011_artist_not_found.py
@@ -1,0 +1,127 @@
+"""Verify 0011 adds `artist.not_found` for LML#510's tombstone discriminator.
+
+Parallel to 0010 but for the artist table. ``artist.name`` is ``text NOT NULL``
+with no ``CHECK (name <> '')`` today; the tombstone INSERT writes ``name = ''``
++ ``not_found = TRUE``. The migration probes the same write so a future-added
+CHECK trips this test (and the migration) rather than the prod LML write.
+
+Tracked at WXYC/library-metadata-lookup#510.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import psycopg
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MIGRATION_PATH = REPO_ROOT / "alembic" / "versions" / "0011_artist_not_found.py"
+SCHEMA_DIR = REPO_ROOT / "schema"
+
+
+def test_migration_file_exists() -> None:
+    assert MIGRATION_PATH.exists(), f"0011 migration missing at {MIGRATION_PATH}."
+
+
+def test_migration_adds_not_found_column() -> None:
+    body = MIGRATION_PATH.read_text(encoding="utf-8")
+    assert "ADD COLUMN IF NOT EXISTS not_found" in body
+    assert "boolean" in body.lower()
+    assert "NOT NULL" in body
+    assert "DEFAULT FALSE" in body or "DEFAULT false" in body
+
+
+def _run_alembic(args: list[str], db_url: str) -> subprocess.CompletedProcess[str]:
+    env = {**os.environ, "DATABASE_URL_DISCOGS": db_url}
+    env.pop("DATABASE_URL", None)
+    return subprocess.run(
+        [sys.executable, "-m", "alembic", *args],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+
+@pytest.fixture()
+def db_with_artist_table(fresh_db_url: str) -> str:
+    with psycopg.connect(fresh_db_url, autocommit=True) as conn, conn.cursor() as cur:
+        cur.execute(SCHEMA_DIR.joinpath("create_database.sql").read_text())
+    return fresh_db_url
+
+
+@pytest.mark.pg
+def test_not_found_column_created_at_head(db_with_artist_table: str) -> None:
+    db_url = db_with_artist_table
+
+    stamp = _run_alembic(["stamp", "0010_release_not_found"], db_url)
+    assert stamp.returncode == 0, (
+        f"alembic stamp failed:\nstdout: {stamp.stdout}\nstderr: {stamp.stderr}"
+    )
+
+    result = _run_alembic(["upgrade", "0011_artist_not_found"], db_url)
+    assert result.returncode == 0, (
+        f"alembic upgrade failed:\nstdout: {result.stdout}\nstderr: {result.stderr}"
+    )
+
+    with psycopg.connect(db_url) as conn, conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT data_type, is_nullable, column_default
+            FROM information_schema.columns
+            WHERE table_schema = 'public'
+              AND table_name = 'artist'
+              AND column_name = 'not_found'
+            """
+        )
+        row = cur.fetchone()
+        assert row is not None, "artist.not_found column missing after 0011 upgrade"
+        data_type, is_nullable, column_default = row
+        assert data_type == "boolean"
+        assert is_nullable == "NO"
+        assert column_default is not None and "false" in column_default.lower()
+
+
+@pytest.mark.pg
+def test_not_found_round_trip_with_empty_name(db_with_artist_table: str) -> None:
+    """Pin the tombstone-write contract: ``name = ''`` + ``not_found = TRUE``."""
+    db_url = db_with_artist_table
+
+    stamp = _run_alembic(["stamp", "0010_release_not_found"], db_url)
+    assert stamp.returncode == 0
+    result = _run_alembic(["upgrade", "0011_artist_not_found"], db_url)
+    assert result.returncode == 0
+
+    with psycopg.connect(db_url, autocommit=True) as conn, conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO artist (id, name, not_found, fetched_at)
+            VALUES (-2147483648, '', TRUE, now())
+            """
+        )
+        cur.execute("SELECT name, not_found FROM artist WHERE id = -2147483648")
+        row = cur.fetchone()
+        assert row == ("", True)
+        cur.execute("DELETE FROM artist WHERE id = -2147483648")
+
+
+@pytest.mark.pg
+def test_not_found_idempotent_on_reapply(db_with_artist_table: str) -> None:
+    db_url = db_with_artist_table
+
+    with psycopg.connect(db_url) as conn, conn.cursor() as cur:
+        cur.execute(
+            "SELECT 1 FROM information_schema.columns "
+            "WHERE table_name = 'artist' AND column_name = 'not_found'"
+        )
+        assert cur.fetchone() is not None
+
+    stamp = _run_alembic(["stamp", "0010_release_not_found"], db_url)
+    assert stamp.returncode == 0
+
+    result = _run_alembic(["upgrade", "0011_artist_not_found"], db_url)
+    assert result.returncode == 0

--- a/tests/integration/test_copy_swap_preserves_not_null.py
+++ b/tests/integration/test_copy_swap_preserves_not_null.py
@@ -62,7 +62,7 @@ else:
 # ALTER statements at the same time. The TestNotNullPinExpectationsMatchSchema
 # class below catches drift between the schema and this expectation.
 _EXPECTED_NOT_NULL: dict[str, tuple[str, ...]] = {
-    "release": ("title",),
+    "release": ("title", "not_found"),
     "release_artist": ("release_id", "artist_name"),
     "release_label": ("release_id", "label_name"),
     "release_genre": ("release_id", "genre"),
@@ -82,6 +82,10 @@ _EXPECTED_DEFAULTS: dict[tuple[str, str], str] = {
     ("cache_metadata", "cached_at"): "now()",
     ("release_artist", "extra"): "0",
     ("release_track_artist", "extra"): "0",
+    # LML#510: release.not_found DEFAULT FALSE must survive the swap so the
+    # copy-swap path's restored NOT NULL constraint doesn't reject an LML
+    # cache-miss INSERT (which omits not_found) between the swap and Level-2.
+    ("release", "not_found"): "false",
 }
 
 # Tables that flow through each copy-swap entrypoint.

--- a/tests/integration/test_dedup.py
+++ b/tests/integration/test_dedup.py
@@ -1105,12 +1105,15 @@ class TestDedupCopySwapAbortCleanup:
         conn = psycopg.connect(self.db_url, autocommit=True)
         ensure_dedup_ids(conn)
 
-        # copy_table drops the stale new_release and creates a fresh one
+        # copy_table drops the stale new_release and creates a fresh one.
+        # Column list must include not_found (LML#510): PRE_SWAP_COLUMN_DEFAULTS
+        # iterates new_release and applies the DEFAULT, so the column must
+        # exist on the CTAS output.
         count = copy_table(
             conn,
             "release",
             "new_release",
-            "id, title, release_year, country, artwork_url, released, format",
+            "id, title, release_year, country, artwork_url, released, format, not_found",
             "id",
         )
 

--- a/tests/integration/test_error_resilience.py
+++ b/tests/integration/test_error_resilience.py
@@ -629,7 +629,7 @@ class TestDedupTerminatedMidOperation:
                     dedup_conn,
                     "release",
                     "new_release",
-                    "id, title, release_year, country, artwork_url, released, format",
+                    "id, title, release_year, country, artwork_url, released, format, not_found",
                     "id",
                 )
                 dedup_releases.copy_table(
@@ -719,7 +719,7 @@ class TestDedupTerminatedMidOperation:
                     rerun_conn,
                     "release",
                     "new_release",
-                    "id, title, release_year, country, artwork_url, released, format",
+                    "id, title, release_year, country, artwork_url, released, format, not_found",
                     "id",
                 )
                 with rerun_conn.cursor() as cur:

--- a/tests/integration/test_import.py
+++ b/tests/integration/test_import.py
@@ -22,6 +22,7 @@ _spec.loader.exec_module(_ic)
 import_csv_func = _ic.import_csv
 import_artwork = _ic.import_artwork
 import_release_via_upsert = _ic.import_release_via_upsert
+import_artist_details = _ic.import_artist_details
 create_track_count_table = _ic.create_track_count_table
 populate_cache_metadata = _ic.populate_cache_metadata
 populate_release_year = _ic.populate_release_year
@@ -1259,3 +1260,101 @@ class TestFilteredVideoImport:
         conn.close()
         # 1001: 2, 3001: 1 = 3
         assert count == 3
+
+
+class TestImportClearsTombstones:
+    """Rebuild paths clear ``not_found`` tombstones from prior LML 404 writes.
+
+    LML#510's tombstone column marks rows where Discogs returned 404 at lookup
+    time. The rebuild pipeline is authoritative — when a fresh dump includes
+    an id that was previously tombstoned, the tombstone must clear so the
+    rebuilt row is reachable again. Without this, a tombstoned id would
+    survive every refresh until LML's admin recovery endpoint deletes it.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _fresh_schema(self, fresh_db_url):
+        self.db_url = fresh_db_url
+        conn = psycopg.connect(fresh_db_url, autocommit=True)
+        with conn.cursor() as cur:
+            cur.execute(SCHEMA_DIR.joinpath("create_database.sql").read_text())
+        conn.close()
+
+    def _write_release_csv(self, tmp_path: Path, rows: list[tuple]) -> None:
+        lines = ["id,title,country,released,format,master_id"]
+        for row in rows:
+            lines.append(",".join("" if v is None else str(v) for v in row))
+        (tmp_path / "release.csv").write_text("\n".join(lines) + "\n")
+
+    def test_rebuild_clears_release_tombstone(self, tmp_path) -> None:
+        """A tombstoned release in PG gets ``not_found`` reset when the
+        fresh dump includes its id. Without this, the rebuild would leave
+        the tombstone in place and the id would stay unreachable."""
+        conn = psycopg.connect(self.db_url)
+        with conn.cursor() as cur:
+            cur.execute(
+                "INSERT INTO release (id, title, not_found, artwork_checked_at) "
+                "VALUES (601, '', TRUE, now())"
+            )
+        conn.commit()
+        conn.close()
+
+        self._write_release_csv(tmp_path, [(601, "Aluminum Tunes", "US", "1998", "LP", None)])
+        # Minimal release_image.csv so import_artwork (called by rebuild flow
+        # callers) doesn't fail — but we only call import_release_via_upsert
+        # here, so it's not strictly required.
+        (tmp_path / "release_image.csv").write_text("release_id,type,width,height,uri\n")
+
+        conn = psycopg.connect(self.db_url)
+        import_release_via_upsert(conn, tmp_path)
+        conn.close()
+
+        conn = psycopg.connect(self.db_url)
+        with conn.cursor() as cur:
+            cur.execute("SELECT title, not_found FROM release WHERE id = 601")
+            row = cur.fetchone()
+        conn.close()
+        assert row == ("Aluminum Tunes", False), (
+            f"Rebuild must clear the tombstone (not_found=FALSE) and write "
+            f"the fresh title; got {row!r}. The INSERT/UPSERT in "
+            f"import_release_via_upsert must include not_found in both the "
+            f"column list and the ON CONFLICT DO UPDATE SET clause."
+        )
+
+    def test_rebuild_clears_artist_tombstone(self, tmp_path) -> None:
+        """A tombstoned artist in PG gets ``not_found`` reset when the
+        fresh dump's release_artist re-stubs its id."""
+        conn = psycopg.connect(self.db_url)
+        with conn.cursor() as cur:
+            # Set up a release + release_artist row referencing artist 701 so
+            # the stub-INSERT pass touches artist 701.
+            cur.execute("INSERT INTO release (id, title) VALUES (700, 'Aluminum Tunes')")
+            cur.execute(
+                "INSERT INTO release_artist (release_id, artist_id, artist_name) "
+                "VALUES (700, 701, 'Stereolab')"
+            )
+            # Pre-existing tombstoned artist.
+            cur.execute("INSERT INTO artist (id, name, not_found) VALUES (701, '', TRUE)")
+        conn.commit()
+        conn.close()
+
+        # No artist.csv → only the stub-INSERT path runs. The stub path is
+        # what the issue specifies must clear tombstones.
+        conn = psycopg.connect(self.db_url)
+        # import_artist_details requires the csv_dir to exist but only reads
+        # artist.csv (optional) for the profile pass — we want only the stub.
+        import_artist_details(conn, tmp_path)
+        conn.close()
+
+        conn = psycopg.connect(self.db_url)
+        with conn.cursor() as cur:
+            cur.execute("SELECT name, not_found FROM artist WHERE id = 701")
+            row = cur.fetchone()
+        conn.close()
+        assert row is not None
+        name, not_found = row
+        assert not_found is False, (
+            f"Rebuild must clear the artist tombstone (not_found=FALSE); "
+            f"got not_found={not_found!r}. The stub-INSERT in "
+            f"import_artist_details must update not_found = FALSE on conflict."
+        )


### PR DESCRIPTION
## Summary

- Adds `not_found BOOLEAN NOT NULL DEFAULT FALSE` to `release` and `artist`, mirrored in both alembic and `schema/create_database.sql`.
- Updates the rebuild + dedup-swap + prune-swap paths so `not_found` survives CTAS, the DEFAULT is restored before swap, NOT NULL is re-asserted at Level-2, and a pipeline refresh clears any prior LML#510 tombstone (`not_found = FALSE` in INSERT + `ON CONFLICT DO UPDATE SET`).
- The `DEFAULT FALSE` keeps the migration backward-compatible: prod LML running pre-510 code reads every existing row as `FALSE` and behaves exactly as before.

Each migration probes a `title = ''` / `name = ''` INSERT before applying the DDL so a future-added CHECK on those columns trips this migration rather than the prod LML tombstone write.

## Land order

This is the foundation. After this lands and `alembic upgrade head` runs in staging:

1. WXYC/wxyc-shared adds `not_found` to `DiscogsReleaseMetadata` (1.12.0).
2. WXYC/library-metadata-lookup#510 pins the new wxyc-shared release, runs codegen, consumes the column from the API and PG cache layers.

## Test plan

- [x] Local PG integration: 6 new alembic tests pass (column shape, idempotence against the legacy dual-written schema path, empty-string round-trip) for both `release` and `artist`.
- [x] Local PG integration: 2 new `import_csv` rebuild tests pass — a pre-existing tombstoned row on both `release` and `artist` gets `not_found = FALSE` after the rebuild.
- [x] Local PG integration: `tests/integration/test_copy_swap_preserves_not_null.py` pins extended with `release.not_found` in `_EXPECTED_NOT_NULL` + `_EXPECTED_DEFAULTS`; dedup-swap and prune-swap regression tests stay green.
- [x] Full local PG sweep: 386 passed, 13 skipped (no regressions); 833 unit tests green.
- [x] `ruff check` + `ruff format --check` clean.
- [ ] Staging `alembic upgrade head` runs against staging PG.

## Related

- WXYC/library-metadata-lookup#510 — the consumer issue and the LML companion PR.
- This repo's #239 / LML#414 — sibling `release.artwork_checked_at` discriminator (same pattern, prior application).
- LML#503 — sibling `artist.fetched_at` discriminator (same pattern, prior application).