### PR TITLE
feat(alembic): 0012 entity.release_identity for LML#526

### DIFF
--- a/alembic/versions/0010_release_not_found.py
+++ b/alembic/versions/0010_release_not_found.py
@@ -74,12 +74,11 @@ Create Date: 2026-06-08
 from __future__ import annotations
 
 import logging
-import os
 from collections.abc import Sequence
 
 import psycopg
 
-from alembic import context
+from lib.alembic_helpers import refuse_offline, resolve_db_url
 
 revision: str = "0010_release_not_found"
 down_revision: str | Sequence[str] | None = "0009_cache_metadata_unique"
@@ -103,26 +102,6 @@ ALTER TABLE release DROP COLUMN IF EXISTS not_found;
 _PROBE_ID = -2147483648
 
 
-def _resolve_db_url() -> str:
-    db_url = os.environ.get("DATABASE_URL_DISCOGS") or os.environ.get("DATABASE_URL")
-    if not db_url:
-        raise RuntimeError(
-            "DATABASE_URL_DISCOGS (or DATABASE_URL) must be set to apply 0010_release_not_found."
-        )
-    return db_url
-
-
-def _refuse_offline(direction: str) -> None:
-    if context.is_offline_mode():
-        raise RuntimeError(
-            f"0010_release_not_found does not support --sql / offline mode "
-            f"({direction}): the migration opens its own psycopg connection "
-            "to apply DDL and run a precondition probe, mirroring 0008. "
-            "Run `alembic upgrade head` (or `downgrade`) against a live DB "
-            "instead."
-        )
-
-
 def _probe_empty_title_write() -> None:
     """Verify ``release.title = ''`` can be written.
 
@@ -133,7 +112,7 @@ def _probe_empty_title_write() -> None:
     consumer (LML#510). Probe runs in a transaction that is always
     rolled back, so nothing is persisted.
     """
-    with psycopg.connect(_resolve_db_url(), autocommit=True) as conn, conn.cursor() as cur:
+    with psycopg.connect(resolve_db_url(revision), autocommit=True) as conn, conn.cursor() as cur:
         cur.execute("BEGIN")
         try:
             cur.execute(
@@ -154,18 +133,18 @@ def _probe_empty_title_write() -> None:
 
 
 def upgrade() -> None:
-    _refuse_offline("upgrade")
+    refuse_offline(revision, "upgrade")
 
     log = logging.getLogger("alembic.runtime.migration")
     _probe_empty_title_write()
 
-    with psycopg.connect(_resolve_db_url(), autocommit=True) as conn, conn.cursor() as cur:
+    with psycopg.connect(resolve_db_url(revision), autocommit=True) as conn, conn.cursor() as cur:
         log.info("0010: ALTER release ADD COLUMN not_found")
         cur.execute(_UPGRADE_SQL)
 
 
 def downgrade() -> None:
-    _refuse_offline("downgrade")
+    refuse_offline(revision, "downgrade")
 
-    with psycopg.connect(_resolve_db_url(), autocommit=True) as conn, conn.cursor() as cur:
+    with psycopg.connect(resolve_db_url(revision), autocommit=True) as conn, conn.cursor() as cur:
         cur.execute(_DOWNGRADE_SQL)

--- a/alembic/versions/0011_artist_not_found.py
+++ b/alembic/versions/0011_artist_not_found.py
@@ -38,12 +38,11 @@ Create Date: 2026-06-08
 from __future__ import annotations
 
 import logging
-import os
 from collections.abc import Sequence
 
 import psycopg
 
-from alembic import context
+from lib.alembic_helpers import refuse_offline, resolve_db_url
 
 revision: str = "0011_artist_not_found"
 down_revision: str | Sequence[str] | None = "0010_release_not_found"
@@ -64,25 +63,6 @@ ALTER TABLE artist DROP COLUMN IF EXISTS not_found;
 _PROBE_ID = -2147483648
 
 
-def _resolve_db_url() -> str:
-    db_url = os.environ.get("DATABASE_URL_DISCOGS") or os.environ.get("DATABASE_URL")
-    if not db_url:
-        raise RuntimeError(
-            "DATABASE_URL_DISCOGS (or DATABASE_URL) must be set to apply 0011_artist_not_found."
-        )
-    return db_url
-
-
-def _refuse_offline(direction: str) -> None:
-    if context.is_offline_mode():
-        raise RuntimeError(
-            f"0011_artist_not_found does not support --sql / offline mode "
-            f"({direction}): the migration opens its own psycopg connection "
-            "to apply DDL and run a precondition probe. Run `alembic "
-            "upgrade head` (or `downgrade`) against a live DB instead."
-        )
-
-
 def _probe_empty_name_write() -> None:
     """Verify ``artist.name = ''`` can be written.
 
@@ -90,7 +70,7 @@ def _probe_empty_name_write() -> None:
     Probing surfaces a future-added CHECK at migration time rather than
     on the first prod 404.
     """
-    with psycopg.connect(_resolve_db_url(), autocommit=True) as conn, conn.cursor() as cur:
+    with psycopg.connect(resolve_db_url(revision), autocommit=True) as conn, conn.cursor() as cur:
         cur.execute("BEGIN")
         try:
             cur.execute(
@@ -111,18 +91,18 @@ def _probe_empty_name_write() -> None:
 
 
 def upgrade() -> None:
-    _refuse_offline("upgrade")
+    refuse_offline(revision, "upgrade")
 
     log = logging.getLogger("alembic.runtime.migration")
     _probe_empty_name_write()
 
-    with psycopg.connect(_resolve_db_url(), autocommit=True) as conn, conn.cursor() as cur:
+    with psycopg.connect(resolve_db_url(revision), autocommit=True) as conn, conn.cursor() as cur:
         log.info("0011: ALTER artist ADD COLUMN not_found")
         cur.execute(_UPGRADE_SQL)
 
 
 def downgrade() -> None:
-    _refuse_offline("downgrade")
+    refuse_offline(revision, "downgrade")
 
-    with psycopg.connect(_resolve_db_url(), autocommit=True) as conn, conn.cursor() as cur:
+    with psycopg.connect(resolve_db_url(revision), autocommit=True) as conn, conn.cursor() as cur:
         cur.execute(_DOWNGRADE_SQL)

--- a/alembic/versions/0012_entity_release_identity.py
+++ b/alembic/versions/0012_entity_release_identity.py
@@ -30,10 +30,12 @@ it. The column exists for forward compatibility with LML#207's
 cross-source joiner and the upcoming reconciliation_status writer; no
 trigger needed in v1.
 
-The downgrade drops in FK order — index, then log, then identity — and
-intentionally leaves the ``entity`` schema in place: the artist-side
-tables (``entity.identity`` / ``entity.reconciliation_log``) still live
-there. Adopting those into the alembic chain is tracked at
+The downgrade drops in FK order — child table (release_reconciliation_log)
+first, then parent (release_identity). The DROP TABLE on the child also
+drops its FK index, so no explicit DROP INDEX is needed. The ``entity``
+schema is intentionally left in place: the artist-side tables
+(``entity.identity`` / ``entity.reconciliation_log``) still live there.
+Adopting those into the alembic chain is tracked at
 WXYC/discogs-etl#279.
 
 Defensive pattern: same ``is_offline_mode()`` refuse + autocommit

--- a/alembic/versions/0012_entity_release_identity.py
+++ b/alembic/versions/0012_entity_release_identity.py
@@ -50,12 +50,11 @@ Create Date: 2026-06-10
 from __future__ import annotations
 
 import logging
-import os
 from collections.abc import Sequence
 
 import psycopg
 
-from alembic import context
+from lib.alembic_helpers import refuse_offline, resolve_db_url
 
 revision: str = "0012_entity_release_identity"
 down_revision: str | Sequence[str] | None = "0011_artist_not_found"
@@ -93,47 +92,29 @@ CREATE INDEX IF NOT EXISTS idx_release_reconciliation_log_identity_id
     ON entity.release_reconciliation_log(identity_id);
 """
 
-# FK order: index, then FK-child table, then FK-parent table. Schema is left
-# in place because the artist-side entity.identity / entity.reconciliation_log
+# FK order: child table first, then parent. The DROP TABLE on the child also
+# drops its FK index, so no explicit DROP INDEX is needed. Schema is left in
+# place because the artist-side entity.identity / entity.reconciliation_log
 # tables still live there (out-of-band bootstrap; see #279 for adoption).
 _DOWNGRADE_SQL = """
-DROP INDEX IF EXISTS entity.idx_release_reconciliation_log_identity_id;
 DROP TABLE IF EXISTS entity.release_reconciliation_log;
 DROP TABLE IF EXISTS entity.release_identity;
 """
 
 
-def _resolve_db_url() -> str:
-    db_url = os.environ.get("DATABASE_URL_DISCOGS") or os.environ.get("DATABASE_URL")
-    if not db_url:
-        raise RuntimeError(
-            "DATABASE_URL_DISCOGS (or DATABASE_URL) must be set to apply "
-            "0012_entity_release_identity."
-        )
-    return db_url
-
-
-def _refuse_offline(direction: str) -> None:
-    if context.is_offline_mode():
-        raise RuntimeError(
-            f"0012_entity_release_identity does not support --sql / offline mode "
-            f"({direction}): the migration opens its own psycopg connection to "
-            "apply DDL. Run `alembic upgrade head` (or `downgrade`) against a "
-            "live DB instead."
-        )
-
-
 def upgrade() -> None:
-    _refuse_offline("upgrade")
+    refuse_offline(revision, "upgrade")
 
     log = logging.getLogger("alembic.runtime.migration")
-    with psycopg.connect(_resolve_db_url(), autocommit=True) as conn, conn.cursor() as cur:
+    with psycopg.connect(resolve_db_url(revision), autocommit=True) as conn, conn.cursor() as cur:
         log.info("0012: CREATE SCHEMA + entity.release_identity + reconciliation_log + FK index")
         cur.execute(_UPGRADE_SQL)
 
 
 def downgrade() -> None:
-    _refuse_offline("downgrade")
+    refuse_offline(revision, "downgrade")
 
-    with psycopg.connect(_resolve_db_url(), autocommit=True) as conn, conn.cursor() as cur:
+    log = logging.getLogger("alembic.runtime.migration")
+    with psycopg.connect(resolve_db_url(revision), autocommit=True) as conn, conn.cursor() as cur:
+        log.info("0012: DROP entity.release_reconciliation_log + entity.release_identity")
         cur.execute(_DOWNGRADE_SQL)

--- a/alembic/versions/0012_entity_release_identity.py
+++ b/alembic/versions/0012_entity_release_identity.py
@@ -1,0 +1,139 @@
+"""entity.release_identity / entity.release_reconciliation_log: release-side
+identity layer for LML#526.
+
+Brings the release-side counterpart of the existing artist-side
+``entity.identity`` surface under the alembic chain. After this lands,
+LML's ``POST /api/v1/identity/resolve`` flips from 503 (probe miss in
+``identity/dependencies.py``) to 200.
+
+DDL is mirrored from LML's canonical ``entity/release_identity.sql``
+(WXYC/library-metadata-lookup#530), with one addition: ``CREATE SCHEMA
+IF NOT EXISTS entity`` precedes the table DDL because the canonical file
+assumes the schema is already present. Existing prod has the schema from
+out-of-band bootstrap; fresh dev DBs do not.
+
+The columns ``discogs_release_id`` and ``discogs_master_id`` are
+``INTEGER`` but **not** FKs to the cache's ``release.id`` / ``master.id``.
+They are external identifiers — the identity layer's lifecycle is
+independent of the monthly cache rebuild, and the FKs would couple the
+two.
+
+Per-source UNIQUE columns are load-bearing for LML's mint protocol
+concurrency safety. ``entity/store.py::mint_or_get_release_identity``
+issues ``INSERT ... ON CONFLICT ({col}) DO NOTHING RETURNING id`` per
+source; dropping any UNIQUE raises a loud 500 (``RuntimeError("UNIQUE
+constraint appears broken")``) rather than silently double-minting.
+
+``updated_at`` currently always equals ``created_at`` — the v1 mint
+protocol never updates an existing row, only conflict-fallthrough-SELECTs
+it. The column exists for forward compatibility with LML#207's
+cross-source joiner and the upcoming reconciliation_status writer; no
+trigger needed in v1.
+
+The downgrade drops in FK order — index, then log, then identity — and
+intentionally leaves the ``entity`` schema in place: the artist-side
+tables (``entity.identity`` / ``entity.reconciliation_log``) still live
+there. Adopting those into the alembic chain is tracked at
+WXYC/discogs-etl#279.
+
+Defensive pattern: same ``is_offline_mode()`` refuse + autocommit
+``psycopg.connect`` side-channel as 0010 / 0011 so ``alembic upgrade
+--sql`` (offline mode) fails fast rather than silently emitting no-op
+SQL.
+
+Revision ID: 0012_entity_release_identity
+Revises: 0011_artist_not_found
+Create Date: 2026-06-10
+
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from collections.abc import Sequence
+
+import psycopg
+
+from alembic import context
+
+revision: str = "0012_entity_release_identity"
+down_revision: str | Sequence[str] | None = "0011_artist_not_found"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+_UPGRADE_SQL = """
+CREATE SCHEMA IF NOT EXISTS entity;
+
+CREATE TABLE IF NOT EXISTS entity.release_identity (
+    id SERIAL PRIMARY KEY,
+    discogs_release_id INTEGER UNIQUE,
+    discogs_master_id INTEGER UNIQUE,
+    musicbrainz_release_id TEXT UNIQUE,
+    spotify_album_id TEXT UNIQUE,
+    apple_music_album_id TEXT UNIQUE,
+    bandcamp_album_url TEXT UNIQUE,
+    reconciliation_status TEXT NOT NULL DEFAULT 'unreconciled',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS entity.release_reconciliation_log (
+    id SERIAL PRIMARY KEY,
+    identity_id INTEGER NOT NULL REFERENCES entity.release_identity(id),
+    source TEXT NOT NULL,
+    external_id TEXT NOT NULL,
+    confidence REAL,
+    method TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_release_reconciliation_log_identity_id
+    ON entity.release_reconciliation_log(identity_id);
+"""
+
+# FK order: index, then FK-child table, then FK-parent table. Schema is left
+# in place because the artist-side entity.identity / entity.reconciliation_log
+# tables still live there (out-of-band bootstrap; see #279 for adoption).
+_DOWNGRADE_SQL = """
+DROP INDEX IF EXISTS entity.idx_release_reconciliation_log_identity_id;
+DROP TABLE IF EXISTS entity.release_reconciliation_log;
+DROP TABLE IF EXISTS entity.release_identity;
+"""
+
+
+def _resolve_db_url() -> str:
+    db_url = os.environ.get("DATABASE_URL_DISCOGS") or os.environ.get("DATABASE_URL")
+    if not db_url:
+        raise RuntimeError(
+            "DATABASE_URL_DISCOGS (or DATABASE_URL) must be set to apply "
+            "0012_entity_release_identity."
+        )
+    return db_url
+
+
+def _refuse_offline(direction: str) -> None:
+    if context.is_offline_mode():
+        raise RuntimeError(
+            f"0012_entity_release_identity does not support --sql / offline mode "
+            f"({direction}): the migration opens its own psycopg connection to "
+            "apply DDL. Run `alembic upgrade head` (or `downgrade`) against a "
+            "live DB instead."
+        )
+
+
+def upgrade() -> None:
+    _refuse_offline("upgrade")
+
+    log = logging.getLogger("alembic.runtime.migration")
+    with psycopg.connect(_resolve_db_url(), autocommit=True) as conn, conn.cursor() as cur:
+        log.info("0012: CREATE SCHEMA + entity.release_identity + reconciliation_log + FK index")
+        cur.execute(_UPGRADE_SQL)
+
+
+def downgrade() -> None:
+    _refuse_offline("downgrade")
+
+    with psycopg.connect(_resolve_db_url(), autocommit=True) as conn, conn.cursor() as cur:
+        cur.execute(_DOWNGRADE_SQL)

--- a/lib/alembic_helpers.py
+++ b/lib/alembic_helpers.py
@@ -20,14 +20,15 @@ from __future__ import annotations
 
 import os
 
-from alembic import context
-
 
 def resolve_db_url(revision_label: str) -> str:
     """Return the discogs-cache DB URL or raise with an actionable message.
 
     ``revision_label`` is the migration's revision id, used in the error
     message so operators see which migration is missing the env var.
+
+    Does NOT import alembic — callable from any context (unit tests, CLI
+    scripts, etc.) without a live MigrationContext.
     """
     db_url = os.environ.get("DATABASE_URL_DISCOGS") or os.environ.get("DATABASE_URL")
     if not db_url:
@@ -45,7 +46,12 @@ def refuse_offline(revision_label: str, direction: str) -> None:
     actually opening a connection, so the side-channel ``psycopg.connect``
     would never run — the operator would see a successful ``alembic
     upgrade --sql`` while the DDL never landed on the target DB.
+
+    ``alembic.context`` is imported lazily so callers that only need
+    ``resolve_db_url`` do not take a hard dependency on alembic.
     """
+    from alembic import context
+
     if context.is_offline_mode():
         raise RuntimeError(
             f"{revision_label} does not support --sql / offline mode "

--- a/lib/alembic_helpers.py
+++ b/lib/alembic_helpers.py
@@ -1,0 +1,55 @@
+"""Shared helpers for autocommit side-channel migrations.
+
+Migrations that need to issue DDL via a direct ``psycopg.connect(...,
+autocommit=True)`` side-channel — rather than through alembic's
+``op.execute`` path — all need the same two pieces of plumbing:
+
+* Resolve the cache DB URL from the canonical env vars
+  (``DATABASE_URL_DISCOGS`` with ``DATABASE_URL`` as deprecated fallback,
+  matching ``alembic/env.py``).
+* Refuse to run under ``alembic upgrade --sql`` (offline mode), which
+  cannot intercept the side-channel connection and would otherwise emit
+  no-op SQL while the migration's DDL silently does not land.
+
+Used by 0010 (``release.not_found``), 0011 (``artist.not_found``), 0012
+(``entity.release_identity`` family), and any future migration following
+the same pattern.
+"""
+
+from __future__ import annotations
+
+import os
+
+from alembic import context
+
+
+def resolve_db_url(revision_label: str) -> str:
+    """Return the discogs-cache DB URL or raise with an actionable message.
+
+    ``revision_label`` is the migration's revision id, used in the error
+    message so operators see which migration is missing the env var.
+    """
+    db_url = os.environ.get("DATABASE_URL_DISCOGS") or os.environ.get("DATABASE_URL")
+    if not db_url:
+        raise RuntimeError(
+            f"DATABASE_URL_DISCOGS (or DATABASE_URL) must be set to apply {revision_label}."
+        )
+    return db_url
+
+
+def refuse_offline(revision_label: str, direction: str) -> None:
+    """Abort if the migration is being applied in offline (``--sql``) mode.
+
+    Side-channel migrations open their own psycopg connection to apply DDL.
+    Alembic's offline mode emits the migration body as SQL text without
+    actually opening a connection, so the side-channel ``psycopg.connect``
+    would never run — the operator would see a successful ``alembic
+    upgrade --sql`` while the DDL never landed on the target DB.
+    """
+    if context.is_offline_mode():
+        raise RuntimeError(
+            f"{revision_label} does not support --sql / offline mode "
+            f"({direction}): the migration opens its own psycopg connection "
+            "to apply DDL. Run `alembic upgrade head` (or `downgrade`) "
+            "against a live DB instead."
+        )

--- a/schema/create_database.sql
+++ b/schema/create_database.sql
@@ -287,3 +287,48 @@ CREATE INDEX IF NOT EXISTS idx_cache_metadata_source ON cache_metadata(source);
 
 -- Negative-cache TTL-sweep index (mirrors 0006_lookup_negative.py)
 CREATE INDEX IF NOT EXISTS idx_lookup_negative_attempted_at ON lookup_negative(attempted_at);
+
+-- ============================================
+-- LML-owned identity layer (entity schema)
+-- ============================================
+-- Mirrors alembic/versions/0012_entity_release_identity.py per the dual-write
+-- convention so a fresh rebuild (`run_pipeline.py --fresh-rebuild`) produces
+-- the same end state as the alembic upgrade chain. Without the mirror, a dev
+-- DB built only through create_database.sql leaves LML's
+-- POST /api/v1/identity/resolve probe returning 503.
+--
+-- Lifecycle note: entity.* tables hold LML-owned mint state and survive the
+-- monthly cache rebuild. drop_core_tables.sql intentionally does NOT drop
+-- them; --truncate-existing intentionally does NOT include them in the
+-- TRUNCATE list (see CACHE_TABLES_TO_TRUNCATE_BASE in scripts/import_csv.py).
+--
+-- Artist-side counterparts (entity.identity / entity.reconciliation_log) still
+-- live in prod via out-of-band bootstrap and are not yet adopted into the
+-- alembic chain or this file — tracked at WXYC/discogs-etl#279.
+CREATE SCHEMA IF NOT EXISTS entity;
+
+CREATE TABLE IF NOT EXISTS entity.release_identity (
+    id                       SERIAL PRIMARY KEY,
+    discogs_release_id       INTEGER UNIQUE,
+    discogs_master_id        INTEGER UNIQUE,
+    musicbrainz_release_id   TEXT UNIQUE,
+    spotify_album_id         TEXT UNIQUE,
+    apple_music_album_id     TEXT UNIQUE,
+    bandcamp_album_url       TEXT UNIQUE,
+    reconciliation_status    TEXT NOT NULL DEFAULT 'unreconciled',
+    created_at               TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at               TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS entity.release_reconciliation_log (
+    id           SERIAL PRIMARY KEY,
+    identity_id  INTEGER NOT NULL REFERENCES entity.release_identity(id),
+    source       TEXT NOT NULL,
+    external_id  TEXT NOT NULL,
+    confidence   REAL,
+    method       TEXT NOT NULL,
+    created_at   TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_release_reconciliation_log_identity_id
+    ON entity.release_reconciliation_log(identity_id);

--- a/scripts/import_csv.py
+++ b/scripts/import_csv.py
@@ -306,23 +306,31 @@ CACHE_TABLES_TO_TRUNCATE_TRACKS: list[str] = [
 ]
 
 
-# Runtime guard for the "preserves the entire entity schema" promise carried
-# by the comment above and by --truncate-existing's help text. The exclusion
-# works because both lists hold bare public-schema table names — any
-# schema-qualified name (the only way to reach entity.* via TRUNCATE) trips
-# this guard at import time, before any pipeline run can do damage. A loose
-# bare-prefix check would overshoot onto legitimate public tables that
-# happen to start with "entity" (e.g. a future `entity_log` analytics
-# table), so the contract is narrowed to schema qualifiers only.
-for _truncate_table in (*CACHE_TABLES_TO_TRUNCATE_BASE, *CACHE_TABLES_TO_TRUNCATE_TRACKS):
-    if "." in _truncate_table:
-        raise RuntimeError(
-            f"--truncate-existing list must not include schema-qualified names; "
-            f"found {_truncate_table!r}. Cross-schema TRUNCATE is the only path "
-            f"that could reach LML-owned entity.* state — see comment above "
-            f"CACHE_TABLES_TO_TRUNCATE_BASE."
-        )
-del _truncate_table
+def _validate_truncate_lists() -> None:
+    """Enforce the 'preserves the entire entity schema' promise at import time.
+
+    The exclusion works because both truncate lists hold bare public-schema
+    table names — any schema-qualified entry (the only way to reach entity.*
+    via TRUNCATE) trips this guard before any pipeline run can do damage.
+    A loose bare-prefix check would overshoot onto legitimate public tables
+    that happen to start with "entity" (e.g. a future ``entity_log``
+    analytics table), so the contract is narrowed to schema qualifiers only.
+
+    Wrapped in a function so the loop variable doesn't leak into the module
+    namespace and so an empty truncate list (e.g. during a future refactor)
+    doesn't raise ``NameError`` from a stray ``del``.
+    """
+    for table in (*CACHE_TABLES_TO_TRUNCATE_BASE, *CACHE_TABLES_TO_TRUNCATE_TRACKS):
+        if "." in table:
+            raise RuntimeError(
+                f"--truncate-existing list must not include schema-qualified "
+                f"names; found {table!r}. Cross-schema TRUNCATE is the only "
+                f"path that could reach LML-owned entity.* state — see "
+                f"comment above CACHE_TABLES_TO_TRUNCATE_BASE."
+            )
+
+
+_validate_truncate_lists()
 
 
 def _truncate_tables(conn, table_names: list[str]) -> None:

--- a/scripts/import_csv.py
+++ b/scripts/import_csv.py
@@ -306,6 +306,21 @@ CACHE_TABLES_TO_TRUNCATE_TRACKS: list[str] = [
 ]
 
 
+# Runtime guard for the "preserves the entire entity schema" promise carried
+# by the comment above and by --truncate-existing's help text. The exclusion
+# is enforced by absence (entity.* tables simply aren't listed), so any
+# accidental addition of a schema-qualified name — or any bare 'entity' alias
+# — would silently break the contract. Tripped at import time, before any
+# pipeline run can do damage.
+for _t in (*CACHE_TABLES_TO_TRUNCATE_BASE, *CACHE_TABLES_TO_TRUNCATE_TRACKS):
+    if "." in _t or _t.startswith("entity"):
+        raise RuntimeError(
+            f"--truncate-existing list must not include entity-schema tables; "
+            f"found {_t!r}. Entity-schema state is LML-owned and survives "
+            f"every cache rebuild — see comment above CACHE_TABLES_TO_TRUNCATE_BASE."
+        )
+
+
 def _truncate_tables(conn, table_names: list[str]) -> None:
     """Wipe the named tables with a single TRUNCATE ... CASCADE.
 

--- a/scripts/import_csv.py
+++ b/scripts/import_csv.py
@@ -264,8 +264,11 @@ TABLES: list[TableConfig] = BASE_TABLES + TRACK_TABLES + VIDEO_TABLES
 # set wipes the full cache; the tracks set wipes only the tables that
 # --tracks-only writes to. Two exclusions in either set:
 #
-#   - entity.identity / entity.reconciliation_log — WXYC-side identity
-#     records the rebuild must NOT touch.
+#   - the entire entity schema (entity.identity / entity.reconciliation_log
+#     are WXYC-side artist identity; entity.release_identity /
+#     entity.release_reconciliation_log are the release-side counterpart
+#     added by alembic 0012 for LML#526). The rebuild must NOT touch any
+#     of these — they hold mint state owned by LML.
 #   - alembic_version — migration history must persist across rebuilds.
 #
 # Mode-awareness matters: in a full run_pipeline.py invocation the base
@@ -1042,7 +1045,7 @@ def main():
         action="store_true",
         help="TRUNCATE the cache tables before COPY. Use when re-running a "
         "rebuild against a DB with stale rows from a prior failed attempt. "
-        "Preserves entity.identity and alembic_version. Without this flag, "
+        "Preserves the entity schema and alembic_version. Without this flag, "
         "a duplicate-key violation on the first table aborts the pipeline.",
     )
 

--- a/scripts/import_csv.py
+++ b/scripts/import_csv.py
@@ -308,17 +308,21 @@ CACHE_TABLES_TO_TRUNCATE_TRACKS: list[str] = [
 
 # Runtime guard for the "preserves the entire entity schema" promise carried
 # by the comment above and by --truncate-existing's help text. The exclusion
-# is enforced by absence (entity.* tables simply aren't listed), so any
-# accidental addition of a schema-qualified name — or any bare 'entity' alias
-# — would silently break the contract. Tripped at import time, before any
-# pipeline run can do damage.
-for _t in (*CACHE_TABLES_TO_TRUNCATE_BASE, *CACHE_TABLES_TO_TRUNCATE_TRACKS):
-    if "." in _t or _t.startswith("entity"):
+# works because both lists hold bare public-schema table names — any
+# schema-qualified name (the only way to reach entity.* via TRUNCATE) trips
+# this guard at import time, before any pipeline run can do damage. A loose
+# bare-prefix check would overshoot onto legitimate public tables that
+# happen to start with "entity" (e.g. a future `entity_log` analytics
+# table), so the contract is narrowed to schema qualifiers only.
+for _truncate_table in (*CACHE_TABLES_TO_TRUNCATE_BASE, *CACHE_TABLES_TO_TRUNCATE_TRACKS):
+    if "." in _truncate_table:
         raise RuntimeError(
-            f"--truncate-existing list must not include entity-schema tables; "
-            f"found {_t!r}. Entity-schema state is LML-owned and survives "
-            f"every cache rebuild — see comment above CACHE_TABLES_TO_TRUNCATE_BASE."
+            f"--truncate-existing list must not include schema-qualified names; "
+            f"found {_truncate_table!r}. Cross-schema TRUNCATE is the only path "
+            f"that could reach LML-owned entity.* state — see comment above "
+            f"CACHE_TABLES_TO_TRUNCATE_BASE."
         )
+del _truncate_table
 
 
 def _truncate_tables(conn, table_names: list[str]) -> None:

--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -274,8 +274,8 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         action="store_true",
         help="Pass --truncate-existing to scripts/import_csv.py so the cache "
         "tables are wiped before COPY. Use when re-running a rebuild against "
-        "a DB with stale rows from a prior failed attempt. Preserves "
-        "entity.identity and alembic_version.",
+        "a DB with stale rows from a prior failed attempt. Preserves the "
+        "entity schema and alembic_version.",
     )
     parser.add_argument(
         "--fresh-rebuild",
@@ -1066,7 +1066,9 @@ def _run_database_build(
             # is a no-op against a populated DB (every CREATE is IF NOT
             # EXISTS), which is the incremental default that preserves
             # LML-back-patched artwork. drop_core_tables.sql does NOT drop
-            # alembic_version, entity.identity, etc.
+            # alembic_version or the entity schema (which holds LML-owned
+            # identity / reconciliation state on both the artist and release
+            # sides — entity.release_identity ships in alembic 0012).
             logger.warning("--fresh-rebuild: dropping core-table subgraph")
             run_sql_file(db_url, SCHEMA_DIR / "drop_core_tables.sql")
         run_sql_file(db_url, SCHEMA_DIR / "create_functions.sql")

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -17,12 +17,21 @@ import pytest
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
+# Cap any single alembic invocation. A migration that deadlocks (e.g., a
+# CREATE INDEX waiting on a lock it never gets) would otherwise hang the
+# test process until CI's outer timeout — often tens of minutes — fires.
+# 60s comfortably covers the slowest migration in the chain today
+# (sub-second) with headroom for Docker-cold-start jitter.
+_ALEMBIC_SUBPROCESS_TIMEOUT_SECONDS = 60
+
+
 def _run_alembic(args: list[str], db_url: str) -> subprocess.CompletedProcess[str]:
     """Invoke ``python -m alembic <args>`` with the cache DB URL set.
 
     Pops ``DATABASE_URL`` so the deprecated fallback in ``alembic/env.py``
     can't accidentally point the subprocess at a different DB if it's
-    inherited from the caller's shell.
+    inherited from the caller's shell. Raises ``subprocess.TimeoutExpired``
+    rather than hanging if the subprocess deadlocks.
     """
     env = {**os.environ, "DATABASE_URL_DISCOGS": db_url}
     env.pop("DATABASE_URL", None)
@@ -32,6 +41,7 @@ def _run_alembic(args: list[str], db_url: str) -> subprocess.CompletedProcess[st
         env=env,
         capture_output=True,
         text=True,
+        timeout=_ALEMBIC_SUBPROCESS_TIMEOUT_SECONDS,
     )
 
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,46 @@
+"""Shared fixtures for integration tests.
+
+Layered on top of ``tests/conftest.py`` (which provides ``db_url`` /
+``fresh_db_url`` against the Docker PG). This file adds helpers that
+several alembic-migration tests need.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _run_alembic(args: list[str], db_url: str) -> subprocess.CompletedProcess[str]:
+    """Invoke ``python -m alembic <args>`` with the cache DB URL set.
+
+    Pops ``DATABASE_URL`` so the deprecated fallback in ``alembic/env.py``
+    can't accidentally point the subprocess at a different DB if it's
+    inherited from the caller's shell.
+    """
+    env = {**os.environ, "DATABASE_URL_DISCOGS": db_url}
+    env.pop("DATABASE_URL", None)
+    return subprocess.run(
+        [sys.executable, "-m", "alembic", *args],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+
+@pytest.fixture()
+def run_alembic():
+    """Function-scoped fixture exposing the subprocess wrapper.
+
+    Migration tests pass a per-test fresh DB URL through the wrapper to
+    drive ``alembic stamp`` / ``alembic upgrade`` / ``alembic downgrade``
+    against an isolated database.
+    """
+    return _run_alembic

--- a/tests/integration/test_alembic_0012_entity_release_identity.py
+++ b/tests/integration/test_alembic_0012_entity_release_identity.py
@@ -1,0 +1,342 @@
+"""Verify 0012 brings entity.release_identity / entity.release_reconciliation_log
+under the alembic chain for LML#526's release-side identity layer.
+
+LML's ``POST /api/v1/identity/resolve`` returns 503 until both tables exist on
+the discogs-cache PostgreSQL instance. The migration:
+
+* Creates the ``entity`` schema if absent — the LML canonical
+  ``entity/release_identity.sql`` assumes the schema is already present
+  (existing prod has it from out-of-band bootstrap; fresh dev DBs do not).
+* Creates ``entity.release_identity`` with six per-source UNIQUE columns
+  that LML's mint protocol (``INSERT ... ON CONFLICT ({col}) DO NOTHING
+  RETURNING id``) binds against. Dropping any UNIQUE breaks the mint
+  surface — see ``entity/store.py::mint_or_get_release_identity`` in LML.
+* Creates ``entity.release_reconciliation_log`` with an FK to
+  ``release_identity.id`` (``NO ACTION``, matching the artist-side
+  convention).
+* Creates the FK index ``idx_release_reconciliation_log_identity_id``.
+  Postgres does not auto-index FK referencing columns; every
+  ``WHERE identity_id = $1`` lookup needs it.
+
+The migration must be re-application-safe (existing prod already has the
+schema, plus a fresh dev DB after a prior partial run). All DDL uses
+``IF NOT EXISTS``.
+
+The downgrade drops in FK order — index, then log, then identity — and
+intentionally leaves the ``entity`` schema in place because the artist-side
+tables (``entity.identity`` / ``entity.reconciliation_log``) still live
+there. Adopting those into the alembic chain is tracked at
+WXYC/discogs-etl#279.
+
+Tracked at WXYC/discogs-etl#278.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import psycopg
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MIGRATION_PATH = REPO_ROOT / "alembic" / "versions" / "0012_entity_release_identity.py"
+
+
+# Per-source UNIQUE columns load-bearing for LML's mint protocol.
+# Order matches the canonical entity/release_identity.sql in LML#530.
+PER_SOURCE_UNIQUE_COLUMNS: tuple[str, ...] = (
+    "discogs_release_id",
+    "discogs_master_id",
+    "musicbrainz_release_id",
+    "spotify_album_id",
+    "apple_music_album_id",
+    "bandcamp_album_url",
+)
+
+
+# ---------------------------------------------------------------------------
+# Static (no DB) checks
+# ---------------------------------------------------------------------------
+
+
+def test_migration_file_exists() -> None:
+    assert MIGRATION_PATH.exists(), (
+        f"0012 migration missing at {MIGRATION_PATH}. The LML release-identity "
+        "surface returns 503 in prod until both entity tables exist on the "
+        "discogs-cache PG instance."
+    )
+
+
+def test_migration_creates_schema_before_tables() -> None:
+    """The LML canonical DDL omits the schema-create; this migration adds it.
+
+    Fresh dev DBs would fail otherwise.
+    """
+    body = MIGRATION_PATH.read_text(encoding="utf-8")
+    assert "CREATE SCHEMA IF NOT EXISTS entity" in body, (
+        "0012 must bootstrap the entity schema. The canonical "
+        "entity/release_identity.sql in LML#530 assumes the schema is "
+        "already present; against a fresh dev DB without prior out-of-band "
+        "bootstrap, the canonical DDL would fail."
+    )
+
+
+def test_migration_declares_all_per_source_uniques() -> None:
+    body = MIGRATION_PATH.read_text(encoding="utf-8")
+    for col in PER_SOURCE_UNIQUE_COLUMNS:
+        assert col in body, (
+            f"0012 must declare {col} on entity.release_identity. LML's mint "
+            f"protocol uses INSERT ... ON CONFLICT ({col}) DO NOTHING RETURNING "
+            f"id; dropping the column breaks the write surface with a loud "
+            f"500, not a silent duplicate-mint."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Live-PG assertions
+# ---------------------------------------------------------------------------
+
+
+def _run_alembic(args: list[str], db_url: str) -> subprocess.CompletedProcess[str]:
+    env = {**os.environ, "DATABASE_URL_DISCOGS": db_url}
+    env.pop("DATABASE_URL", None)
+    return subprocess.run(
+        [sys.executable, "-m", "alembic", *args],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _stamp_and_upgrade(db_url: str) -> None:
+    """Stamp at 0011 (skipping the prior chain) then upgrade to 0012.
+
+    Stamping avoids dragging the whole 0001→0011 chain into a test that only
+    cares about 0012's surface. The migration is self-contained: it does
+    not depend on any column added by earlier revisions.
+    """
+    stamp = _run_alembic(["stamp", "0011_artist_not_found"], db_url)
+    assert stamp.returncode == 0, (
+        f"alembic stamp failed:\nstdout: {stamp.stdout}\nstderr: {stamp.stderr}"
+    )
+    result = _run_alembic(["upgrade", "0012_entity_release_identity"], db_url)
+    assert result.returncode == 0, (
+        f"alembic upgrade failed:\nstdout: {result.stdout}\nstderr: {result.stderr}"
+    )
+
+
+@pytest.mark.pg
+def test_entity_schema_exists(fresh_db_url: str) -> None:
+    _stamp_and_upgrade(fresh_db_url)
+    with psycopg.connect(fresh_db_url) as conn, conn.cursor() as cur:
+        cur.execute(
+            "SELECT schema_name FROM information_schema.schemata WHERE schema_name = %s",
+            ("entity",),
+        )
+        assert cur.fetchone() is not None, (
+            "entity schema missing after 0012 upgrade. The canonical LML DDL "
+            "omits the schema-create; 0012 must add it for fresh dev DBs."
+        )
+
+
+@pytest.mark.pg
+def test_release_identity_columns(fresh_db_url: str) -> None:
+    _stamp_and_upgrade(fresh_db_url)
+    with psycopg.connect(fresh_db_url) as conn, conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT column_name, data_type, is_nullable
+            FROM information_schema.columns
+            WHERE table_schema = 'entity' AND table_name = 'release_identity'
+            ORDER BY ordinal_position
+            """
+        )
+        rows = {name: (data_type, is_nullable) for name, data_type, is_nullable in cur.fetchall()}
+
+    expected_columns = {
+        "id",
+        "discogs_release_id",
+        "discogs_master_id",
+        "musicbrainz_release_id",
+        "spotify_album_id",
+        "apple_music_album_id",
+        "bandcamp_album_url",
+        "reconciliation_status",
+        "created_at",
+        "updated_at",
+    }
+    assert expected_columns.issubset(rows.keys()), (
+        f"entity.release_identity missing columns: {expected_columns - rows.keys()}"
+    )
+    assert rows["reconciliation_status"] == ("text", "NO")
+    assert rows["created_at"][0] == "timestamp with time zone"
+    assert rows["updated_at"][0] == "timestamp with time zone"
+
+
+@pytest.mark.pg
+def test_six_per_source_unique_constraints(fresh_db_url: str) -> None:
+    """All six per-source UNIQUEs are load-bearing for LML's mint protocol.
+
+    Dropping any one breaks the ON CONFLICT clause in
+    ``entity/store.py::mint_or_get_release_identity`` and raises a loud
+    500 on the LML write surface.
+    """
+    _stamp_and_upgrade(fresh_db_url)
+    with psycopg.connect(fresh_db_url) as conn, conn.cursor() as cur:
+        # Per the wxyc-shared convention, walk pg_constraint rather than
+        # information_schema.table_constraints — the latter loses the
+        # column-list mapping behind a join we'd have to rebuild here.
+        cur.execute(
+            """
+            SELECT a.attname
+            FROM pg_constraint c
+            JOIN pg_class t ON t.oid = c.conrelid
+            JOIN pg_namespace n ON n.oid = t.relnamespace
+            JOIN pg_attribute a ON a.attrelid = c.conrelid AND a.attnum = ANY(c.conkey)
+            WHERE n.nspname = 'entity'
+              AND t.relname = 'release_identity'
+              AND c.contype = 'u'
+              AND cardinality(c.conkey) = 1
+            ORDER BY a.attname
+            """
+        )
+        unique_columns = {row[0] for row in cur.fetchall()}
+
+    assert unique_columns == set(PER_SOURCE_UNIQUE_COLUMNS), (
+        f"Per-source UNIQUE drift on entity.release_identity. Got {unique_columns}, "
+        f"expected {set(PER_SOURCE_UNIQUE_COLUMNS)}. LML's mint protocol binds "
+        f"each ON CONFLICT clause to one of these columns; missing one raises "
+        f"a loud 500 (RuntimeError 'UNIQUE constraint appears broken') in "
+        f"entity/store.py."
+    )
+
+
+@pytest.mark.pg
+def test_reconciliation_log_fk_no_action(fresh_db_url: str) -> None:
+    """FK has no ON DELETE CASCADE — matches the artist-side convention."""
+    _stamp_and_upgrade(fresh_db_url)
+    with psycopg.connect(fresh_db_url) as conn, conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT rc.delete_rule
+            FROM information_schema.referential_constraints rc
+            JOIN information_schema.table_constraints tc
+              ON tc.constraint_name = rc.constraint_name
+             AND tc.constraint_schema = rc.constraint_schema
+            WHERE tc.table_schema = 'entity'
+              AND tc.table_name = 'release_reconciliation_log'
+              AND tc.constraint_type = 'FOREIGN KEY'
+            """
+        )
+        rows = cur.fetchall()
+    assert len(rows) == 1, (
+        f"Expected exactly one FK on entity.release_reconciliation_log, got {len(rows)}."
+    )
+    assert rows[0][0] == "NO ACTION", (
+        f"FK delete_rule must be NO ACTION, got {rows[0][0]!r}. CASCADE would "
+        "silently delete the audit log; consumers expect explicit cleanup."
+    )
+
+
+@pytest.mark.pg
+def test_fk_index_present(fresh_db_url: str) -> None:
+    """idx_release_reconciliation_log_identity_id covers WHERE identity_id = $1."""
+    _stamp_and_upgrade(fresh_db_url)
+    with psycopg.connect(fresh_db_url) as conn, conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT indexname FROM pg_indexes
+            WHERE schemaname = 'entity'
+              AND tablename = 'release_reconciliation_log'
+              AND indexname = 'idx_release_reconciliation_log_identity_id'
+            """
+        )
+        assert cur.fetchone() is not None, (
+            "FK index missing. Postgres does not auto-index FK referencing "
+            "columns, so every WHERE identity_id = $1 lookup would seq-scan."
+        )
+
+
+@pytest.mark.pg
+def test_mint_then_remint_smoke(fresh_db_url: str) -> None:
+    """End-to-end mint protocol shape: first INSERT mints, second is a no-op.
+
+    Mirrors ``entity/store.py::mint_or_get_release_identity`` in LML#530:
+    ``INSERT ... ON CONFLICT (discogs_release_id) DO NOTHING RETURNING id``.
+    The second call must return zero rows so the LML caller falls through
+    to the SELECT-for-conflict-loser branch.
+    """
+    _stamp_and_upgrade(fresh_db_url)
+    with psycopg.connect(fresh_db_url, autocommit=True) as conn, conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO entity.release_identity (discogs_release_id)
+            VALUES (12345)
+            ON CONFLICT (discogs_release_id) DO NOTHING
+            RETURNING id
+            """
+        )
+        first = cur.fetchone()
+        assert first is not None, "First mint must return the new id."
+        identity_id = first[0]
+
+        cur.execute(
+            """
+            INSERT INTO entity.release_identity (discogs_release_id)
+            VALUES (12345)
+            ON CONFLICT (discogs_release_id) DO NOTHING
+            RETURNING id
+            """
+        )
+        second = cur.fetchone()
+        assert second is None, (
+            "Second mint must return zero rows (conflict loser path). "
+            "If this returns a row, the UNIQUE constraint is missing and "
+            "the LML write surface would silently double-mint."
+        )
+
+        cur.execute("SELECT id FROM entity.release_identity WHERE discogs_release_id = 12345")
+        rows = cur.fetchall()
+        assert rows == [(identity_id,)], (
+            f"Expected exactly one row after mint+remint, got {rows!r}."
+        )
+
+
+@pytest.mark.pg
+def test_reapply_is_noop(fresh_db_url: str) -> None:
+    """Re-running the migration against an already-upgraded DB must not fail.
+
+    Production prereq: discogs-cache PG already has the entity schema +
+    artist-side tables from the out-of-band bootstrap. The migration must
+    no-op against that state rather than perturbing it.
+    """
+    _stamp_and_upgrade(fresh_db_url)
+
+    # Seed a sentinel row so we can prove re-application doesn't perturb data.
+    with psycopg.connect(fresh_db_url, autocommit=True) as conn, conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO entity.release_identity (discogs_release_id) VALUES (99999) RETURNING id"
+        )
+        sentinel_id = cur.fetchone()[0]
+
+    # Downgrade alembic state and re-upgrade so the IF NOT EXISTS branches fire.
+    downgrade = _run_alembic(["stamp", "0011_artist_not_found"], fresh_db_url)
+    assert downgrade.returncode == 0
+    reupgrade = _run_alembic(["upgrade", "0012_entity_release_identity"], fresh_db_url)
+    assert reupgrade.returncode == 0, (
+        f"Re-application failed:\nstdout: {reupgrade.stdout}\nstderr: {reupgrade.stderr}"
+    )
+
+    with psycopg.connect(fresh_db_url) as conn, conn.cursor() as cur:
+        cur.execute(
+            "SELECT discogs_release_id FROM entity.release_identity WHERE id = %s",
+            (sentinel_id,),
+        )
+        assert cur.fetchone() == (99999,), (
+            "Sentinel row lost across re-application. The migration must use "
+            "CREATE TABLE IF NOT EXISTS so existing rows survive."
+        )

--- a/tests/integration/test_alembic_0012_entity_release_identity.py
+++ b/tests/integration/test_alembic_0012_entity_release_identity.py
@@ -33,6 +33,7 @@ Tracked at WXYC/discogs-etl#278.
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 import psycopg
@@ -40,6 +41,30 @@ import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 MIGRATION_PATH = REPO_ROOT / "alembic" / "versions" / "0012_entity_release_identity.py"
+
+
+def _read_revision_metadata() -> tuple[str, str]:
+    """Return (revision, down_revision) parsed from 0012's source file.
+
+    Source-of-truth lookup keeps the test from hardcoding revision strings
+    that might be shortened later (e.g., 0009's revision id was trimmed to
+    fit alembic_version varchar(32) in commit c228b47). If the chain is
+    renamed, this test tracks automatically instead of failing eight cases
+    in lockstep on a stale stamp target.
+
+    Regex over the file rather than importlib because the migration's
+    imports (``from lib.alembic_helpers import ...``) require alembic-aware
+    sys.path setup that pytest collection does not guarantee.
+    """
+    body = MIGRATION_PATH.read_text(encoding="utf-8")
+    rev = re.search(r'^revision:\s*str\s*=\s*"([^"]+)"', body, re.MULTILINE)
+    down = re.search(r'^down_revision:\s*str\s*\|[^=]+=\s*"([^"]+)"', body, re.MULTILINE)
+    assert rev is not None, f"Could not find revision assignment in {MIGRATION_PATH}"
+    assert down is not None, f"Could not find down_revision assignment in {MIGRATION_PATH}"
+    return rev.group(1), down.group(1)
+
+
+REVISION, PRIOR_REVISION = _read_revision_metadata()
 
 
 # Per-source UNIQUE columns load-bearing for LML's mint protocol.
@@ -113,11 +138,11 @@ def _stamp_and_upgrade(run_alembic, db_url: str) -> None:
     cares about 0012's surface. The migration is self-contained: it does
     not depend on any column added by earlier revisions.
     """
-    stamp = run_alembic(["stamp", "0011_artist_not_found"], db_url)
+    stamp = run_alembic(["stamp", PRIOR_REVISION], db_url)
     assert stamp.returncode == 0, (
         f"alembic stamp failed:\nstdout: {stamp.stdout}\nstderr: {stamp.stderr}"
     )
-    result = run_alembic(["upgrade", "0012_entity_release_identity"], db_url)
+    result = run_alembic(["upgrade", REVISION], db_url)
     assert result.returncode == 0, (
         f"alembic upgrade failed:\nstdout: {result.stdout}\nstderr: {result.stderr}"
     )
@@ -203,13 +228,24 @@ def test_release_identity_columns(run_alembic, fresh_db_url: str) -> None:
 
     # reconciliation_status DEFAULT 'unreconciled' is load-bearing for LML's
     # state machine — newly-minted rows must carry the canonical sentinel so
-    # the reconciler routes them to the right branch.
+    # the reconciler routes them to the right branch. Extract the literal
+    # portion of the column_default expression and assert exact equality so
+    # a drift to 'unreconciled_v2' or similar (which would still pass a
+    # substring check that didn't anchor the closing quote in PG syntax)
+    # cannot slip through.
     status_default = rows["reconciliation_status"][2] or ""
-    assert "'unreconciled'" in status_default, (
-        f"entity.release_identity.reconciliation_status DEFAULT drifted. "
-        f"Got column_default={status_default!r}; expected the literal "
-        f"'unreconciled'. LML's mint INSERT omits this column, so the "
-        f"DEFAULT is the only place the seed sentinel is written."
+    literal_match = re.fullmatch(r"'([^']*)'::text", status_default)
+    assert literal_match is not None, (
+        f"entity.release_identity.reconciliation_status DEFAULT expression "
+        f"is not a bare text literal. Got column_default={status_default!r}; "
+        f"expected 'unreconciled'::text. LML's mint INSERT omits this column, "
+        f"so the DEFAULT is the only place the seed sentinel is written."
+    )
+    assert literal_match.group(1) == "unreconciled", (
+        f"entity.release_identity.reconciliation_status DEFAULT literal "
+        f"drifted: got {literal_match.group(1)!r}, expected 'unreconciled'. "
+        f"LML's reconciler routes on the canonical sentinel; any rename "
+        f"strands newly-minted rows in the wrong state-machine branch."
     )
 
 
@@ -438,9 +474,9 @@ def test_reapply_is_noop(run_alembic, fresh_db_url: str) -> None:
 
     # Rewind alembic state (stamp, not downgrade — tables stay) and re-upgrade
     # so the IF NOT EXISTS branches fire against existing tables.
-    rewind = run_alembic(["stamp", "0011_artist_not_found"], fresh_db_url)
+    rewind = run_alembic(["stamp", PRIOR_REVISION], fresh_db_url)
     assert rewind.returncode == 0
-    reupgrade = run_alembic(["upgrade", "0012_entity_release_identity"], fresh_db_url)
+    reupgrade = run_alembic(["upgrade", REVISION], fresh_db_url)
     assert reupgrade.returncode == 0, (
         f"Re-application failed:\nstdout: {reupgrade.stdout}\nstderr: {reupgrade.stderr}"
     )
@@ -472,7 +508,7 @@ def test_downgrade_drops_release_side_tables(run_alembic, fresh_db_url: str) -> 
     """
     _stamp_and_upgrade(run_alembic, fresh_db_url)
 
-    downgrade = run_alembic(["downgrade", "0011_artist_not_found"], fresh_db_url)
+    downgrade = run_alembic(["downgrade", PRIOR_REVISION], fresh_db_url)
     assert downgrade.returncode == 0, (
         f"alembic downgrade failed:\nstdout: {downgrade.stdout}\nstderr: {downgrade.stderr}"
     )

--- a/tests/integration/test_alembic_0012_entity_release_identity.py
+++ b/tests/integration/test_alembic_0012_entity_release_identity.py
@@ -22,7 +22,7 @@ The migration must be re-application-safe (existing prod already has the
 schema, plus a fresh dev DB after a prior partial run). All DDL uses
 ``IF NOT EXISTS``.
 
-The downgrade drops in FK order — index, then log, then identity — and
+The downgrade drops in FK order — child table, then parent — and
 intentionally leaves the ``entity`` schema in place because the artist-side
 tables (``entity.identity`` / ``entity.reconciliation_log``) still live
 there. Adopting those into the alembic chain is tracked at
@@ -33,9 +33,6 @@ Tracked at WXYC/discogs-etl#278.
 
 from __future__ import annotations
 
-import os
-import subprocess
-import sys
 from pathlib import Path
 
 import psycopg
@@ -57,12 +54,46 @@ PER_SOURCE_UNIQUE_COLUMNS: tuple[str, ...] = (
 )
 
 
+# Expected column shape on entity.release_identity:
+# (data_type, is_nullable). Keys are column names.
+# Pins types so a future widening (id INTEGER → BIGINT, discogs_*_id INTEGER →
+# BIGINT) trips this test before reaching LML's mint protocol.
+RELEASE_IDENTITY_COLUMN_SHAPE: dict[str, tuple[str, str]] = {
+    "id": ("integer", "NO"),
+    "discogs_release_id": ("integer", "YES"),
+    "discogs_master_id": ("integer", "YES"),
+    "musicbrainz_release_id": ("text", "YES"),
+    "spotify_album_id": ("text", "YES"),
+    "apple_music_album_id": ("text", "YES"),
+    "bandcamp_album_url": ("text", "YES"),
+    "reconciliation_status": ("text", "NO"),
+    "created_at": ("timestamp with time zone", "NO"),
+    "updated_at": ("timestamp with time zone", "NO"),
+}
+
+
+# Expected column shape on entity.release_reconciliation_log.
+# LML's audit-log INSERT binds the (source, external_id, confidence, method)
+# tuple positionally; drift in nullability or types corrupts the audit trail.
+RECONCILIATION_LOG_COLUMN_SHAPE: dict[str, tuple[str, str]] = {
+    "id": ("integer", "NO"),
+    "identity_id": ("integer", "NO"),
+    "source": ("text", "NO"),
+    "external_id": ("text", "NO"),
+    "confidence": ("real", "YES"),
+    "method": ("text", "NO"),
+    "created_at": ("timestamp with time zone", "NO"),
+}
+
+
 # ---------------------------------------------------------------------------
 # Static (no DB) checks
 # ---------------------------------------------------------------------------
 
 
 def test_migration_file_exists() -> None:
+    """Fast static gate so a missing-file regression doesn't masquerade as a
+    pg-skip when the Docker DB isn't available."""
     assert MIGRATION_PATH.exists(), (
         f"0012 migration missing at {MIGRATION_PATH}. The LML release-identity "
         "surface returns 503 in prod until both entity tables exist on the "
@@ -70,68 +101,57 @@ def test_migration_file_exists() -> None:
     )
 
 
-def test_migration_creates_schema_before_tables() -> None:
-    """The LML canonical DDL omits the schema-create; this migration adds it.
-
-    Fresh dev DBs would fail otherwise.
-    """
-    body = MIGRATION_PATH.read_text(encoding="utf-8")
-    assert "CREATE SCHEMA IF NOT EXISTS entity" in body, (
-        "0012 must bootstrap the entity schema. The canonical "
-        "entity/release_identity.sql in LML#530 assumes the schema is "
-        "already present; against a fresh dev DB without prior out-of-band "
-        "bootstrap, the canonical DDL would fail."
-    )
-
-
-def test_migration_declares_all_per_source_uniques() -> None:
-    body = MIGRATION_PATH.read_text(encoding="utf-8")
-    for col in PER_SOURCE_UNIQUE_COLUMNS:
-        assert col in body, (
-            f"0012 must declare {col} on entity.release_identity. LML's mint "
-            f"protocol uses INSERT ... ON CONFLICT ({col}) DO NOTHING RETURNING "
-            f"id; dropping the column breaks the write surface with a loud "
-            f"500, not a silent duplicate-mint."
-        )
-
-
 # ---------------------------------------------------------------------------
 # Live-PG assertions
 # ---------------------------------------------------------------------------
 
 
-def _run_alembic(args: list[str], db_url: str) -> subprocess.CompletedProcess[str]:
-    env = {**os.environ, "DATABASE_URL_DISCOGS": db_url}
-    env.pop("DATABASE_URL", None)
-    return subprocess.run(
-        [sys.executable, "-m", "alembic", *args],
-        cwd=REPO_ROOT,
-        env=env,
-        capture_output=True,
-        text=True,
-    )
-
-
-def _stamp_and_upgrade(db_url: str) -> None:
+def _stamp_and_upgrade(run_alembic, db_url: str) -> None:
     """Stamp at 0011 (skipping the prior chain) then upgrade to 0012.
 
     Stamping avoids dragging the whole 0001→0011 chain into a test that only
     cares about 0012's surface. The migration is self-contained: it does
     not depend on any column added by earlier revisions.
     """
-    stamp = _run_alembic(["stamp", "0011_artist_not_found"], db_url)
+    stamp = run_alembic(["stamp", "0011_artist_not_found"], db_url)
     assert stamp.returncode == 0, (
         f"alembic stamp failed:\nstdout: {stamp.stdout}\nstderr: {stamp.stderr}"
     )
-    result = _run_alembic(["upgrade", "0012_entity_release_identity"], db_url)
+    result = run_alembic(["upgrade", "0012_entity_release_identity"], db_url)
     assert result.returncode == 0, (
         f"alembic upgrade failed:\nstdout: {result.stdout}\nstderr: {result.stderr}"
     )
 
 
+def _seed_bootstrap_state(db_url: str) -> None:
+    """Pre-create the entity schema + a mock artist-side ``entity.identity``
+    table so we exercise the documented prod scenario: existing prod has the
+    schema and artist-side tables from out-of-band bootstrap before 0012
+    runs. The migration must no-op cleanly against that state.
+
+    The mock ``entity.identity`` table is shaped after LML's canonical
+    artist-side SQL — just enough to verify the migration leaves
+    pre-existing entity tables alone.
+    """
+    with psycopg.connect(db_url, autocommit=True) as conn, conn.cursor() as cur:
+        cur.execute("CREATE SCHEMA entity")
+        cur.execute(
+            """
+            CREATE TABLE entity.identity (
+                id SERIAL PRIMARY KEY,
+                discogs_artist_id INTEGER UNIQUE,
+                musicbrainz_artist_id TEXT UNIQUE,
+                reconciliation_status TEXT NOT NULL DEFAULT 'unreconciled',
+                created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+            )
+            """
+        )
+        cur.execute("INSERT INTO entity.identity (discogs_artist_id) VALUES (777) RETURNING id")
+
+
 @pytest.mark.pg
-def test_entity_schema_exists(fresh_db_url: str) -> None:
-    _stamp_and_upgrade(fresh_db_url)
+def test_entity_schema_exists(run_alembic, fresh_db_url: str) -> None:
+    _stamp_and_upgrade(run_alembic, fresh_db_url)
     with psycopg.connect(fresh_db_url) as conn, conn.cursor() as cur:
         cur.execute(
             "SELECT schema_name FROM information_schema.schemata WHERE schema_name = %s",
@@ -144,48 +164,96 @@ def test_entity_schema_exists(fresh_db_url: str) -> None:
 
 
 @pytest.mark.pg
-def test_release_identity_columns(fresh_db_url: str) -> None:
-    _stamp_and_upgrade(fresh_db_url)
+def test_release_identity_columns(run_alembic, fresh_db_url: str) -> None:
+    """Pin every column's type, nullability, and (where load-bearing) default.
+
+    Strict equality on the column set: a stray added column trips this test
+    instead of slipping through as a silent schema drift.
+    """
+    _stamp_and_upgrade(run_alembic, fresh_db_url)
     with psycopg.connect(fresh_db_url) as conn, conn.cursor() as cur:
         cur.execute(
             """
-            SELECT column_name, data_type, is_nullable
+            SELECT column_name, data_type, is_nullable, column_default
             FROM information_schema.columns
             WHERE table_schema = 'entity' AND table_name = 'release_identity'
             ORDER BY ordinal_position
             """
         )
-        rows = {name: (data_type, is_nullable) for name, data_type, is_nullable in cur.fetchall()}
+        rows = {
+            name: (data_type, is_nullable, column_default)
+            for name, data_type, is_nullable, column_default in cur.fetchall()
+        }
 
-    expected_columns = {
-        "id",
-        "discogs_release_id",
-        "discogs_master_id",
-        "musicbrainz_release_id",
-        "spotify_album_id",
-        "apple_music_album_id",
-        "bandcamp_album_url",
-        "reconciliation_status",
-        "created_at",
-        "updated_at",
-    }
-    assert expected_columns.issubset(rows.keys()), (
-        f"entity.release_identity missing columns: {expected_columns - rows.keys()}"
+    assert rows.keys() == RELEASE_IDENTITY_COLUMN_SHAPE.keys(), (
+        f"entity.release_identity column-set drift. "
+        f"Missing: {RELEASE_IDENTITY_COLUMN_SHAPE.keys() - rows.keys()}; "
+        f"Unexpected: {rows.keys() - RELEASE_IDENTITY_COLUMN_SHAPE.keys()}."
     )
-    assert rows["reconciliation_status"] == ("text", "NO")
-    assert rows["created_at"][0] == "timestamp with time zone"
-    assert rows["updated_at"][0] == "timestamp with time zone"
+    for col, (expected_type, expected_nullable) in RELEASE_IDENTITY_COLUMN_SHAPE.items():
+        actual_type, actual_nullable, _ = rows[col]
+        assert (actual_type, actual_nullable) == (expected_type, expected_nullable), (
+            f"entity.release_identity.{col} drifted: "
+            f"got ({actual_type!r}, {actual_nullable!r}), "
+            f"expected ({expected_type!r}, {expected_nullable!r}). "
+            f"A SERIAL→BIGSERIAL widening or INTEGER↔TEXT swap on any per-source "
+            f"identifier breaks LML's mint protocol or the FK alignment with "
+            f"entity.release_reconciliation_log.identity_id INTEGER."
+        )
+
+    # reconciliation_status DEFAULT 'unreconciled' is load-bearing for LML's
+    # state machine — newly-minted rows must carry the canonical sentinel so
+    # the reconciler routes them to the right branch.
+    status_default = rows["reconciliation_status"][2] or ""
+    assert "'unreconciled'" in status_default, (
+        f"entity.release_identity.reconciliation_status DEFAULT drifted. "
+        f"Got column_default={status_default!r}; expected the literal "
+        f"'unreconciled'. LML's mint INSERT omits this column, so the "
+        f"DEFAULT is the only place the seed sentinel is written."
+    )
 
 
 @pytest.mark.pg
-def test_six_per_source_unique_constraints(fresh_db_url: str) -> None:
+def test_release_reconciliation_log_columns(run_alembic, fresh_db_url: str) -> None:
+    """Pin entity.release_reconciliation_log column shape end-to-end.
+
+    LML's audit-log writer binds (identity_id, source, external_id, confidence,
+    method) positionally; any drift in column existence, type, or nullability
+    corrupts the audit trail.
+    """
+    _stamp_and_upgrade(run_alembic, fresh_db_url)
+    with psycopg.connect(fresh_db_url) as conn, conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT column_name, data_type, is_nullable
+            FROM information_schema.columns
+            WHERE table_schema = 'entity' AND table_name = 'release_reconciliation_log'
+            ORDER BY ordinal_position
+            """
+        )
+        rows = {name: (data_type, is_nullable) for name, data_type, is_nullable in cur.fetchall()}
+
+    assert rows.keys() == RECONCILIATION_LOG_COLUMN_SHAPE.keys(), (
+        f"entity.release_reconciliation_log column-set drift. "
+        f"Missing: {RECONCILIATION_LOG_COLUMN_SHAPE.keys() - rows.keys()}; "
+        f"Unexpected: {rows.keys() - RECONCILIATION_LOG_COLUMN_SHAPE.keys()}."
+    )
+    for col, expected in RECONCILIATION_LOG_COLUMN_SHAPE.items():
+        assert rows[col] == expected, (
+            f"entity.release_reconciliation_log.{col} drifted: got {rows[col]!r}, "
+            f"expected {expected!r}."
+        )
+
+
+@pytest.mark.pg
+def test_six_per_source_unique_constraints(run_alembic, fresh_db_url: str) -> None:
     """All six per-source UNIQUEs are load-bearing for LML's mint protocol.
 
     Dropping any one breaks the ON CONFLICT clause in
     ``entity/store.py::mint_or_get_release_identity`` and raises a loud
     500 on the LML write surface.
     """
-    _stamp_and_upgrade(fresh_db_url)
+    _stamp_and_upgrade(run_alembic, fresh_db_url)
     with psycopg.connect(fresh_db_url) as conn, conn.cursor() as cur:
         # Per the wxyc-shared convention, walk pg_constraint rather than
         # information_schema.table_constraints — the latter loses the
@@ -216,13 +284,16 @@ def test_six_per_source_unique_constraints(fresh_db_url: str) -> None:
 
 
 @pytest.mark.pg
-def test_reconciliation_log_fk_no_action(fresh_db_url: str) -> None:
-    """FK has no ON DELETE CASCADE — matches the artist-side convention."""
-    _stamp_and_upgrade(fresh_db_url)
+def test_reconciliation_log_fk_rules(run_alembic, fresh_db_url: str) -> None:
+    """FK has neither ON DELETE CASCADE nor ON UPDATE CASCADE — matches the
+    artist-side convention. CASCADE would silently delete the audit log or
+    propagate id renumbering through it; consumers expect explicit cleanup.
+    """
+    _stamp_and_upgrade(run_alembic, fresh_db_url)
     with psycopg.connect(fresh_db_url) as conn, conn.cursor() as cur:
         cur.execute(
             """
-            SELECT rc.delete_rule
+            SELECT rc.delete_rule, rc.update_rule
             FROM information_schema.referential_constraints rc
             JOIN information_schema.table_constraints tc
               ON tc.constraint_name = rc.constraint_name
@@ -236,16 +307,21 @@ def test_reconciliation_log_fk_no_action(fresh_db_url: str) -> None:
     assert len(rows) == 1, (
         f"Expected exactly one FK on entity.release_reconciliation_log, got {len(rows)}."
     )
-    assert rows[0][0] == "NO ACTION", (
-        f"FK delete_rule must be NO ACTION, got {rows[0][0]!r}. CASCADE would "
+    delete_rule, update_rule = rows[0]
+    assert delete_rule == "NO ACTION", (
+        f"FK delete_rule must be NO ACTION, got {delete_rule!r}. CASCADE would "
         "silently delete the audit log; consumers expect explicit cleanup."
+    )
+    assert update_rule == "NO ACTION", (
+        f"FK update_rule must be NO ACTION, got {update_rule!r}. CASCADE would "
+        "silently propagate id renumbering through the audit log."
     )
 
 
 @pytest.mark.pg
-def test_fk_index_present(fresh_db_url: str) -> None:
+def test_fk_index_present(run_alembic, fresh_db_url: str) -> None:
     """idx_release_reconciliation_log_identity_id covers WHERE identity_id = $1."""
-    _stamp_and_upgrade(fresh_db_url)
+    _stamp_and_upgrade(run_alembic, fresh_db_url)
     with psycopg.connect(fresh_db_url) as conn, conn.cursor() as cur:
         cur.execute(
             """
@@ -262,7 +338,7 @@ def test_fk_index_present(fresh_db_url: str) -> None:
 
 
 @pytest.mark.pg
-def test_mint_then_remint_smoke(fresh_db_url: str) -> None:
+def test_mint_then_remint_smoke(run_alembic, fresh_db_url: str) -> None:
     """End-to-end mint protocol shape: first INSERT mints, second is a no-op.
 
     Mirrors ``entity/store.py::mint_or_get_release_identity`` in LML#530:
@@ -270,7 +346,7 @@ def test_mint_then_remint_smoke(fresh_db_url: str) -> None:
     The second call must return zero rows so the LML caller falls through
     to the SELECT-for-conflict-loser branch.
     """
-    _stamp_and_upgrade(fresh_db_url)
+    _stamp_and_upgrade(run_alembic, fresh_db_url)
     with psycopg.connect(fresh_db_url, autocommit=True) as conn, conn.cursor() as cur:
         cur.execute(
             """
@@ -307,14 +383,51 @@ def test_mint_then_remint_smoke(fresh_db_url: str) -> None:
 
 
 @pytest.mark.pg
-def test_reapply_is_noop(fresh_db_url: str) -> None:
+def test_upgrade_against_prod_bootstrap_state(run_alembic, fresh_db_url: str) -> None:
+    """Simulate the documented prod scenario before upgrade.
+
+    Per 0012's docstring, prod already has the entity schema + artist-side
+    ``entity.identity`` / ``entity.reconciliation_log`` tables from
+    out-of-band bootstrap. The upgrade must:
+
+    * succeed without error,
+    * create entity.release_identity / entity.release_reconciliation_log,
+    * leave the pre-existing entity.identity rows untouched.
+    """
+    _seed_bootstrap_state(fresh_db_url)
+    _stamp_and_upgrade(run_alembic, fresh_db_url)
+
+    with psycopg.connect(fresh_db_url) as conn, conn.cursor() as cur:
+        # Release-side tables landed.
+        cur.execute(
+            "SELECT to_regclass('entity.release_identity'), "
+            "to_regclass('entity.release_reconciliation_log')"
+        )
+        release_identity, log = cur.fetchone()
+        assert release_identity is not None, (
+            "0012 upgrade failed to create entity.release_identity against a "
+            "prod-bootstrap-shaped DB. The IF NOT EXISTS path should still "
+            "create the new release-side tables alongside artist-side ones."
+        )
+        assert log is not None, "0012 upgrade failed to create entity.release_reconciliation_log."
+
+        # Pre-existing artist-side data survived.
+        cur.execute("SELECT discogs_artist_id FROM entity.identity")
+        assert cur.fetchall() == [(777,)], (
+            "Pre-existing entity.identity data was perturbed by 0012 upgrade. "
+            "The artist-side tables (out-of-band bootstrap) must survive."
+        )
+
+
+@pytest.mark.pg
+def test_reapply_is_noop(run_alembic, fresh_db_url: str) -> None:
     """Re-running the migration against an already-upgraded DB must not fail.
 
-    Production prereq: discogs-cache PG already has the entity schema +
-    artist-side tables from the out-of-band bootstrap. The migration must
-    no-op against that state rather than perturbing it.
+    Stamps the alembic_version row back to 0011 (no DDL — the actual tables
+    are not dropped) and re-runs the upgrade so the IF NOT EXISTS branches
+    fire against existing tables. Existing rows must survive.
     """
-    _stamp_and_upgrade(fresh_db_url)
+    _stamp_and_upgrade(run_alembic, fresh_db_url)
 
     # Seed a sentinel row so we can prove re-application doesn't perturb data.
     with psycopg.connect(fresh_db_url, autocommit=True) as conn, conn.cursor() as cur:
@@ -323,10 +436,11 @@ def test_reapply_is_noop(fresh_db_url: str) -> None:
         )
         sentinel_id = cur.fetchone()[0]
 
-    # Downgrade alembic state and re-upgrade so the IF NOT EXISTS branches fire.
-    downgrade = _run_alembic(["stamp", "0011_artist_not_found"], fresh_db_url)
-    assert downgrade.returncode == 0
-    reupgrade = _run_alembic(["upgrade", "0012_entity_release_identity"], fresh_db_url)
+    # Rewind alembic state (stamp, not downgrade — tables stay) and re-upgrade
+    # so the IF NOT EXISTS branches fire against existing tables.
+    rewind = run_alembic(["stamp", "0011_artist_not_found"], fresh_db_url)
+    assert rewind.returncode == 0
+    reupgrade = run_alembic(["upgrade", "0012_entity_release_identity"], fresh_db_url)
     assert reupgrade.returncode == 0, (
         f"Re-application failed:\nstdout: {reupgrade.stdout}\nstderr: {reupgrade.stderr}"
     )
@@ -339,4 +453,55 @@ def test_reapply_is_noop(fresh_db_url: str) -> None:
         assert cur.fetchone() == (99999,), (
             "Sentinel row lost across re-application. The migration must use "
             "CREATE TABLE IF NOT EXISTS so existing rows survive."
+        )
+
+
+@pytest.mark.pg
+def test_downgrade_drops_release_side_tables(run_alembic, fresh_db_url: str) -> None:
+    """Exercise _DOWNGRADE_SQL end-to-end.
+
+    After upgrade → downgrade:
+
+    * ``entity.release_identity`` and ``entity.release_reconciliation_log``
+      are dropped (the FK index goes with the child table).
+    * The ``entity`` schema is preserved (artist-side tables outlive this
+      migration; their adoption is tracked at WXYC/discogs-etl#279).
+
+    This is the only test that runs the actual ``alembic downgrade`` —
+    without it, a typo in _DOWNGRADE_SQL would ship green.
+    """
+    _stamp_and_upgrade(run_alembic, fresh_db_url)
+
+    downgrade = run_alembic(["downgrade", "0011_artist_not_found"], fresh_db_url)
+    assert downgrade.returncode == 0, (
+        f"alembic downgrade failed:\nstdout: {downgrade.stdout}\nstderr: {downgrade.stderr}"
+    )
+
+    with psycopg.connect(fresh_db_url) as conn, conn.cursor() as cur:
+        # Release-side tables and FK index gone.
+        cur.execute(
+            "SELECT to_regclass('entity.release_identity'), "
+            "to_regclass('entity.release_reconciliation_log')"
+        )
+        release_identity, log = cur.fetchone()
+        assert release_identity is None, "entity.release_identity should be dropped"
+        assert log is None, "entity.release_reconciliation_log should be dropped"
+
+        cur.execute(
+            """
+            SELECT 1 FROM pg_indexes
+            WHERE schemaname = 'entity'
+              AND indexname = 'idx_release_reconciliation_log_identity_id'
+            """
+        )
+        assert cur.fetchone() is None, "FK index should be gone with its table"
+
+        # Schema preserved.
+        cur.execute(
+            "SELECT schema_name FROM information_schema.schemata WHERE schema_name = 'entity'"
+        )
+        assert cur.fetchone() is not None, (
+            "entity schema should outlive the downgrade — the artist-side "
+            "tables (entity.identity / entity.reconciliation_log) still live "
+            "there. See migration docstring."
         )

--- a/tests/integration/test_alembic_0012_entity_release_identity.py
+++ b/tests/integration/test_alembic_0012_entity_release_identity.py
@@ -55,6 +55,11 @@ def _read_revision_metadata() -> tuple[str, str]:
     Regex over the file rather than importlib because the migration's
     imports (``from lib.alembic_helpers import ...``) require alembic-aware
     sys.path setup that pytest collection does not guarantee.
+
+    Called lazily from ``_stamp_and_upgrade`` rather than at module load so
+    a missing or malformed migration file shows up as the dedicated
+    ``test_migration_file_exists`` failure instead of an opaque collection
+    error that swallows every other test in the file.
     """
     body = MIGRATION_PATH.read_text(encoding="utf-8")
     rev = re.search(r'^revision:\s*str\s*=\s*"([^"]+)"', body, re.MULTILINE)
@@ -62,9 +67,6 @@ def _read_revision_metadata() -> tuple[str, str]:
     assert rev is not None, f"Could not find revision assignment in {MIGRATION_PATH}"
     assert down is not None, f"Could not find down_revision assignment in {MIGRATION_PATH}"
     return rev.group(1), down.group(1)
-
-
-REVISION, PRIOR_REVISION = _read_revision_metadata()
 
 
 # Per-source UNIQUE columns load-bearing for LML's mint protocol.
@@ -138,11 +140,12 @@ def _stamp_and_upgrade(run_alembic, db_url: str) -> None:
     cares about 0012's surface. The migration is self-contained: it does
     not depend on any column added by earlier revisions.
     """
-    stamp = run_alembic(["stamp", PRIOR_REVISION], db_url)
+    revision, prior_revision = _read_revision_metadata()
+    stamp = run_alembic(["stamp", prior_revision], db_url)
     assert stamp.returncode == 0, (
         f"alembic stamp failed:\nstdout: {stamp.stdout}\nstderr: {stamp.stderr}"
     )
-    result = run_alembic(["upgrade", REVISION], db_url)
+    result = run_alembic(["upgrade", revision], db_url)
     assert result.returncode == 0, (
         f"alembic upgrade failed:\nstdout: {result.stdout}\nstderr: {result.stderr}"
     )
@@ -474,9 +477,10 @@ def test_reapply_is_noop(run_alembic, fresh_db_url: str) -> None:
 
     # Rewind alembic state (stamp, not downgrade — tables stay) and re-upgrade
     # so the IF NOT EXISTS branches fire against existing tables.
-    rewind = run_alembic(["stamp", PRIOR_REVISION], fresh_db_url)
+    revision, prior_revision = _read_revision_metadata()
+    rewind = run_alembic(["stamp", prior_revision], fresh_db_url)
     assert rewind.returncode == 0
-    reupgrade = run_alembic(["upgrade", REVISION], fresh_db_url)
+    reupgrade = run_alembic(["upgrade", revision], fresh_db_url)
     assert reupgrade.returncode == 0, (
         f"Re-application failed:\nstdout: {reupgrade.stdout}\nstderr: {reupgrade.stderr}"
     )
@@ -508,7 +512,8 @@ def test_downgrade_drops_release_side_tables(run_alembic, fresh_db_url: str) -> 
     """
     _stamp_and_upgrade(run_alembic, fresh_db_url)
 
-    downgrade = run_alembic(["downgrade", PRIOR_REVISION], fresh_db_url)
+    _, prior_revision = _read_revision_metadata()
+    downgrade = run_alembic(["downgrade", prior_revision], fresh_db_url)
     assert downgrade.returncode == 0, (
         f"alembic downgrade failed:\nstdout: {downgrade.stdout}\nstderr: {downgrade.stderr}"
     )
@@ -541,3 +546,61 @@ def test_downgrade_drops_release_side_tables(run_alembic, fresh_db_url: str) -> 
             "tables (entity.identity / entity.reconciliation_log) still live "
             "there. See migration docstring."
         )
+
+
+# ---------------------------------------------------------------------------
+# Dual-write drift detection (schema/create_database.sql direction)
+# ---------------------------------------------------------------------------
+
+
+CREATE_DATABASE_SQL_PATH = REPO_ROOT / "schema" / "create_database.sql"
+
+
+def _shape_from_db(conn, table_name: str) -> dict[str, tuple[str, str]]:
+    """Return ``{column_name: (data_type, is_nullable)}`` for ``entity.<table>``."""
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT column_name, data_type, is_nullable
+            FROM information_schema.columns
+            WHERE table_schema = 'entity' AND table_name = %s
+            ORDER BY ordinal_position
+            """,
+            (table_name,),
+        )
+        return {name: (data_type, is_nullable) for name, data_type, is_nullable in cur.fetchall()}
+
+
+@pytest.mark.pg
+def test_create_database_sql_matches_migration_shape(fresh_db_url: str) -> None:
+    """Apply schema/create_database.sql against a fresh DB and assert the
+    same entity-table shape the migration produces.
+
+    Catches the OTHER direction of dual-write drift: the migration tests
+    already pin the alembic path; this test pins the create_database.sql
+    path. If a future PR edits one but not the other, this test fails
+    instead of letting the divergence ship to dev DBs built by
+    ``--fresh-rebuild``.
+    """
+    sql_body = CREATE_DATABASE_SQL_PATH.read_text(encoding="utf-8")
+    with psycopg.connect(fresh_db_url, autocommit=True) as conn, conn.cursor() as cur:
+        cur.execute(sql_body)
+
+    with psycopg.connect(fresh_db_url) as conn:
+        identity_shape = _shape_from_db(conn, "release_identity")
+        log_shape = _shape_from_db(conn, "release_reconciliation_log")
+
+    assert identity_shape == RELEASE_IDENTITY_COLUMN_SHAPE, (
+        "schema/create_database.sql's entity.release_identity diverged from "
+        "the migration's shape. Dual-write convention requires both produce "
+        "the same end state.\n"
+        f"Got: {identity_shape}\n"
+        f"Expected: {RELEASE_IDENTITY_COLUMN_SHAPE}"
+    )
+    assert log_shape == RECONCILIATION_LOG_COLUMN_SHAPE, (
+        "schema/create_database.sql's entity.release_reconciliation_log "
+        "diverged from the migration's shape. Dual-write convention requires "
+        "both produce the same end state.\n"
+        f"Got: {log_shape}\n"
+        f"Expected: {RECONCILIATION_LOG_COLUMN_SHAPE}"
+    )

--- a/tests/unit/test_alembic_helpers.py
+++ b/tests/unit/test_alembic_helpers.py
@@ -1,0 +1,78 @@
+"""Unit tests for lib.alembic_helpers.
+
+The migration-level integration tests exercise the helpers transitively (a
+broken helper would cause every side-channel migration to fail), but they
+all need a live Docker PG and a stamped DB. Direct unit tests run without
+those preconditions and pin three contracts:
+
+* ``resolve_db_url`` honours the canonical env-var precedence
+  (``DATABASE_URL_DISCOGS`` over ``DATABASE_URL``) and includes the
+  revision label in its error message.
+* ``refuse_offline`` imports ``alembic.context`` lazily, so the module
+  can be imported (and ``resolve_db_url`` exercised) without alembic
+  being installed.
+* The helper module itself does not import alembic at module load time.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+
+import pytest
+
+from lib import alembic_helpers
+
+
+def test_resolve_db_url_prefers_database_url_discogs(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("DATABASE_URL_DISCOGS", "postgresql://canonical/discogs")
+    monkeypatch.setenv("DATABASE_URL", "postgresql://deprecated/fallback")
+    assert alembic_helpers.resolve_db_url("0012_test") == "postgresql://canonical/discogs"
+
+
+def test_resolve_db_url_falls_back_to_database_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("DATABASE_URL_DISCOGS", raising=False)
+    monkeypatch.setenv("DATABASE_URL", "postgresql://deprecated/fallback")
+    assert alembic_helpers.resolve_db_url("0012_test") == "postgresql://deprecated/fallback"
+
+
+def test_resolve_db_url_treats_empty_string_as_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Empty string should not be treated as a configured URL.
+
+    Falsy fallback is the documented behaviour — psycopg.connect('') would
+    raise an opaque parser error rather than the actionable RuntimeError.
+    """
+    monkeypatch.setenv("DATABASE_URL_DISCOGS", "")
+    monkeypatch.setenv("DATABASE_URL", "postgresql://deprecated/fallback")
+    assert alembic_helpers.resolve_db_url("0012_test") == "postgresql://deprecated/fallback"
+
+
+def test_resolve_db_url_raises_with_revision_label(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("DATABASE_URL_DISCOGS", raising=False)
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    with pytest.raises(RuntimeError, match=r"0012_specific_label"):
+        alembic_helpers.resolve_db_url("0012_specific_label")
+
+
+def test_module_does_not_import_alembic_at_load() -> None:
+    """``resolve_db_url`` must be usable without alembic — the lazy-import
+    contract on ``refuse_offline`` is the whole reason the helper exists.
+
+    Re-imports the module against a fresh module cache and inspects
+    ``sys.modules`` to confirm alembic is not pulled in by the top-level
+    import. ``refuse_offline``'s import is deferred to call time.
+    """
+    # Drop both the helper and alembic from the module cache so the re-import
+    # is observed cleanly. The actual alembic package, if installed, may
+    # already be cached from earlier in the test session; what we're testing
+    # is that *importing alembic_helpers* doesn't trigger it.
+    for name in list(sys.modules):
+        if name == "lib.alembic_helpers" or name == "alembic" or name.startswith("alembic."):
+            sys.modules.pop(name, None)
+
+    importlib.import_module("lib.alembic_helpers")
+
+    assert "alembic" not in sys.modules, (
+        "lib.alembic_helpers must not import alembic at module load — "
+        "the lazy import inside refuse_offline is the whole point."
+    )


### PR DESCRIPTION
## Summary

- Add alembic 0012 that creates `entity.release_identity` + `entity.release_reconciliation_log` + FK index on the discogs-cache PG instance. After this lands, LML's `POST /api/v1/identity/resolve` flips from 503 to 200.
- Includes `CREATE SCHEMA IF NOT EXISTS entity` so fresh dev DBs work — the LML canonical `entity/release_identity.sql` assumes the schema is already present (existing prod has it from out-of-band bootstrap).
- Generalise `--truncate-existing` comments and help text in `scripts/import_csv.py` / `scripts/run_pipeline.py` from "entity.identity" to "the entity schema" so the messaging covers all four entity tables and the schema-level exclusion convention.

## Design notes

- Modeled on 0011's autocommit side-channel pattern (`is_offline_mode()` refuse + `DATABASE_URL_DISCOGS` → `DATABASE_URL` resolver + direct `psycopg.connect(..., autocommit=True)`). DDL is `IF NOT EXISTS`-only so the migration is safe to re-apply against prod, which already has the schema from the artist-side bootstrap.
- Six per-source UNIQUE columns are load-bearing for LML's mint protocol (`INSERT ... ON CONFLICT ({col}) DO NOTHING RETURNING id`). The integration test enumerates them against `pg_constraint` so any drift surfaces in CI.
- FK index added — Postgres does not auto-index FK referencing columns, so every `WHERE identity_id = $1` lookup needs it.
- Downgrade drops in FK order (index → log → identity) and intentionally leaves the `entity` schema in place. Adopting the artist-side `entity.identity` / `entity.reconciliation_log` into the alembic chain is tracked at #279.
- `discogs_release_id` / `discogs_master_id` are `INTEGER` but **not** FKs to the cache's `release.id` / `master.id` — the identity layer's lifecycle is independent of the monthly cache rebuild, matching the canonical LML shape.

## Test plan

- [x] `ruff check .` clean
- [x] `ruff format --check .` clean
- [x] All 10 tests in `tests/integration/test_alembic_0012_entity_release_identity.py` pass against the Docker PG (3 static + 7 pg-marked).
- [x] Sibling alembic test suites (0007–0011 + backfill) still pass — 41/41 total.
- [ ] Post-merge smoke: `POST /api/v1/identity/resolve` against prod LML returns 200 with `{"identity_id": N, "minted": true}` on a fresh `(discogs_release, 12345)` and `{"identity_id": N, "minted": false}` on the repeat. Operator step — runs after the next `rebuild-cache.yml` invocation applies `alembic upgrade head` against discogs-cache PG.

Closes #278