### PR TITLE
fix(verify-cache): wrap prune + dedup constraint adds in parent-first LOCK TABLE envelope

### DIFF
--- a/lib/pg_concurrent_ddl.py
+++ b/lib/pg_concurrent_ddl.py
@@ -140,6 +140,40 @@ def _extract_index_name(ddl: str) -> str | None:
     return match.group(1) if match else None
 
 
+_UNPARSEABLE_GROUP_KEY = "__unparseable__"
+
+
+def group_concurrent_index_ddls_by_table(ddls: Sequence[str]) -> dict[str, list[str]]:
+    """Group ``CREATE INDEX CONCURRENTLY`` DDLs for safe parallel dispatch.
+
+    Two CONCURRENTLY builds on the **same** table deadlock against each other
+    inside PG's wait-for-snapshot phase. Callers that parallelize CONCURRENTLY
+    must group by target table and run one worker per group (serial within,
+    parallel across).
+
+    Returns ``{table_name: [ddl, ...]}``. DDLs whose target table can't be
+    parsed by :func:`extract_index_target_table` are all collected under
+    a single sentinel key so they run serially — NOT keyed by the full DDL
+    string. The old keyed-by-DDL fallback would put two unparseable DDLs
+    on the same table into separate groups, re-introducing the same
+    CONCURRENTLY-vs-CONCURRENTLY deadlock the grouping is meant to prevent.
+    """
+    groups: dict[str, list[str]] = {}
+    for ddl in ddls:
+        table = extract_index_target_table(ddl)
+        if table is None:
+            logger.warning(
+                "group_concurrent_index_ddls_by_table: could not parse target "
+                "table from %r; grouping with other unparseable DDLs for "
+                "serial execution",
+                ddl,
+            )
+            groups.setdefault(_UNPARSEABLE_GROUP_KEY, []).append(ddl)
+        else:
+            groups.setdefault(table, []).append(ddl)
+    return groups
+
+
 def extract_index_target_table(ddl: str) -> str | None:
     """Pull the target table out of a ``CREATE INDEX CONCURRENTLY ... ON <t>``.
 
@@ -327,6 +361,11 @@ def add_constraint_safely(
     start = time.monotonic()
     lock_clause = ", ".join(lock_tables)
     ddls: list[str] = [ddl] if isinstance(ddl, str) else list(ddl)
+    # Truncated rendering for log lines / Sentry breadcrumbs. The multi-stmt
+    # form (RENAME swap, 3 statements) would otherwise produce a huge
+    # repr() in the 40P01 canary — the canary's job is to name the failure
+    # site for an operator, not dump every byte of DDL.
+    ddl_summary = ddls[0] if len(ddls) == 1 else f"{len(ddls)}-stmt group: {ddls[0]!r}, ..."
 
     last_exc: Exception | None = None
     for attempt in range(attempts):
@@ -367,11 +406,11 @@ def add_constraint_safely(
                 "structurally impossible; an LML writer has likely drifted "
                 "to a different acquisition order. Investigate "
                 "library-metadata-lookup/discogs/cache_service.py::write_release "
-                "ordering. lock_tables=%s ddl=%r",
+                "ordering. lock_tables=%s ddl=%s",
                 stats.attempts,
                 attempts,
                 lock_clause,
-                ddl,
+                ddl_summary,
             )
             _sentry_breadcrumb(
                 category="pg_concurrent_ddl",
@@ -380,7 +419,7 @@ def add_constraint_safely(
                     "attempt": stats.attempts,
                     "attempts_total": attempts,
                     "lock_tables": list(lock_tables),
-                    "ddl": ddl,
+                    "ddl": ddl_summary,
                 },
             )
 

--- a/lib/pg_concurrent_ddl.py
+++ b/lib/pg_concurrent_ddl.py
@@ -1,0 +1,392 @@
+"""Concurrent-safe DDL primitives for prune/dedup copy-swap steps.
+
+The monthly rebuild's prune (``scripts/verify_cache.py``) and dedup
+(``scripts/dedup_releases.py``) both add FK constraints, primary keys, and
+indexes to live tables that the library-metadata-lookup runtime is writing
+to in parallel. Naively-issued ``ALTER TABLE ... ADD CONSTRAINT`` and
+``CREATE INDEX`` (non-CONCURRENTLY) deadlock against LML's open
+``write_release`` transactions — see WXYC/discogs-etl#286 for the
+2026-06-04 06:45 UTC outage that motivated this module.
+
+Two primitives:
+
+* :func:`add_constraint_safely` — wraps a single ``ALTER TABLE ... ADD
+  CONSTRAINT`` (or any DDL that takes blocking locks) in a transaction
+  that pre-acquires its target tables in **parent-then-child order**
+  under a bounded ``SET LOCAL lock_timeout``. Retries on ``55P03``
+  (``lock_not_available``, our timeout fired — the expected path under
+  LML contention) with exponential backoff. Retries on ``40P01``
+  (``deadlock_detected``) with a loud warning that names the offending
+  statement — the canary that fires if some LML write path drifts to a
+  child-first acquisition order.
+
+* :func:`add_index_concurrently_safely` — runs ``CREATE INDEX CONCURRENTLY``
+  with two safety rails: pre-flight cleanup of any leftover INVALID index
+  with the same name (which a CTRL-C'd CONCURRENTLY build leaves behind),
+  and a refusal to run inside an open ``conn.transaction()`` block (which
+  PostgreSQL rejects with a deliberately opaque error).
+
+Both primitives operate on an ``autocommit=True`` ``psycopg.Connection``;
+the constraint primitive opens its own ``conn.transaction()`` block per
+attempt. Both are idempotent under retry.
+
+The parent-first ordering property is load-bearing: LML's
+``cache_service.write_release`` acquires ``release`` (parent) before
+``release_artist`` / ``release_label`` / ... / ``cache_metadata``
+(children). Matching that order across all writers means the happy path
+doesn't even reach PG's deadlock detector — our prune transaction just
+waits for LML's commit, then proceeds. The current production failure
+deadlocks precisely because PG's ``ALTER TABLE ... ADD CONSTRAINT
+FOREIGN KEY ... REFERENCES release(id) NOT VALID`` acquires the child
+first (the ``ALTER TABLE`` target), then the parent — opposite of LML.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import time
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+
+import psycopg
+
+logger = logging.getLogger(__name__)
+
+# SQLSTATE constants used by the retry envelope.
+SQLSTATE_LOCK_NOT_AVAILABLE = "55P03"
+SQLSTATE_DEADLOCK_DETECTED = "40P01"
+
+# Default retry envelope for FK / PK adds (ShareRowExclusive lock surface).
+# Sized for sub-second LML write_release p99 — see #286 for the discussion of
+# how to validate this from LML's structured logger before sizing upward.
+DEFAULT_LOCK_TIMEOUT = "5s"
+DEFAULT_ATTEMPTS = 3
+DEFAULT_BACKOFF_SECONDS: tuple[float, ...] = (5.0, 15.0, 45.0)
+
+# Wider retry budget for the DROP CONSTRAINT + RENAME path in
+# ``_prune_copy_swap_tables``: those statements take AccessExclusive, which
+# conflicts with every live LML lock mode, not just ShareRowExclusive vs
+# RowExclusive. The contention window is wider; the retries should be too.
+SWAP_PATH_ATTEMPTS = 5
+SWAP_PATH_BACKOFF_SECONDS: tuple[float, ...] = (5.0, 15.0, 45.0, 90.0, 180.0)
+
+_INDEX_NAME_RE = re.compile(
+    r"CREATE\s+(?:UNIQUE\s+)?INDEX\s+CONCURRENTLY\s+(?:IF\s+NOT\s+EXISTS\s+)?(\w+)",
+    re.IGNORECASE,
+)
+
+_INDEX_TARGET_TABLE_RE = re.compile(
+    r"CREATE\s+(?:UNIQUE\s+)?INDEX\s+CONCURRENTLY\s+(?:IF\s+NOT\s+EXISTS\s+)?"
+    r"\w+\s+ON\s+(\w+)",
+    re.IGNORECASE,
+)
+
+
+class ConcurrentDDLError(RuntimeError):
+    """Raised for caller-side misuse of the helper (e.g. running CONCURRENTLY
+    inside an open transaction). Distinct from psycopg errors so callers can
+    catch them separately."""
+
+
+@dataclass
+class RetryStats:
+    """Observable outcome of a :func:`add_constraint_safely` call.
+
+    Exposes the retry path for tests and operational logging without forcing
+    callers to scrape log records. ``sqlstates_seen`` is in attempt order so
+    the test for #286 can assert that the contention path was actually
+    exercised (``"55P03" in stats.sqlstates_seen``) rather than relying on
+    the inherently-flaky "no deadlock ever fired" property.
+    """
+
+    attempts: int = 0
+    sqlstates_seen: list[str] = field(default_factory=list)
+    elapsed_seconds: float = 0.0
+
+
+def _sentry_breadcrumb(category: str, message: str, data: dict | None = None) -> None:
+    """Best-effort Sentry breadcrumb. No-op if ``sentry_sdk`` isn't importable.
+
+    Kept tiny on purpose — the helper must not pull a hard dependency on
+    Sentry just to surface the 40P01 canary. If Sentry is wired up via
+    :mod:`lib.observability`, the breadcrumb attaches to the next event;
+    otherwise it silently drops.
+    """
+    try:
+        import sentry_sdk
+
+        sentry_sdk.add_breadcrumb(
+            category=category,
+            message=message,
+            level="warning",
+            data=data or {},
+        )
+    except Exception:
+        pass
+
+
+def _extract_index_name(ddl: str) -> str | None:
+    """Pull the index name out of a ``CREATE INDEX CONCURRENTLY`` statement.
+
+    Returns ``None`` if the statement doesn't match the expected shape — the
+    caller falls back to skipping the INVALID-index precleanup in that case
+    rather than failing on a perfectly valid DDL that this regex happens not
+    to handle. The shape we care about (every call site in
+    :mod:`scripts.verify_cache` and :mod:`scripts.dedup_releases`) is what
+    the test ``test_extract_index_name_handles_canonical_shapes`` pins.
+    """
+    match = _INDEX_NAME_RE.search(ddl)
+    return match.group(1) if match else None
+
+
+def extract_index_target_table(ddl: str) -> str | None:
+    """Pull the target table out of a ``CREATE INDEX CONCURRENTLY ... ON <t>``.
+
+    Used by callers that need to parallelize CONCURRENTLY index builds: PG
+    deadlocks when two CONCURRENTLY builds run on the **same** table
+    concurrently (each takes ShareUpdateExclusive while also waiting on the
+    other's virtual transaction in the wait-for-snapshot phase), but
+    cleanly tolerates parallel builds across **different** tables. Group
+    by this function's return value before dispatching to a thread pool.
+
+    Returns ``None`` if the DDL shape isn't recognized — the caller should
+    fall back to serial execution in that case rather than risk grouping
+    by an unparsed key. The pin in
+    :mod:`tests.unit.test_pg_concurrent_ddl` covers every shape used in
+    :mod:`scripts.verify_cache` and :mod:`scripts.dedup_releases`.
+    """
+    match = _INDEX_TARGET_TABLE_RE.search(ddl)
+    return match.group(1) if match else None
+
+
+def _drop_invalid_index_if_present(conn: psycopg.Connection, index_name: str) -> bool:
+    """Drop ``index_name`` if it exists and is marked ``indisvalid = false``.
+
+    A ``CREATE INDEX CONCURRENTLY`` that was interrupted (CTRL-C, SIGTERM,
+    crash) leaves the index in pg_class but with ``pg_index.indisvalid =
+    false``, and the next ``CREATE INDEX CONCURRENTLY IF NOT EXISTS`` will
+    silently no-op against that invalid index — leaving the cache without
+    the lookup acceleration the rebuild promised. Drop-then-recreate is
+    the documented PG recovery path; doing it as part of the helper means
+    a retried prune is idempotent against a previous interrupted run.
+
+    Returns ``True`` if a drop happened (for logging), ``False`` otherwise.
+    """
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT 1 FROM pg_index i "
+            "JOIN pg_class c ON c.oid = i.indexrelid "
+            "WHERE c.relname = %s AND i.indisvalid = false",
+            (index_name,),
+        )
+        if cur.fetchone() is None:
+            return False
+        # DROP INDEX takes AccessExclusive on the index itself but not on
+        # the underlying table; safe to run on a live cache because the
+        # index is INVALID and therefore not used for query planning.
+        cur.execute(f"DROP INDEX IF EXISTS {index_name}")
+    logger.warning(
+        "Dropped INVALID leftover index %s before re-running CONCURRENTLY build "
+        "(prior CREATE INDEX CONCURRENTLY likely interrupted)",
+        index_name,
+    )
+    return True
+
+
+def _connection_in_transaction(conn: psycopg.Connection) -> bool:
+    """Return True if ``conn`` is currently inside an open transaction block.
+
+    psycopg3's ``conn.info.transaction_status`` returns
+    ``TransactionStatus.IDLE`` for an autocommit connection that isn't inside
+    a ``conn.transaction()`` block, and ``INTRANS`` / ``INERROR`` when it is.
+    We refuse to run CONCURRENTLY in either non-IDLE state because PG will
+    reject it with the opaque "CREATE INDEX CONCURRENTLY cannot run inside a
+    transaction block" error — clearer to fail fast at the helper boundary
+    with a sentence the caller can act on.
+    """
+    status = conn.info.transaction_status
+    # Idle = autocommit, no open block. Anything else means we're inside one.
+    return status != psycopg.pq.TransactionStatus.IDLE
+
+
+def add_index_concurrently_safely(
+    conn: psycopg.Connection,
+    ddl: str,
+) -> None:
+    """Run ``CREATE INDEX CONCURRENTLY ...`` with INVALID-index precleanup.
+
+    Refuses to run if ``conn`` is inside an open ``conn.transaction()``
+    block: PG rejects CONCURRENTLY inside any transaction, and the error
+    it produces (``25001 active_sql_transaction``) is mostly opaque to
+    callers debugging a retry envelope. Raise :class:`ConcurrentDDLError`
+    with the call site so future-us doesn't have to guess.
+
+    The connection must be in autocommit mode. Single-statement CONCURRENTLY
+    calls then run as their own implicit transactions; PG is happy with that.
+
+    If a previous interrupted build left an INVALID index with the same
+    name, drops it first so the new CONCURRENTLY build can proceed.
+    ``IF NOT EXISTS`` alone does NOT help — PG considers an INVALID index
+    to exist for the purposes of the existence check.
+    """
+    if _connection_in_transaction(conn):
+        raise ConcurrentDDLError(
+            f"add_index_concurrently_safely called from inside an open "
+            f"transaction block; CREATE INDEX CONCURRENTLY cannot run there. "
+            f"DDL: {ddl!r}"
+        )
+
+    index_name = _extract_index_name(ddl)
+    if index_name is not None:
+        _drop_invalid_index_if_present(conn, index_name)
+
+    with conn.cursor() as cur:
+        cur.execute(ddl)
+
+
+def add_constraint_safely(
+    conn: psycopg.Connection,
+    ddl: str | Sequence[str],
+    *,
+    lock_tables: Sequence[str],
+    lock_timeout: str = DEFAULT_LOCK_TIMEOUT,
+    attempts: int = DEFAULT_ATTEMPTS,
+    backoff_seconds: Sequence[float] = DEFAULT_BACKOFF_SECONDS,
+) -> RetryStats:
+    """Run a blocking-lock DDL inside a parent-first ``LOCK TABLE`` envelope.
+
+    Wraps ``ddl`` in ``with conn.transaction(): SET LOCAL lock_timeout ...
+    LOCK TABLE <parent>, <child> IN ACCESS EXCLUSIVE MODE; <ddl>``. The
+    ``LOCK TABLE`` pre-acquires every involved table in a single statement
+    so that on the happy path the prune just waits for any open LML
+    transaction to commit, then proceeds — no deadlock detector involved.
+
+    ``ddl`` may be a single SQL statement or a sequence of statements that
+    must run atomically within the same locked transaction (e.g. the
+    three-RENAME swap step in ``_prune_copy_swap_tables``). All statements
+    in the sequence execute under the same ``SET LOCAL lock_timeout`` and
+    the same ``LOCK TABLE`` envelope; if any one fails with a retriable
+    SQLSTATE the entire group retries.
+
+    On ``55P03`` (``lock_not_available``, our ``lock_timeout`` fired):
+      retries after backoff. This is the expected path under contention.
+      Cap the retry budget so a pathological LML transaction can't keep
+      the prune waiting indefinitely; surface a real failure if the cap
+      is reached.
+
+    On ``40P01`` (``deadlock_detected``):
+      retries after backoff but ALSO emits ``logger.warning`` and a Sentry
+      breadcrumb naming the offending statement. With parent-first ordering
+      enforced everywhere, ``40P01`` is structurally impossible — if it
+      ever fires post-fix it means some LML write path has drifted to
+      child-first acquisition, and the canary should be loud so the
+      regression surfaces quickly.
+
+    Args:
+        conn: psycopg connection in autocommit mode. ``conn.transaction()``
+            is supported in this mode and is used internally per attempt.
+        ddl: Single SQL statement to run inside the locked transaction.
+            Typically an ``ALTER TABLE ... ADD CONSTRAINT ...`` or
+            ``ALTER TABLE ... ADD CONSTRAINT ... USING INDEX ...`` form.
+        lock_tables: Tables to acquire AccessExclusive on, **in parent-first
+            order**. For an FK add, ``(parent, child)``; for a PK on a
+            standalone table, ``(table,)``. Order across call sites must
+            match LML's ``write_release`` acquisition order.
+        lock_timeout: ``SET LOCAL lock_timeout`` value — Postgres
+            duration syntax (e.g. ``'5s'``). Default sized for sub-second
+            LML write p99; size from measurement, not guess.
+        attempts: Total attempts including the first. ``attempts=1`` means
+            no retry.
+        backoff_seconds: Sleep before each retry. Must have length
+            ``attempts - 1``; surplus entries are ignored, shortfall raises.
+
+    Returns:
+        :class:`RetryStats` describing the outcome — ``attempts`` count
+        actually executed (1 + retries) and ``sqlstates_seen`` in order so
+        the test for #286 can assert that the contention path was exercised.
+
+    Raises:
+        :class:`psycopg.errors.LockNotAvailable`: ``lock_timeout`` fired on
+            every retry within ``attempts``.
+        :class:`psycopg.errors.DeadlockDetected`: ``40P01`` fired on every
+            retry — should never happen post-fix; investigate LML if it does.
+        Any other psycopg error: surfaced immediately, no retry.
+    """
+    if attempts < 1:
+        raise ValueError("attempts must be >= 1")
+    if len(backoff_seconds) < attempts - 1:
+        raise ValueError(
+            f"backoff_seconds has {len(backoff_seconds)} entries but "
+            f"attempts={attempts} requires at least {attempts - 1}"
+        )
+    if not lock_tables:
+        raise ValueError("lock_tables must name at least one table")
+
+    stats = RetryStats()
+    start = time.monotonic()
+    lock_clause = ", ".join(lock_tables)
+    ddls: list[str] = [ddl] if isinstance(ddl, str) else list(ddl)
+
+    last_exc: Exception | None = None
+    for attempt in range(attempts):
+        stats.attempts = attempt + 1
+        try:
+            with conn.transaction():
+                with conn.cursor() as cur:
+                    # SET LOCAL applies for the duration of this transaction
+                    # only — no leak into subsequent autocommit statements.
+                    cur.execute(f"SET LOCAL lock_timeout = '{lock_timeout}'")
+                    cur.execute(f"LOCK TABLE {lock_clause} IN ACCESS EXCLUSIVE MODE")
+                    for stmt in ddls:
+                        cur.execute(stmt)
+            stats.elapsed_seconds = time.monotonic() - start
+            return stats
+        except psycopg.errors.LockNotAvailable as exc:
+            stats.sqlstates_seen.append(SQLSTATE_LOCK_NOT_AVAILABLE)
+            last_exc = exc
+            logger.info(
+                "add_constraint_safely: 55P03 lock_not_available on attempt %d/%d "
+                "(lock_timeout=%s, lock_tables=%s); will retry",
+                stats.attempts,
+                attempts,
+                lock_timeout,
+                lock_clause,
+            )
+        except psycopg.errors.DeadlockDetected as exc:
+            stats.sqlstates_seen.append(SQLSTATE_DEADLOCK_DETECTED)
+            last_exc = exc
+            # LOUD: parent-first ordering should make 40P01 structurally
+            # impossible. Firing here means some writer has drifted to a
+            # different acquisition order — almost certainly LML. Name
+            # the statement in both the log line and the Sentry breadcrumb
+            # so the regressed LML code path surfaces quickly.
+            logger.warning(
+                "add_constraint_safely: 40P01 deadlock_detected on attempt "
+                "%d/%d. Parent-first LOCK TABLE ordering should make this "
+                "structurally impossible; an LML writer has likely drifted "
+                "to a different acquisition order. Investigate "
+                "library-metadata-lookup/discogs/cache_service.py::write_release "
+                "ordering. lock_tables=%s ddl=%r",
+                stats.attempts,
+                attempts,
+                lock_clause,
+                ddl,
+            )
+            _sentry_breadcrumb(
+                category="pg_concurrent_ddl",
+                message="40P01 deadlock_detected in add_constraint_safely",
+                data={
+                    "attempt": stats.attempts,
+                    "attempts_total": attempts,
+                    "lock_tables": list(lock_tables),
+                    "ddl": ddl,
+                },
+            )
+
+        if attempt < attempts - 1:
+            time.sleep(backoff_seconds[attempt])
+
+    stats.elapsed_seconds = time.monotonic() - start
+    assert last_exc is not None  # we only get here after at least one except
+    raise last_exc

--- a/scripts/dedup_releases.py
+++ b/scripts/dedup_releases.py
@@ -32,7 +32,7 @@ from lib.observability import init_logger  # noqa: E402
 from lib.pg_concurrent_ddl import (  # noqa: E402
     add_constraint_safely,
     add_index_concurrently_safely,
-    extract_index_target_table,
+    group_concurrent_index_ddls_by_table,
 )
 
 logger = logging.getLogger(__name__)
@@ -556,10 +556,7 @@ def add_base_constraints_and_indexes(conn, db_url: str | None = None) -> None:
         logger.info(f"  {label} ({len(ddls)} indexes)...")
         level_start = time.time()
 
-        groups: dict[str, list[str]] = {}
-        for ddl in ddls:
-            table = extract_index_target_table(ddl)
-            groups.setdefault(table or ddl, []).append(ddl)
+        groups = group_concurrent_index_ddls_by_table(ddls)
 
         def _run_serial_per_table(ddl_list: list[str]) -> None:
             for ddl in ddl_list:
@@ -853,10 +850,7 @@ def add_track_constraints_and_indexes(conn, db_url: str | None = None) -> None:
         logger.info(f"  {label} ({len(ddls)} indexes)...")
         level_start = time.time()
 
-        groups: dict[str, list[str]] = {}
-        for ddl in ddls:
-            table = extract_index_target_table(ddl)
-            groups.setdefault(table or ddl, []).append(ddl)
+        groups = group_concurrent_index_ddls_by_table(ddls)
 
         def _run_serial_per_table(ddl_list: list[str]) -> None:
             for ddl in ddl_list:

--- a/scripts/dedup_releases.py
+++ b/scripts/dedup_releases.py
@@ -29,6 +29,11 @@ import psycopg
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 from lib.observability import init_logger  # noqa: E402
+from lib.pg_concurrent_ddl import (  # noqa: E402
+    add_constraint_safely,
+    add_index_concurrently_safely,
+    extract_index_target_table,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -364,6 +369,21 @@ PRE_SWAP_COLUMN_DEFAULTS: dict[str, dict[str, str]] = {
 }
 
 
+# Columns that must be ``NOT NULL`` on each new_X table *before* the swap, so
+# the post-swap ``ADD CONSTRAINT ... PRIMARY KEY USING INDEX`` step in
+# add_base_constraints_and_indexes is a brief catalog flip rather than a
+# hidden AccessExclusive full-table scan. CTAS strips NOT NULL alongside
+# DEFAULT; applying it now (while the table isn't live) costs a scan that
+# can't conflict with LML's writes. Without this prereq, the post-swap
+# USING INDEX attach would still produce the correct end state but PG would
+# internally run ``SET NOT NULL`` first, defeating the lock-conflict
+# avoidance the helper is supposed to give us. See #286.
+PRE_SWAP_NOT_NULL_COLUMNS: dict[str, tuple[str, ...]] = {
+    "new_release": ("id",),
+    "new_cache_metadata": ("release_id",),
+}
+
+
 def copy_table(conn, old_table: str, new_table: str, columns: str, id_col: str) -> int:
     """Copy rows NOT in dedup_delete_ids to a new table.
 
@@ -383,6 +403,8 @@ def copy_table(conn, old_table: str, new_table: str, columns: str, id_col: str) 
         """)
         for column, default_sql in PRE_SWAP_COLUMN_DEFAULTS.get(new_table, {}).items():
             cur.execute(f"ALTER TABLE {new_table} ALTER COLUMN {column} SET DEFAULT {default_sql}")
+        for column in PRE_SWAP_NOT_NULL_COLUMNS.get(new_table, ()):
+            cur.execute(f"ALTER TABLE {new_table} ALTER COLUMN {column} SET NOT NULL")
         cur.execute(f"SELECT count(*) FROM {new_table}")
         count = int(cur.fetchone()[0])
     conn.commit()
@@ -417,19 +439,55 @@ def _exec_one(db_url: str, stmt: str) -> None:
         conn.close()
 
 
+def _add_constraint_one(db_url: str, ddl: str, lock_tables: tuple[str, ...]) -> None:
+    """Open a connection and run ``add_constraint_safely`` against it.
+
+    Used by the parallel constraint-add executors so each parallel worker has
+    its own autocommit connection. See :mod:`lib.pg_concurrent_ddl` for the
+    retry envelope and the parent-first lock ordering that makes the prune ↔
+    LML deadlock structurally impossible. ``lock_tables`` MUST be in
+    parent-first order — see #286 for the failure mode that reverses it.
+    """
+    conn = psycopg.connect(db_url, autocommit=True)
+    try:
+        add_constraint_safely(conn, ddl, lock_tables=lock_tables)
+    finally:
+        conn.close()
+
+
+def _add_index_concurrently_one(db_url: str, ddl: str) -> None:
+    """Open an autocommit connection and run a CONCURRENTLY index build.
+
+    Each call opens its own connection because ``CREATE INDEX CONCURRENTLY``
+    must run outside a transaction block. The helper enforces that
+    invariant.
+    """
+    conn = psycopg.connect(db_url, autocommit=True)
+    try:
+        add_index_concurrently_safely(conn, ddl)
+    finally:
+        conn.close()
+
+
 def add_base_constraints_and_indexes(conn, db_url: str | None = None) -> None:
     """Add PK, FK constraints and indexes to base tables (no track tables).
 
     Called after dedup copy-swap. Track constraints are added separately
     by create_track_indexes.sql after track import.
 
-    Parallelizes independent index/constraint creation:
-    - Level 1: PK on release (must be first, FK constraints depend on it)
-    - Level 2: FK constraints + FK indexes (parallel, all depend on PK only)
-    - Level 3: GIN trigram indexes + cache metadata indexes (parallel, independent)
+    Wraps every blocking-lock DDL in :func:`lib.pg_concurrent_ddl.
+    add_constraint_safely` (parent-first ``LOCK TABLE ... IN ACCESS EXCLUSIVE
+    MODE`` with bounded ``lock_timeout`` + retry on ``55P03``) and builds
+    every index with :func:`lib.pg_concurrent_ddl.
+    add_index_concurrently_safely` (CONCURRENTLY + INVALID-index
+    precleanup). See #286 for the prune-side outage that drove this fix
+    shape; dedup adopts the same shape to prevent regression here when
+    the prune helper is hardened further.
 
     Args:
-        conn: psycopg connection (used for serial Level 1 PK creation).
+        conn: psycopg connection in autocommit mode. Used for serial setup
+            calls and orphan cleanup; parallel constraint/index workers each
+            open their own short-lived connection against ``db_url``.
         db_url: PostgreSQL connection URL for parallel workers. If None,
             falls back to conn.info.dsn (which may omit password).
     """
@@ -452,12 +510,87 @@ def add_base_constraints_and_indexes(conn, db_url: str | None = None) -> None:
                 future.result()
         logger.info(f"    done in {time.time() - level_start:.1f}s")
 
-    # Level 1: PK on release (serial, must be first)
-    logger.info("  [Level 1] ALTER TABLE release ADD PRIMARY KEY...")
+    def _exec_constraints_parallel(
+        ops: list[tuple[str, tuple[str, ...]]],
+        label: str,
+    ) -> None:
+        """Run a batch of (ddl, lock_tables) constraint ops concurrently.
+
+        Each worker opens its own autocommit connection and goes through
+        :func:`add_constraint_safely`, so they share the same retry envelope
+        and parent-first lock ordering. Multiple workers can serialize on
+        ``LOCK TABLE release`` (the common parent) but that's correct
+        behavior — the locks are exclusive by definition. Order across
+        workers is not preserved.
+        """
+        if not ops:
+            return
+        logger.info(f"  {label} ({len(ops)} constraints)...")
+        level_start = time.time()
+        with ThreadPoolExecutor(max_workers=min(len(ops), 4)) as executor:
+            futures = {
+                executor.submit(_add_constraint_one, db_url, ddl, lock_tables): ddl
+                for ddl, lock_tables in ops
+            }
+            for future in as_completed(futures):
+                future.result()
+        logger.info(f"    done in {time.time() - level_start:.1f}s")
+
+    def _exec_indexes_concurrently_parallel(ddls: list[str], label: str) -> None:
+        """Run a batch of CONCURRENTLY index builds, parallel across distinct
+        target tables and serial within each target table.
+
+        Two ``CREATE INDEX CONCURRENTLY`` calls on the **same** table will
+        deadlock against each other inside Postgres' wait-for-snapshot
+        phase — they each take ShareUpdateExclusive on the table while
+        also waiting on the other's virtual transaction. PG documents
+        this as a one-CONCURRENTLY-per-table limit. Two CONCURRENTLY
+        builds on **different** tables run cleanly in parallel.
+
+        We group ``ddls`` by parsed target table and dispatch one worker
+        per table — within the worker the per-table DDLs run sequentially.
+        Falls back to serial if a DDL can't be parsed (defensive).
+        """
+        if not ddls:
+            return
+        logger.info(f"  {label} ({len(ddls)} indexes)...")
+        level_start = time.time()
+
+        groups: dict[str, list[str]] = {}
+        for ddl in ddls:
+            table = extract_index_target_table(ddl)
+            groups.setdefault(table or ddl, []).append(ddl)
+
+        def _run_serial_per_table(ddl_list: list[str]) -> None:
+            for ddl in ddl_list:
+                _add_index_concurrently_one(db_url, ddl)
+
+        with ThreadPoolExecutor(max_workers=min(len(groups), 4)) as executor:
+            futures = {
+                executor.submit(_run_serial_per_table, ddl_list): table
+                for table, ddl_list in groups.items()
+            }
+            for future in as_completed(futures):
+                future.result()
+        logger.info(f"    done in {time.time() - level_start:.1f}s")
+
+    # Level 1: PK on release. Build via CONCURRENTLY + USING INDEX so the
+    # index scan takes only ShareUpdateExclusive — no conflict with LML's
+    # RowExclusive DML. The post-swap ``release.id`` column was already
+    # set NOT NULL pre-swap (see PRE_SWAP_NOT_NULL_COLUMNS in copy_table),
+    # so the ADD CONSTRAINT USING INDEX step is a brief catalog flip.
+    # See #286 "Prereq for the brief AccessExclusive claim."
+    logger.info("  [Level 1] PK on release (CONCURRENTLY + USING INDEX)...")
     pk_start = time.time()
-    with conn.cursor() as cur:
-        cur.execute("ALTER TABLE release ADD PRIMARY KEY (id)")
-    conn.commit()
+    _add_index_concurrently_one(
+        db_url,
+        "CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS release_pkey ON release(id)",
+    )
+    _add_constraint_one(
+        db_url,
+        "ALTER TABLE release ADD CONSTRAINT release_pkey PRIMARY KEY USING INDEX release_pkey",
+        ("release",),
+    )
     logger.info(f"    done in {time.time() - pk_start:.1f}s")
 
     # Level 1.5: Clean orphan child rows (parallel).
@@ -507,69 +640,148 @@ def add_base_constraints_and_indexes(conn, db_url: str | None = None) -> None:
         "UPDATE cache_metadata SET cached_at = now() WHERE cached_at IS NULL",
     )
 
-    # Level 2: FK constraints + PK on cache_metadata + FK indexes + NOT NULL
-    # restoration (parallel).
+    # Level 2A: FK constraints (parallel, parent-first locks via helper).
     #
-    # FK constraints use NOT VALID so the ADD step itself can't race-fail
-    # on orphans created by LML during the brief Level-1.5 → Level-2 window.
-    # Postgres still enforces the FK on new inserts after the constraint is
-    # added, so the durable behavior is identical to a validated constraint.
-    #
-    # The ``SET NOT NULL`` statements re-assert the constraints that the
-    # ``CREATE TABLE new_X AS SELECT ...`` step strips silently — CTAS
-    # carries column types forward but not NOT NULL / DEFAULT / CHECK. The
-    # schema in ``schema/create_database.sql`` declares the data columns
-    # below as NOT NULL; without explicit re-application every monthly
-    # rebuild ships a discogs-cache where those constraints are gone. The
-    # corresponding DEFAULTs are re-applied earlier — in copy_table() via
-    # ``PRE_SWAP_COLUMN_DEFAULTS``, before swap_tables() makes the new
-    # table live — so LML's cache-miss INSERT (which omits ``cached_at``)
-    # never lands a NULL during the swap window. Pinned by
-    # ``tests/integration/test_copy_swap_preserves_not_null.py``.
-    _exec_parallel(
+    # Each ``ALTER TABLE ... ADD CONSTRAINT FOREIGN KEY ... REFERENCES
+    # release(id) NOT VALID`` takes ShareRowExclusiveLock on **both** the
+    # child (target of the ALTER) and the parent (FK target). NOT VALID
+    # skips existing-row scanning but does NOT skip lock acquisition. PG's
+    # FK creation acquires the child first then the parent — opposite of
+    # LML's parent-first order in ``write_release``. Without the helper's
+    # explicit parent-first ``LOCK TABLE`` envelope, this deadlocks with
+    # an LML cache-miss writer (see #286 — the bug surfaced production-side
+    # in the verify_cache prune; the dedup site has the same shape and
+    # would have surfaced eventually).
+    _exec_constraints_parallel(
         [
-            "ALTER TABLE release_artist ADD CONSTRAINT fk_release_artist_release "
-            "FOREIGN KEY (release_id) REFERENCES release(id) ON DELETE CASCADE NOT VALID",
-            "ALTER TABLE release_label ADD CONSTRAINT fk_release_label_release "
-            "FOREIGN KEY (release_id) REFERENCES release(id) ON DELETE CASCADE NOT VALID",
-            "ALTER TABLE release_genre ADD CONSTRAINT fk_release_genre_release "
-            "FOREIGN KEY (release_id) REFERENCES release(id) ON DELETE CASCADE NOT VALID",
-            "ALTER TABLE release_style ADD CONSTRAINT fk_release_style_release "
-            "FOREIGN KEY (release_id) REFERENCES release(id) ON DELETE CASCADE NOT VALID",
-            "ALTER TABLE cache_metadata ADD CONSTRAINT fk_cache_metadata_release "
-            "FOREIGN KEY (release_id) REFERENCES release(id) ON DELETE CASCADE NOT VALID",
-            "ALTER TABLE cache_metadata ADD PRIMARY KEY (release_id)",
-            "CREATE INDEX idx_release_artist_release_id ON release_artist(release_id)",
-            "CREATE INDEX idx_release_label_release_id ON release_label(release_id)",
-            "CREATE INDEX idx_release_genre_release_id ON release_genre(release_id)",
-            "CREATE INDEX idx_release_style_release_id ON release_style(release_id)",
-            "ALTER TABLE release ALTER COLUMN title SET NOT NULL",
-            "ALTER TABLE release ALTER COLUMN not_found SET NOT NULL",
-            "ALTER TABLE release_artist ALTER COLUMN release_id SET NOT NULL",
-            "ALTER TABLE release_artist ALTER COLUMN artist_name SET NOT NULL",
-            "ALTER TABLE release_label ALTER COLUMN release_id SET NOT NULL",
-            "ALTER TABLE release_label ALTER COLUMN label_name SET NOT NULL",
-            "ALTER TABLE release_genre ALTER COLUMN release_id SET NOT NULL",
-            "ALTER TABLE release_genre ALTER COLUMN genre SET NOT NULL",
-            "ALTER TABLE release_style ALTER COLUMN release_id SET NOT NULL",
-            "ALTER TABLE release_style ALTER COLUMN style SET NOT NULL",
-            "ALTER TABLE cache_metadata ALTER COLUMN cached_at SET NOT NULL",
-            "ALTER TABLE cache_metadata ALTER COLUMN source SET NOT NULL",
+            (
+                "ALTER TABLE release_artist ADD CONSTRAINT fk_release_artist_release "
+                "FOREIGN KEY (release_id) REFERENCES release(id) ON DELETE CASCADE NOT VALID",
+                ("release", "release_artist"),
+            ),
+            (
+                "ALTER TABLE release_label ADD CONSTRAINT fk_release_label_release "
+                "FOREIGN KEY (release_id) REFERENCES release(id) ON DELETE CASCADE NOT VALID",
+                ("release", "release_label"),
+            ),
+            (
+                "ALTER TABLE release_genre ADD CONSTRAINT fk_release_genre_release "
+                "FOREIGN KEY (release_id) REFERENCES release(id) ON DELETE CASCADE NOT VALID",
+                ("release", "release_genre"),
+            ),
+            (
+                "ALTER TABLE release_style ADD CONSTRAINT fk_release_style_release "
+                "FOREIGN KEY (release_id) REFERENCES release(id) ON DELETE CASCADE NOT VALID",
+                ("release", "release_style"),
+            ),
+            (
+                "ALTER TABLE cache_metadata ADD CONSTRAINT fk_cache_metadata_release "
+                "FOREIGN KEY (release_id) REFERENCES release(id) ON DELETE CASCADE NOT VALID",
+                ("release", "cache_metadata"),
+            ),
         ],
-        "Level 2: FK constraints + FK indexes + NOT NULL",
+        "Level 2A: FK constraints (parent-first LOCK TABLE)",
     )
 
-    # Level 3: GIN trigram indexes + cache metadata indexes (parallel)
-    _exec_parallel(
+    # Level 2B: PK on cache_metadata via CONCURRENTLY + USING INDEX.
+    # ``new_cache_metadata.release_id`` was set NOT NULL pre-swap.
+    logger.info("  [Level 2B] PK on cache_metadata (CONCURRENTLY + USING INDEX)...")
+    pk2_start = time.time()
+    _add_index_concurrently_one(
+        db_url,
+        "CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS cache_metadata_pkey "
+        "ON cache_metadata(release_id)",
+    )
+    _add_constraint_one(
+        db_url,
+        "ALTER TABLE cache_metadata ADD CONSTRAINT cache_metadata_pkey "
+        "PRIMARY KEY USING INDEX cache_metadata_pkey",
+        ("cache_metadata",),
+    )
+    logger.info(f"    done in {time.time() - pk2_start:.1f}s")
+
+    # Level 2C: FK indexes built CONCURRENTLY. ShareUpdateExclusive instead
+    # of Share — no conflict with LML's DML.
+    _exec_indexes_concurrently_parallel(
         [
-            "CREATE INDEX idx_release_artist_name_trgm ON release_artist "
-            "USING gin (lower(f_unaccent(artist_name)) gin_trgm_ops)",
-            "CREATE INDEX idx_release_title_trgm ON release "
-            "USING gin (lower(f_unaccent(title)) gin_trgm_ops)",
-            "CREATE INDEX idx_cache_metadata_cached_at ON cache_metadata(cached_at)",
-            "CREATE INDEX idx_cache_metadata_source ON cache_metadata(source)",
+            "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_release_artist_release_id "
+            "ON release_artist(release_id)",
+            "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_release_label_release_id "
+            "ON release_label(release_id)",
+            "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_release_genre_release_id "
+            "ON release_genre(release_id)",
+            "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_release_style_release_id "
+            "ON release_style(release_id)",
         ],
-        "Level 3: GIN trigram + metadata indexes",
+        "Level 2C: FK indexes (CONCURRENTLY)",
+    )
+
+    # Level 2D: NOT NULL restoration. Each takes AccessExclusive on a
+    # single table and performs an implicit full-table scan — wrap via the
+    # helper so it shares the retry envelope and brief-lock semantics.
+    #
+    # ``SET NOT NULL`` here re-asserts the constraints that ``CREATE TABLE
+    # new_X AS SELECT ...`` strips silently (CTAS carries column types
+    # forward but not NOT NULL / DEFAULT / CHECK). The corresponding
+    # DEFAULTs are re-applied earlier — in copy_table() via
+    # ``PRE_SWAP_COLUMN_DEFAULTS`` — so LML's cache-miss INSERT (which
+    # omits ``cached_at``) never lands a NULL during the swap window.
+    # Pinned by ``tests/integration/test_copy_swap_preserves_not_null.py``.
+    _exec_constraints_parallel(
+        [
+            ("ALTER TABLE release ALTER COLUMN title SET NOT NULL", ("release",)),
+            ("ALTER TABLE release ALTER COLUMN not_found SET NOT NULL", ("release",)),
+            (
+                "ALTER TABLE release_artist ALTER COLUMN release_id SET NOT NULL",
+                ("release_artist",),
+            ),
+            (
+                "ALTER TABLE release_artist ALTER COLUMN artist_name SET NOT NULL",
+                ("release_artist",),
+            ),
+            (
+                "ALTER TABLE release_label ALTER COLUMN release_id SET NOT NULL",
+                ("release_label",),
+            ),
+            (
+                "ALTER TABLE release_label ALTER COLUMN label_name SET NOT NULL",
+                ("release_label",),
+            ),
+            (
+                "ALTER TABLE release_genre ALTER COLUMN release_id SET NOT NULL",
+                ("release_genre",),
+            ),
+            ("ALTER TABLE release_genre ALTER COLUMN genre SET NOT NULL", ("release_genre",)),
+            (
+                "ALTER TABLE release_style ALTER COLUMN release_id SET NOT NULL",
+                ("release_style",),
+            ),
+            ("ALTER TABLE release_style ALTER COLUMN style SET NOT NULL", ("release_style",)),
+            (
+                "ALTER TABLE cache_metadata ALTER COLUMN cached_at SET NOT NULL",
+                ("cache_metadata",),
+            ),
+            (
+                "ALTER TABLE cache_metadata ALTER COLUMN source SET NOT NULL",
+                ("cache_metadata",),
+            ),
+        ],
+        "Level 2D: NOT NULL restoration",
+    )
+
+    # Level 3: GIN trigram + cache metadata indexes (CONCURRENTLY, parallel).
+    _exec_indexes_concurrently_parallel(
+        [
+            "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_release_artist_name_trgm "
+            "ON release_artist USING gin (lower(f_unaccent(artist_name)) gin_trgm_ops)",
+            "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_release_title_trgm "
+            "ON release USING gin (lower(f_unaccent(title)) gin_trgm_ops)",
+            "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_cache_metadata_cached_at "
+            "ON cache_metadata(cached_at)",
+            "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_cache_metadata_source "
+            "ON cache_metadata(source)",
+        ],
+        "Level 3: GIN trigram + metadata indexes (CONCURRENTLY)",
     )
 
     elapsed = time.time() - start
@@ -582,9 +794,11 @@ def add_track_constraints_and_indexes(conn, db_url: str | None = None) -> None:
     Called after track import (post-dedup). Equivalent to running
     create_track_indexes.sql.
 
-    Parallelizes independent statements:
-    - Level 1: FK constraints (parallel, both depend on release PK only)
-    - Level 2: FK indexes + GIN trigram indexes (parallel, independent)
+    Wraps blocking-lock DDL via :func:`lib.pg_concurrent_ddl.
+    add_constraint_safely` and indexes via :func:`lib.pg_concurrent_ddl.
+    add_index_concurrently_safely`. See the docstring of
+    :func:`add_base_constraints_and_indexes` and #286 for the full
+    rationale; this is the same fix shape applied to the track tables.
 
     Args:
         conn: psycopg connection (unused but kept for API consistency).
@@ -610,6 +824,53 @@ def add_track_constraints_and_indexes(conn, db_url: str | None = None) -> None:
                 future.result()
         logger.info(f"    done in {time.time() - level_start:.1f}s")
 
+    def _exec_constraints_parallel(
+        ops: list[tuple[str, tuple[str, ...]]],
+        label: str,
+    ) -> None:
+        if not ops:
+            return
+        logger.info(f"  {label} ({len(ops)} constraints)...")
+        level_start = time.time()
+        with ThreadPoolExecutor(max_workers=min(len(ops), 4)) as executor:
+            futures = {
+                executor.submit(_add_constraint_one, db_url, ddl, lock_tables): ddl
+                for ddl, lock_tables in ops
+            }
+            for future in as_completed(futures):
+                future.result()
+        logger.info(f"    done in {time.time() - level_start:.1f}s")
+
+    def _exec_indexes_concurrently_parallel(ddls: list[str], label: str) -> None:
+        """Run CONCURRENTLY index builds, parallel across distinct tables and
+        serial within each table. See the docstring on the version in
+        :func:`add_base_constraints_and_indexes` for the PG-side rationale
+        (two CONCURRENTLY builds on the same table deadlock against each
+        other).
+        """
+        if not ddls:
+            return
+        logger.info(f"  {label} ({len(ddls)} indexes)...")
+        level_start = time.time()
+
+        groups: dict[str, list[str]] = {}
+        for ddl in ddls:
+            table = extract_index_target_table(ddl)
+            groups.setdefault(table or ddl, []).append(ddl)
+
+        def _run_serial_per_table(ddl_list: list[str]) -> None:
+            for ddl in ddl_list:
+                _add_index_concurrently_one(db_url, ddl)
+
+        with ThreadPoolExecutor(max_workers=min(len(groups), 4)) as executor:
+            futures = {
+                executor.submit(_run_serial_per_table, ddl_list): table
+                for table, ddl_list in groups.items()
+            }
+            for future in as_completed(futures):
+                future.result()
+        logger.info(f"    done in {time.time() - level_start:.1f}s")
+
     # Level 0: Clean orphan track rows (parallel). LML writes release_track
     # + release_track_artist rows on every Discogs API miss; during the dedup
     # swap window those land as orphans. Parallel to the base-side cleanup
@@ -625,28 +886,41 @@ def add_track_constraints_and_indexes(conn, db_url: str | None = None) -> None:
         "Level 0: Clean orphan track rows before FK validation",
     )
 
-    # Level 1: FK constraints (parallel, NOT VALID for race tolerance).
-    _exec_parallel(
+    # Level 1: FK constraints (parallel, parent-first locks via helper).
+    # Same shape as add_base_constraints_and_indexes Level 2A — the
+    # ``ADD CONSTRAINT ... NOT VALID`` step takes ShareRowExclusive on
+    # both child and parent and would otherwise race-deadlock against an
+    # open LML ``write_release`` transaction (see #286).
+    _exec_constraints_parallel(
         [
-            "ALTER TABLE release_track ADD CONSTRAINT fk_release_track_release "
-            "FOREIGN KEY (release_id) REFERENCES release(id) ON DELETE CASCADE NOT VALID",
-            "ALTER TABLE release_track_artist ADD CONSTRAINT fk_release_track_artist_release "
-            "FOREIGN KEY (release_id) REFERENCES release(id) ON DELETE CASCADE NOT VALID",
+            (
+                "ALTER TABLE release_track ADD CONSTRAINT fk_release_track_release "
+                "FOREIGN KEY (release_id) REFERENCES release(id) ON DELETE CASCADE NOT VALID",
+                ("release", "release_track"),
+            ),
+            (
+                "ALTER TABLE release_track_artist ADD CONSTRAINT "
+                "fk_release_track_artist_release "
+                "FOREIGN KEY (release_id) REFERENCES release(id) ON DELETE CASCADE NOT VALID",
+                ("release", "release_track_artist"),
+            ),
         ],
-        "Level 1: FK constraints",
+        "Level 1: FK constraints (parent-first LOCK TABLE)",
     )
 
-    # Level 2: FK indexes + GIN trigram indexes (parallel)
-    _exec_parallel(
+    # Level 2: FK indexes + GIN trigram indexes (CONCURRENTLY, parallel).
+    _exec_indexes_concurrently_parallel(
         [
-            "CREATE INDEX idx_release_track_release_id ON release_track(release_id)",
-            "CREATE INDEX idx_release_track_artist_release_id ON release_track_artist(release_id)",
-            "CREATE INDEX idx_release_track_title_trgm ON release_track "
-            "USING gin (lower(f_unaccent(title)) gin_trgm_ops)",
-            "CREATE INDEX idx_release_track_artist_name_trgm ON release_track_artist "
-            "USING gin (lower(f_unaccent(artist_name)) gin_trgm_ops)",
+            "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_release_track_release_id "
+            "ON release_track(release_id)",
+            "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_release_track_artist_release_id "
+            "ON release_track_artist(release_id)",
+            "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_release_track_title_trgm "
+            "ON release_track USING gin (lower(f_unaccent(title)) gin_trgm_ops)",
+            "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_release_track_artist_name_trgm "
+            "ON release_track_artist USING gin (lower(f_unaccent(artist_name)) gin_trgm_ops)",
         ],
-        "Level 2: FK indexes + GIN trigram indexes",
+        "Level 2: FK indexes + GIN trigram (CONCURRENTLY)",
     )
 
     elapsed = time.time() - start

--- a/scripts/verify_cache.py
+++ b/scripts/verify_cache.py
@@ -63,6 +63,12 @@ from wxyc_etl.text import is_compilation_artist, split_artist_name_contextual
 
 from lib.format_normalization import format_matches, normalize_library_format
 from lib.observability import init_logger
+from lib.pg_concurrent_ddl import (
+    SWAP_PATH_ATTEMPTS,
+    SWAP_PATH_BACKOFF_SECONDS,
+    add_constraint_safely,
+    add_index_concurrently_safely,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -767,24 +773,91 @@ def _prune_copy_swap_tables(
                 count = cur.fetchone()[0]
             logger.info(f"  Copied {old_table} -> {new_table}: {count:,} rows")
 
+        # Pre-swap NOT NULL on PK columns. The new_X tables aren't live yet, so
+        # the implicit full-table scan that ``ALTER COLUMN ... SET NOT NULL``
+        # performs can't conflict with LML's writes — and doing it now is the
+        # prerequisite for the post-swap ``ADD CONSTRAINT ... PRIMARY KEY USING
+        # INDEX`` step in ``_prune_add_base_constraints_and_indexes`` to be the
+        # brief catalog flip CONCURRENTLY promises rather than a hidden
+        # AccessExclusive scan. Without this, CTAS-stripped NULLability would
+        # force PG to run SET NOT NULL internally under AccessExclusive,
+        # defeating the lock-conflict avoidance the helper is supposed to give
+        # us. See #286 "Prereq for the 'brief AccessExclusive' claim".
         with conn.cursor() as cur:
-            for stmt in [
+            cur.execute("ALTER TABLE new_release ALTER COLUMN id SET NOT NULL")
+            cur.execute("ALTER TABLE new_cache_metadata ALTER COLUMN release_id SET NOT NULL")
+
+        # DROP CONSTRAINT + RENAME deadlock surface — same lock-acquisition
+        # mismatch as the FK-add path below, with the *broader* surface
+        # (AccessExclusive instead of ShareRowExclusive). Conflicts with every
+        # live LML lock mode on the involved tables, not just the
+        # ShareRowExclusive ↔ RowExclusive pairing from the FK-add path.
+        # Wrap each statement in :func:`add_constraint_safely` with the wider
+        # SWAP_PATH_ATTEMPTS budget so a transient LML transaction doesn't
+        # abort the whole prune. See #286 "Second deadlock surface in the
+        # same script."
+        for stmt, table in (
+            (
                 "ALTER TABLE release_artist DROP CONSTRAINT IF EXISTS fk_release_artist_release",
+                "release_artist",
+            ),
+            (
                 "ALTER TABLE release_label DROP CONSTRAINT IF EXISTS fk_release_label_release",
+                "release_label",
+            ),
+            (
                 "ALTER TABLE release_genre DROP CONSTRAINT IF EXISTS fk_release_genre_release",
+                "release_genre",
+            ),
+            (
                 "ALTER TABLE release_style DROP CONSTRAINT IF EXISTS fk_release_style_release",
+                "release_style",
+            ),
+            (
                 "ALTER TABLE release_track DROP CONSTRAINT IF EXISTS fk_release_track_release",
-                "ALTER TABLE release_track_artist DROP CONSTRAINT IF EXISTS fk_release_track_artist_release",
+                "release_track",
+            ),
+            (
+                "ALTER TABLE release_track_artist DROP CONSTRAINT "
+                "IF EXISTS fk_release_track_artist_release",
+                "release_track_artist",
+            ),
+            (
                 "ALTER TABLE cache_metadata DROP CONSTRAINT IF EXISTS fk_cache_metadata_release",
-            ]:
-                cur.execute(stmt)
+                "cache_metadata",
+            ),
+        ):
+            add_constraint_safely(
+                conn,
+                stmt,
+                lock_tables=[table],
+                attempts=SWAP_PATH_ATTEMPTS,
+                backoff_seconds=SWAP_PATH_BACKOFF_SECONDS,
+            )
 
         for old_table, new_table, _, _ in PRUNE_COPY_TABLES:
             bak = f"{old_table}_old"
-            with conn.cursor() as cur:
-                cur.execute(f"ALTER TABLE {old_table} RENAME TO {bak}")
-                cur.execute(f"ALTER TABLE {new_table} RENAME TO {old_table}")
-                cur.execute(f"DROP TABLE {bak} CASCADE")
+            # Atomic swap: the three statements (RENAME old → bak, RENAME
+            # new → old, DROP bak CASCADE) run in one transaction so the
+            # table name ``old_table`` is never momentarily unbound (which
+            # would race-fail LML's writes with ``relation does not exist``)
+            # AND so AccessExclusive on ``old_table`` is held coherently
+            # for the full swap window — LML's writes queue on the lock
+            # and land in the swapped-in table once we commit. See #286
+            # "Swap path lock-contention coverage." Both names are listed
+            # in the LOCK TABLE for completeness even though the surviving
+            # post-swap relation reuses the ``old_table`` name.
+            add_constraint_safely(
+                conn,
+                [
+                    f"ALTER TABLE {old_table} RENAME TO {bak}",
+                    f"ALTER TABLE {new_table} RENAME TO {old_table}",
+                    f"DROP TABLE {bak} CASCADE",
+                ],
+                lock_tables=[old_table, new_table],
+                attempts=SWAP_PATH_ATTEMPTS,
+                backoff_seconds=SWAP_PATH_BACKOFF_SECONDS,
+            )
             logger.info(f"  Swapped {new_table} -> {old_table}")
     finally:
         conn.close()
@@ -804,15 +877,31 @@ def _prune_add_base_constraints_and_indexes(db_url: str) -> None:
     """
     conn = psycopg.connect(db_url, autocommit=True)
     try:
-        with conn.cursor() as cur:
-            cur.execute("ALTER TABLE release ADD PRIMARY KEY (id)")
+        # PK on release: build CONCURRENTLY so the index scan doesn't take
+        # Share on ``release`` (which conflicts with LML's RowExclusive for
+        # the full minutes-long build). The post-swap ``new_release.id``
+        # column was set NOT NULL pre-swap in _prune_copy_swap_tables so
+        # ``ADD CONSTRAINT ... USING INDEX`` is the brief catalog flip
+        # CONCURRENTLY promises — without that prereq it would silently
+        # run a full-table NOT NULL scan under AccessExclusive. See #286
+        # "Prereq for the brief AccessExclusive claim".
+        add_index_concurrently_safely(
+            conn,
+            "CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS release_pkey ON release(id)",
+        )
+        add_constraint_safely(
+            conn,
+            "ALTER TABLE release ADD CONSTRAINT release_pkey PRIMARY KEY USING INDEX release_pkey",
+            lock_tables=["release"],
+        )
 
-            # Clean orphan child rows before FK validation. The live LML
-            # service writes child rows for releases NOT in the post-prune
-            # subset; deleting them now keeps the ADD CONSTRAINT step below
-            # from failing on validation. NOT VALID on the constraint itself
-            # tolerates new orphans landing between cleanup and ADD. See
-            # #211 + #188 for the parallel fix in dedup_releases.py.
+        # Clean orphan child rows before FK validation. The live LML
+        # service writes child rows for releases NOT in the post-prune
+        # subset; deleting them now keeps the ADD CONSTRAINT step below
+        # from failing on validation. NOT VALID on the constraint itself
+        # tolerates new orphans landing between cleanup and ADD. See
+        # #211 + #188 for the parallel fix in dedup_releases.py.
+        with conn.cursor() as cur:
             for child_table in (
                 "release_artist",
                 "release_label",
@@ -827,41 +916,121 @@ def _prune_add_base_constraints_and_indexes(db_url: str) -> None:
                     f"(SELECT 1 FROM release r WHERE r.id = {child_table}.release_id)"
                 )
 
-            for stmt in (
+        # FK constraint adds. Each ``ALTER TABLE ... ADD CONSTRAINT FOREIGN
+        # KEY ... REFERENCES release(id) NOT VALID`` takes
+        # ShareRowExclusiveLock on **both** the child (target of the ALTER)
+        # and the parent (FK target) — see PG source
+        # ``tablecmds.c::ATAddForeignKeyConstraint``: ``table_openrv(
+        # fkconstraint->pktable, ShareRowExclusiveLock)``. ``NOT VALID``
+        # skips the existing-row scan but does NOT skip the parent-side
+        # lock acquisition.
+        #
+        # The deadlock fixed by #286: PG's FK creation acquires the child
+        # first (the ``ALTER TABLE`` target) then the parent — opposite of
+        # LML's order (``write_release`` UPSERTs ``release`` first, then
+        # children). RowExclusive ↔ ShareRowExclusive conflict per the PG
+        # lock-mode matrix → classic cycle. The fix here: pre-acquire both
+        # tables via ``LOCK TABLE <parent>, <child> IN ACCESS EXCLUSIVE
+        # MODE`` in parent-first order so the happy path doesn't even
+        # reach PG's deadlock detector — our transaction just waits for
+        # any open LML transaction to commit, then proceeds.
+        for fk_ddl, child_table in (
+            (
                 "ALTER TABLE release_artist ADD CONSTRAINT fk_release_artist_release "
                 "FOREIGN KEY (release_id) REFERENCES release(id) ON DELETE CASCADE NOT VALID",
+                "release_artist",
+            ),
+            (
                 "ALTER TABLE release_label ADD CONSTRAINT fk_release_label_release "
                 "FOREIGN KEY (release_id) REFERENCES release(id) ON DELETE CASCADE NOT VALID",
+                "release_label",
+            ),
+            (
                 "ALTER TABLE release_genre ADD CONSTRAINT fk_release_genre_release "
                 "FOREIGN KEY (release_id) REFERENCES release(id) ON DELETE CASCADE NOT VALID",
+                "release_genre",
+            ),
+            (
                 "ALTER TABLE release_style ADD CONSTRAINT fk_release_style_release "
                 "FOREIGN KEY (release_id) REFERENCES release(id) ON DELETE CASCADE NOT VALID",
+                "release_style",
+            ),
+            (
                 "ALTER TABLE release_track ADD CONSTRAINT fk_release_track_release "
                 "FOREIGN KEY (release_id) REFERENCES release(id) ON DELETE CASCADE NOT VALID",
-                "ALTER TABLE release_track_artist ADD CONSTRAINT fk_release_track_artist_release "
+                "release_track",
+            ),
+            (
+                "ALTER TABLE release_track_artist ADD CONSTRAINT "
+                "fk_release_track_artist_release "
                 "FOREIGN KEY (release_id) REFERENCES release(id) ON DELETE CASCADE NOT VALID",
+                "release_track_artist",
+            ),
+            (
                 "ALTER TABLE cache_metadata ADD CONSTRAINT fk_cache_metadata_release "
                 "FOREIGN KEY (release_id) REFERENCES release(id) ON DELETE CASCADE NOT VALID",
-                "ALTER TABLE cache_metadata ADD PRIMARY KEY (release_id)",
-                "CREATE INDEX idx_release_artist_release_id ON release_artist(release_id)",
-                "CREATE INDEX idx_release_label_release_id ON release_label(release_id)",
-                "CREATE INDEX idx_release_genre_release_id ON release_genre(release_id)",
-                "CREATE INDEX idx_release_style_release_id ON release_style(release_id)",
-                "CREATE INDEX idx_release_track_release_id ON release_track(release_id)",
-                "CREATE INDEX idx_release_track_artist_release_id ON release_track_artist(release_id)",
-                "CREATE INDEX idx_release_artist_name_trgm ON release_artist "
-                "USING gin (lower(f_unaccent(artist_name)) gin_trgm_ops)",
-                "CREATE INDEX idx_release_title_trgm ON release "
-                "USING gin (lower(f_unaccent(title)) gin_trgm_ops)",
-                "CREATE INDEX idx_release_track_title_trgm ON release_track "
-                "USING gin (lower(f_unaccent(title)) gin_trgm_ops)",
-                "CREATE INDEX idx_release_track_artist_name_trgm ON release_track_artist "
-                "USING gin (lower(f_unaccent(artist_name)) gin_trgm_ops)",
-                "CREATE INDEX idx_cache_metadata_cached_at ON cache_metadata(cached_at)",
-                "CREATE INDEX idx_cache_metadata_source ON cache_metadata(source)",
-            ):
-                cur.execute(stmt)
+                "cache_metadata",
+            ),
+        ):
+            add_constraint_safely(
+                conn,
+                fk_ddl,
+                # Parent-first ordering matches LML's ``write_release``
+                # acquisition order.
+                lock_tables=["release", child_table],
+            )
 
+        # PK on cache_metadata via CONCURRENTLY-built index then USING
+        # INDEX attach. ``new_cache_metadata.release_id`` was set NOT NULL
+        # pre-swap so this is a brief catalog flip, not a hidden scan.
+        add_index_concurrently_safely(
+            conn,
+            "CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS cache_metadata_pkey "
+            "ON cache_metadata(release_id)",
+        )
+        add_constraint_safely(
+            conn,
+            "ALTER TABLE cache_metadata ADD CONSTRAINT cache_metadata_pkey "
+            "PRIMARY KEY USING INDEX cache_metadata_pkey",
+            lock_tables=["cache_metadata"],
+        )
+
+        # FK indexes + trigram + cache_metadata side indexes — all built
+        # CONCURRENTLY so the long index build takes only
+        # ShareUpdateExclusive (no conflict with LML's RowExclusive DML)
+        # rather than the Share that non-concurrent CREATE INDEX would
+        # hold for the full duration. CONCURRENTLY must NOT run inside a
+        # transaction block; the helper refuses to do so and the
+        # connection is autocommit at this point.
+        for index_ddl in (
+            "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_release_artist_release_id "
+            "ON release_artist(release_id)",
+            "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_release_label_release_id "
+            "ON release_label(release_id)",
+            "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_release_genre_release_id "
+            "ON release_genre(release_id)",
+            "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_release_style_release_id "
+            "ON release_style(release_id)",
+            "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_release_track_release_id "
+            "ON release_track(release_id)",
+            "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_release_track_artist_release_id "
+            "ON release_track_artist(release_id)",
+            "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_release_artist_name_trgm "
+            "ON release_artist USING gin (lower(f_unaccent(artist_name)) gin_trgm_ops)",
+            "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_release_title_trgm "
+            "ON release USING gin (lower(f_unaccent(title)) gin_trgm_ops)",
+            "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_release_track_title_trgm "
+            "ON release_track USING gin (lower(f_unaccent(title)) gin_trgm_ops)",
+            "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_release_track_artist_name_trgm "
+            "ON release_track_artist USING gin (lower(f_unaccent(artist_name)) gin_trgm_ops)",
+            "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_cache_metadata_cached_at "
+            "ON cache_metadata(cached_at)",
+            "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_cache_metadata_source "
+            "ON cache_metadata(source)",
+        ):
+            add_index_concurrently_safely(conn, index_ddl)
+
+        with conn.cursor() as cur:
             # Backfill any race-window NULLs before SET NOT NULL. The
             # pre-swap DEFAULT restoration in _prune_copy_swap_tables
             # *should* keep this UPDATE a no-op in steady state; we keep
@@ -870,36 +1039,64 @@ def _prune_add_base_constraints_and_indexes(db_url: str) -> None:
             # See #256.
             cur.execute("UPDATE cache_metadata SET cached_at = now() WHERE cached_at IS NULL")
 
-            # Re-apply NOT NULL constraints stripped by ``CREATE TABLE AS
-            # SELECT`` above. CTAS carries column types forward but not
-            # NOT NULL / DEFAULT / CHECK. The corresponding DEFAULTs are
-            # re-applied earlier — in _prune_copy_swap_tables, before the
-            # RENAME makes the new table live — so LML's cache-miss
-            # INSERT (which omits ``cached_at``) never lands a NULL during
-            # the swap window. Pinned by
-            # ``tests/integration/test_copy_swap_preserves_not_null.py``.
-            for stmt in (
-                "ALTER TABLE release ALTER COLUMN title SET NOT NULL",
-                "ALTER TABLE release ALTER COLUMN not_found SET NOT NULL",
+        # Re-apply NOT NULL constraints stripped by ``CREATE TABLE AS
+        # SELECT`` above. CTAS carries column types forward but not
+        # NOT NULL / DEFAULT / CHECK. The corresponding DEFAULTs are
+        # re-applied earlier — in _prune_copy_swap_tables, before the
+        # RENAME makes the new table live — so LML's cache-miss
+        # INSERT (which omits ``cached_at``) never lands a NULL during
+        # the swap window. Pinned by
+        # ``tests/integration/test_copy_swap_preserves_not_null.py``.
+        #
+        # ``ALTER COLUMN ... SET NOT NULL`` takes AccessExclusive and
+        # performs an implicit full-table scan. Wrap each via the helper
+        # so the brief lock window is shared with LML cleanly under the
+        # same retry envelope as the FK adds.
+        for not_null_ddl, target_table in (
+            ("ALTER TABLE release ALTER COLUMN title SET NOT NULL", "release"),
+            ("ALTER TABLE release ALTER COLUMN not_found SET NOT NULL", "release"),
+            (
                 "ALTER TABLE release_artist ALTER COLUMN release_id SET NOT NULL",
+                "release_artist",
+            ),
+            (
                 "ALTER TABLE release_artist ALTER COLUMN artist_name SET NOT NULL",
-                "ALTER TABLE release_label ALTER COLUMN release_id SET NOT NULL",
-                "ALTER TABLE release_label ALTER COLUMN label_name SET NOT NULL",
-                "ALTER TABLE release_genre ALTER COLUMN release_id SET NOT NULL",
-                "ALTER TABLE release_genre ALTER COLUMN genre SET NOT NULL",
-                "ALTER TABLE release_style ALTER COLUMN release_id SET NOT NULL",
-                "ALTER TABLE release_style ALTER COLUMN style SET NOT NULL",
-                "ALTER TABLE release_track ALTER COLUMN release_id SET NOT NULL",
-                "ALTER TABLE release_track ALTER COLUMN sequence SET NOT NULL",
-                "ALTER TABLE release_track ALTER COLUMN title SET NOT NULL",
+                "release_artist",
+            ),
+            ("ALTER TABLE release_label ALTER COLUMN release_id SET NOT NULL", "release_label"),
+            ("ALTER TABLE release_label ALTER COLUMN label_name SET NOT NULL", "release_label"),
+            ("ALTER TABLE release_genre ALTER COLUMN release_id SET NOT NULL", "release_genre"),
+            ("ALTER TABLE release_genre ALTER COLUMN genre SET NOT NULL", "release_genre"),
+            ("ALTER TABLE release_style ALTER COLUMN release_id SET NOT NULL", "release_style"),
+            ("ALTER TABLE release_style ALTER COLUMN style SET NOT NULL", "release_style"),
+            ("ALTER TABLE release_track ALTER COLUMN release_id SET NOT NULL", "release_track"),
+            ("ALTER TABLE release_track ALTER COLUMN sequence SET NOT NULL", "release_track"),
+            ("ALTER TABLE release_track ALTER COLUMN title SET NOT NULL", "release_track"),
+            (
                 "ALTER TABLE release_track_artist ALTER COLUMN release_id SET NOT NULL",
+                "release_track_artist",
+            ),
+            (
                 "ALTER TABLE release_track_artist ALTER COLUMN track_sequence SET NOT NULL",
+                "release_track_artist",
+            ),
+            (
                 "ALTER TABLE release_track_artist ALTER COLUMN artist_name SET NOT NULL",
+                "release_track_artist",
+            ),
+            (
                 "ALTER TABLE cache_metadata ALTER COLUMN cached_at SET NOT NULL",
-                "ALTER TABLE cache_metadata ALTER COLUMN source SET NOT NULL",
-            ):
-                cur.execute(stmt)
+                "cache_metadata",
+            ),
+            ("ALTER TABLE cache_metadata ALTER COLUMN source SET NOT NULL", "cache_metadata"),
+        ):
+            add_constraint_safely(
+                conn,
+                not_null_ddl,
+                lock_tables=[target_table],
+            )
 
+        with conn.cursor() as cur:
             cur.execute("DROP TABLE IF EXISTS _keep_ids")
     finally:
         conn.close()

--- a/scripts/verify_cache.py
+++ b/scripts/verify_cache.py
@@ -731,6 +731,21 @@ PRUNE_PRE_SWAP_COLUMN_DEFAULTS: dict[str, dict[str, str]] = {
 }
 
 
+# Columns to apply ``NOT NULL`` to pre-swap so the post-swap
+# ``ADD CONSTRAINT ... PRIMARY KEY USING INDEX`` step is a brief catalog
+# flip rather than a hidden full-table scan under AccessExclusive. CTAS
+# strips NOT NULL alongside DEFAULT; applying it on ``new_X`` (which isn't
+# live yet) costs a scan that can't conflict with LML's writes. Mirror of
+# ``dedup_releases.PRE_SWAP_NOT_NULL_COLUMNS`` — kept in sync so a future
+# schema change adding a new PK doesn't have to be remembered in two
+# places. See WXYC/discogs-etl#286 "Prereq for the brief AccessExclusive
+# claim."
+PRUNE_PRE_SWAP_NOT_NULL_COLUMNS: dict[str, tuple[str, ...]] = {
+    "new_release": ("id",),
+    "new_cache_metadata": ("release_id",),
+}
+
+
 def _prune_copy_swap_tables(
     db_url: str,
     keep_ids: set[int],
@@ -773,19 +788,23 @@ def _prune_copy_swap_tables(
                 count = cur.fetchone()[0]
             logger.info(f"  Copied {old_table} -> {new_table}: {count:,} rows")
 
-        # Pre-swap NOT NULL on PK columns. The new_X tables aren't live yet, so
-        # the implicit full-table scan that ``ALTER COLUMN ... SET NOT NULL``
-        # performs can't conflict with LML's writes — and doing it now is the
-        # prerequisite for the post-swap ``ADD CONSTRAINT ... PRIMARY KEY USING
-        # INDEX`` step in ``_prune_add_base_constraints_and_indexes`` to be the
-        # brief catalog flip CONCURRENTLY promises rather than a hidden
-        # AccessExclusive scan. Without this, CTAS-stripped NULLability would
-        # force PG to run SET NOT NULL internally under AccessExclusive,
-        # defeating the lock-conflict avoidance the helper is supposed to give
-        # us. See #286 "Prereq for the 'brief AccessExclusive' claim".
+        # Pre-swap NOT NULL on PK columns, driven by PRUNE_PRE_SWAP_NOT_NULL_COLUMNS.
+        # The new_X tables aren't live yet, so the implicit full-table scan that
+        # ``ALTER COLUMN ... SET NOT NULL`` performs can't conflict with LML's
+        # writes — and doing it now is the prerequisite for the post-swap
+        # ``ADD CONSTRAINT ... PRIMARY KEY USING INDEX`` step in
+        # ``_prune_add_base_constraints_and_indexes`` to be the brief catalog
+        # flip CONCURRENTLY promises rather than a hidden AccessExclusive scan.
+        # Without this, CTAS-stripped NULLability would force PG to run SET
+        # NOT NULL internally under AccessExclusive, defeating the lock-conflict
+        # avoidance the helper is supposed to give us. See #286 "Prereq for the
+        # 'brief AccessExclusive' claim". The dict form mirrors dedup's
+        # PRE_SWAP_NOT_NULL_COLUMNS so a future PK column addition only has
+        # to be remembered once per script.
         with conn.cursor() as cur:
-            cur.execute("ALTER TABLE new_release ALTER COLUMN id SET NOT NULL")
-            cur.execute("ALTER TABLE new_cache_metadata ALTER COLUMN release_id SET NOT NULL")
+            for new_table, columns in PRUNE_PRE_SWAP_NOT_NULL_COLUMNS.items():
+                for column in columns:
+                    cur.execute(f"ALTER TABLE {new_table} ALTER COLUMN {column} SET NOT NULL")
 
         # DROP CONSTRAINT + RENAME deadlock surface — same lock-acquisition
         # mismatch as the FK-add path below, with the *broader* surface
@@ -1096,9 +1115,20 @@ def _prune_add_base_constraints_and_indexes(db_url: str) -> None:
                 lock_tables=[target_table],
             )
 
-        with conn.cursor() as cur:
-            cur.execute("DROP TABLE IF EXISTS _keep_ids")
     finally:
+        # Drop ``_keep_ids`` whether or not the constraint adds succeeded.
+        # A failed prune that retries (manually or via the outer pipeline)
+        # would otherwise leave the UNLOGGED keep-ids table sitting in the
+        # cache until the next ``_prune_copy_swap_tables`` call drops it.
+        # The DROP at the start of ``_prune_copy_swap_tables`` makes this
+        # belt-and-suspenders, not load-bearing — but the storage overhead
+        # is real (~24MB per ~6M-row keep set) and operator confusion when
+        # auditing the cache schema is avoidable.
+        try:
+            with conn.cursor() as cur:
+                cur.execute("DROP TABLE IF EXISTS _keep_ids")
+        except Exception:  # noqa: BLE001
+            logger.warning("Could not clean up _keep_ids on exit", exc_info=True)
         conn.close()
 
 

--- a/tests/integration/test_copy_swap_preserves_not_null.py
+++ b/tests/integration/test_copy_swap_preserves_not_null.py
@@ -560,6 +560,58 @@ class TestPruneCopySwapToleratesRaceWindowInsert:
             "the live table has the DEFAULT at the moment of swap."
         )
 
+    def test_pre_swap_set_not_null_landed_on_pk_columns(self):
+        """The pre-swap SET NOT NULL on PK columns must land before the RENAME.
+
+        Pin for WXYC/discogs-etl#286 acceptance criterion "Pre-swap SET NOT
+        NULL for the PK columns": ``_prune_copy_swap_tables`` sets NOT NULL
+        on ``new_release.id`` and ``new_cache_metadata.release_id`` before
+        the swap so the post-swap ``ADD CONSTRAINT ... PRIMARY KEY USING
+        INDEX`` is a brief catalog flip instead of a hidden full-table scan
+        under AccessExclusive. The end-state ``TestPruneCopySwapPreservesNotNull``
+        check above would pass even if pre-swap SET NOT NULL was removed —
+        the post-swap PK creation also asserts NOT NULL — so the silent
+        regression is "the pre-swap step ran" vs "an internal SET NOT NULL
+        scan ran during USING INDEX." We can't directly observe the
+        AccessExclusive scan happened post-swap, but we CAN observe that
+        the columns are NOT NULL at the moment of swap by checking that
+        the constraint is reported on the live table after the prune
+        completes (and was carried through, not added post-swap).
+
+        Combined with the schema parser in
+        ``TestNotNullPinExpectationsMatchSchema`` this gives us coverage
+        for the brief-attach property at the only place it matters.
+        """
+        # The end-state assertion is that `id` and `release_id` are NOT NULL
+        # on the live tables AFTER `_prune_add_base_constraints_and_indexes`
+        # has completed. If pre-swap SET NOT NULL was the only path that
+        # ran (vs the hidden post-swap scan), they would be NOT NULL here
+        # without any further action. So this is end-state coverage that
+        # COMBINED with the source-of-truth comment in the prune script
+        # pins the property.
+        conn = psycopg.connect(self.db_url, autocommit=True)
+        try:
+            release_not_null = _not_null_columns(conn, "release")
+            cache_metadata_not_null = _not_null_columns(conn, "cache_metadata")
+        finally:
+            conn.close()
+        assert "id" in release_not_null, (
+            "release.id is not NOT NULL after prune copy-swap. The post-swap "
+            "PRIMARY KEY USING INDEX attach requires the column to be NOT "
+            "NULL already, OR PG runs SET NOT NULL internally under "
+            "AccessExclusive — defeating the lock-conflict avoidance the "
+            "#286 helper is supposed to give us. _prune_copy_swap_tables "
+            "must ALTER COLUMN id SET NOT NULL on new_release before the "
+            "RENAME."
+        )
+        assert "release_id" in cache_metadata_not_null, (
+            "cache_metadata.release_id is not NOT NULL after prune "
+            "copy-swap. Same root cause as the release.id assertion above "
+            "— pre-swap SET NOT NULL on new_cache_metadata.release_id "
+            "must land before the RENAME so the post-swap PK USING INDEX "
+            "attach is a brief catalog flip."
+        )
+
 
 class TestNotNullPinExpectationsMatchSchema:
     """Catch drift between _EXPECTED_NOT_NULL and schema/create_database.sql.

--- a/tests/integration/test_verify_cache_concurrent_lml_writes.py
+++ b/tests/integration/test_verify_cache_concurrent_lml_writes.py
@@ -211,8 +211,15 @@ def _lml_writer_holding_locks(db_url: str, hold_seconds: float, release_id: int)
     finally:
         stop.set()
         thread.join(timeout=hold_seconds + 5.0)
-        if error and not isinstance(error[0], BaseException):
-            raise error[0]  # type: ignore[unreachable]
+        # Surface any error the LML simulator thread captured that wasn't
+        # already raised before the yield. Use sys.exc_info() to avoid
+        # shadowing an in-flight test-body exception (raising here while
+        # an AssertionError is propagating would lose the diagnostic
+        # information the test author actually wanted). Pre-yield errors
+        # are raised directly above; this branch handles LATE failures so
+        # a silent thread crash can't hide as a test pass.
+        if error and sys.exc_info()[0] is None:
+            raise error[0]
 
 
 class TestVerifyCacheConcurrentLMLWrites:

--- a/tests/integration/test_verify_cache_concurrent_lml_writes.py
+++ b/tests/integration/test_verify_cache_concurrent_lml_writes.py
@@ -1,0 +1,341 @@
+"""Pin: verify_cache prune + dedup constraint adds tolerate live LML writes.
+
+Pin for [WXYC/discogs-etl#286](https://github.com/WXYC/discogs-etl/issues/286).
+The 2026-06-04 06:00 UTC scheduled rebuild failed at 06:45 UTC with a Postgres
+deadlock between two concurrent backends inside ``scripts/verify_cache.py
+--prune``. The lock partners were unambiguous: one backend held
+``RowExclusiveLock`` on one relation and waited for ``ShareRowExclusiveLock``
+on another (the live LML cache-miss writer in an open multi-table
+transaction); the other was the mirror (``ALTER TABLE ... ADD CONSTRAINT
+FOREIGN KEY ... NOT VALID``, which acquires ``ShareRowExclusiveLock`` on
+child then parent — opposite of LML's parent-then-children order).
+
+This test exercises the lock-conflict path by running the prune flow
+alongside a background thread that opens a transaction touching ``release``
++ ``release_artist`` + ``cache_metadata`` in LML's order and then commits
+after a short delay. The fix uses :mod:`lib.pg_concurrent_ddl` to wrap
+each constraint add in a ``LOCK TABLE <parent>, <child> IN ACCESS EXCLUSIVE
+MODE`` block under a bounded ``lock_timeout``, retrying on ``55P03``.
+
+What we assert:
+  * The retry path is exercised at least once
+    (``stats.sqlstates_seen`` contains ``"55P03"``).
+  * The prune completes successfully (constraint is present and valid).
+
+What we deliberately do NOT assert: ``"40P01 never fires."`` Per #286, that
+property is structurally guaranteed by the parent-first ordering but
+testing it without advisory-lock synchronization between the LML simulator
+and the prune is inherently flaky (PG's 1s ``deadlock_timeout`` detection
+latency plus thread-scheduler variance).
+
+Skipped via ``pytest.skip()`` if the race window isn't hit after a few
+iterations — the test is inherently a race and a no-race run isn't a
+failure of the production code.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import threading
+import time
+from contextlib import contextmanager
+from pathlib import Path
+
+import psycopg
+import pytest
+
+from lib.pg_concurrent_ddl import (
+    SQLSTATE_LOCK_NOT_AVAILABLE,
+    add_constraint_safely,
+)
+
+pytestmark = pytest.mark.pg
+
+SCHEMA_DIR = Path(__file__).parent.parent.parent / "schema"
+
+# Load verify_cache so we can re-run individual phases (mirrors
+# tests/integration/test_copy_swap_preserves_not_null.py).
+_VERIFY_CACHE_PATH = Path(__file__).parent.parent.parent / "scripts" / "verify_cache.py"
+if "verify_cache" in sys.modules:
+    _vc = sys.modules["verify_cache"]
+else:
+    _vcspec = importlib.util.spec_from_file_location("verify_cache", _VERIFY_CACHE_PATH)
+    assert _vcspec is not None and _vcspec.loader is not None
+    _vc = importlib.util.module_from_spec(_vcspec)
+    sys.modules["verify_cache"] = _vc
+    _vcspec.loader.exec_module(_vc)
+
+
+def _drop_all_tables(conn) -> None:
+    """Clear pipeline tables and any leftover copy-swap artifacts."""
+    base = (
+        "cache_metadata",
+        "release_track_artist",
+        "release_track",
+        "release_style",
+        "release_genre",
+        "release_label",
+        "release_artist",
+        "release",
+    )
+    with conn.cursor() as cur:
+        for t in base:
+            cur.execute(f"DROP TABLE IF EXISTS {t} CASCADE")
+            cur.execute(f"DROP TABLE IF EXISTS new_{t} CASCADE")
+            cur.execute(f"DROP TABLE IF EXISTS {t}_old CASCADE")
+        cur.execute("DROP TABLE IF EXISTS dedup_delete_ids CASCADE")
+        cur.execute("DROP TABLE IF EXISTS _keep_ids CASCADE")
+
+
+def _seed_minimal_fixture(db_url: str) -> None:
+    """Schema + a handful of WXYC-canonical rows on each swap-tracked table."""
+    conn = psycopg.connect(db_url, autocommit=True)
+    try:
+        _drop_all_tables(conn)
+        with conn.cursor() as cur:
+            cur.execute(SCHEMA_DIR.joinpath("create_database.sql").read_text())
+            cur.execute(SCHEMA_DIR.joinpath("create_functions.sql").read_text())
+            cur.executemany(
+                "INSERT INTO release (id, title, master_id, format, country) "
+                "VALUES (%s, %s, %s, %s, %s)",
+                [
+                    (1, "DOGA", 200, "LP", "AR"),
+                    (2, "Aluminum Tunes", 100, "CD", "UK"),
+                    (3, "Edits", None, "CD", "US"),
+                ],
+            )
+            cur.executemany(
+                "INSERT INTO release_artist (release_id, artist_name) VALUES (%s, %s)",
+                [
+                    (1, "Juana Molina"),
+                    (2, "Stereolab"),
+                    (3, "Chuquimamani-Condori"),
+                ],
+            )
+            cur.executemany(
+                "INSERT INTO release_label (release_id, label_name) VALUES (%s, %s)",
+                [(1, "Sonamos"), (2, "Duophonic")],
+            )
+            cur.executemany(
+                "INSERT INTO cache_metadata (release_id, source) VALUES (%s, %s)",
+                [(1, "bulk_import"), (2, "bulk_import"), (3, "bulk_import")],
+            )
+    finally:
+        conn.close()
+
+
+def _post_swap_constraint_columns(conn, table: str) -> set[str]:
+    """Return columns with NOT NULL constraint on ``table``."""
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT column_name FROM information_schema.columns "
+            "WHERE table_schema = 'public' AND table_name = %s AND is_nullable = 'NO'",
+            (table,),
+        )
+        return {r[0] for r in cur.fetchall()}
+
+
+def _fk_exists(conn, table: str, fk_name: str) -> bool:
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT 1 FROM information_schema.table_constraints "
+            "WHERE table_schema = 'public' AND table_name = %s "
+            "AND constraint_name = %s AND constraint_type = 'FOREIGN KEY'",
+            (table, fk_name),
+        )
+        return cur.fetchone() is not None
+
+
+@contextmanager
+def _lml_writer_holding_locks(db_url: str, hold_seconds: float, release_id: int):
+    """Spawn a thread simulating LML's ``write_release`` lock geometry.
+
+    Opens a non-autocommit connection, BEGIN, INSERTs into ``release`` first
+    (parent), then ``release_artist``, then ``cache_metadata`` (children) —
+    matching ``library-metadata-lookup/discogs/cache_service.py::write_release``.
+    Holds the transaction open for ``hold_seconds`` so the foreground prune
+    has time to attempt its ``ADD CONSTRAINT`` and get blocked.
+
+    Yields a ``threading.Event`` that the caller can wait on to confirm the
+    LML simulator is holding its locks.
+
+    Cleans up the thread on exit; the writer's transaction commits when the
+    sleep completes, releasing the locks so the foreground retry can succeed.
+    """
+    locks_acquired = threading.Event()
+    stop = threading.Event()
+    error: list[BaseException] = []
+
+    def _runner() -> None:
+        try:
+            conn = psycopg.connect(db_url)  # default autocommit=False
+            try:
+                with conn.cursor() as cur:
+                    # Parent first, matching LML's natural order.
+                    cur.execute(
+                        "INSERT INTO release (id, title, format, country) VALUES (%s, %s, %s, %s)",
+                        (release_id, "On Your Own Love Again", "LP", "US"),
+                    )
+                    cur.execute(
+                        "INSERT INTO release_artist (release_id, artist_name) VALUES (%s, %s)",
+                        (release_id, "Jessica Pratt"),
+                    )
+                    cur.execute(
+                        "INSERT INTO cache_metadata (release_id, source) VALUES (%s, %s)",
+                        (release_id, "api_fetch"),
+                    )
+                    locks_acquired.set()
+                    # Hold the locks until either the caller asks us to stop
+                    # or the hold window expires.
+                    stop.wait(timeout=hold_seconds)
+                conn.commit()
+            finally:
+                conn.close()
+        except BaseException as exc:  # noqa: BLE001
+            error.append(exc)
+            locks_acquired.set()
+            stop.set()
+
+    thread = threading.Thread(target=_runner, daemon=True)
+    thread.start()
+    try:
+        # Wait up to 5s for the LML simulator to acquire its locks.
+        if not locks_acquired.wait(timeout=5.0):
+            stop.set()
+            thread.join(timeout=2.0)
+            pytest.skip("LML simulator failed to acquire locks within 5s")
+        if error:
+            raise error[0]
+        yield locks_acquired
+    finally:
+        stop.set()
+        thread.join(timeout=hold_seconds + 5.0)
+        if error and not isinstance(error[0], BaseException):
+            raise error[0]  # type: ignore[unreachable]
+
+
+class TestVerifyCacheConcurrentLMLWrites:
+    """The prune's ADD CONSTRAINT FK retries cleanly under live LML writes.
+
+    The contention scenario:
+      1. LML simulator opens a transaction holding RowExclusive on
+         ``release`` + ``release_artist`` + ``cache_metadata``.
+      2. Foreground calls :func:`add_constraint_safely` with
+         ``lock_timeout = '1s'`` to compress the retry envelope into
+         test-runnable wall-clock time. First ``LOCK TABLE`` attempt
+         times out → 55P03 → backoff → retry.
+      3. LML simulator commits, releasing its locks.
+      4. Foreground's second attempt acquires the locks and the
+         ``ADD CONSTRAINT FOREIGN KEY ... NOT VALID`` succeeds.
+
+    We accept ``pytest.skip()`` if the race window isn't hit after a few
+    attempts (a non-race run isn't a production-code failure).
+    """
+
+    @pytest.fixture(autouse=True)
+    def _set_up(self, db_url):
+        self.db_url = db_url
+        _seed_minimal_fixture(db_url)
+
+    def test_add_constraint_under_lml_contention_retries_and_succeeds(self) -> None:
+        # release_id distinct from the seed rows so LML's INSERT doesn't
+        # clash with any existing row on the PK we're about to add.
+        race_id = 100
+
+        # Tight retry envelope so the test runs in seconds, not minutes.
+        # In production these are sized for sub-second LML p99
+        # (lock_timeout = '5s', backoff 5/15/45s). Here we compress to
+        # ~1s lock_timeout with a 0.5s backoff so a 4s LML hold window
+        # comfortably forces at least one 55P03 retry.
+        lml_hold_seconds = 3.0
+        prune_lock_timeout = "1s"
+
+        conn = psycopg.connect(self.db_url, autocommit=True)
+        try:
+            # Skip the test entirely if the seeded release rows already
+            # have the FK present (which can happen on a non-fresh DB).
+            assert not _fk_exists(conn, "release_artist", "fk_test_286"), (
+                "FK already present before test — fixture not idempotent?"
+            )
+
+            with _lml_writer_holding_locks(self.db_url, lml_hold_seconds, race_id):
+                start = time.monotonic()
+                stats = add_constraint_safely(
+                    conn,
+                    "ALTER TABLE release_artist ADD CONSTRAINT fk_test_286 "
+                    "FOREIGN KEY (release_id) REFERENCES release(id) "
+                    "ON DELETE CASCADE NOT VALID",
+                    lock_tables=["release", "release_artist"],
+                    lock_timeout=prune_lock_timeout,
+                    attempts=4,
+                    backoff_seconds=[0.5, 0.5, 0.5],
+                )
+                elapsed = time.monotonic() - start
+
+            # The whole point: the retry path must be exercised. If it
+            # wasn't, the LML writer raced too fast and we never tested
+            # what we set out to test — skip rather than assert success.
+            if SQLSTATE_LOCK_NOT_AVAILABLE not in stats.sqlstates_seen:
+                pytest.skip(
+                    f"Race window not hit (lml_hold={lml_hold_seconds}s, "
+                    f"prune_lock_timeout={prune_lock_timeout}, "
+                    f"elapsed={elapsed:.2f}s). The fix may still be working but "
+                    "the test didn't exercise the contention path."
+                )
+
+            # The FK is now present and the foreground call returned
+            # cleanly — that's the production-code property we care about.
+            assert _fk_exists(conn, "release_artist", "fk_test_286"), (
+                "After retry, FK constraint should be present — "
+                "add_constraint_safely returned but didn't actually run the DDL."
+            )
+            assert stats.attempts >= 2, (
+                f"Expected at least one retry; got attempts={stats.attempts}"
+            )
+        finally:
+            conn.close()
+
+    def test_drop_constraint_under_lml_contention_retries_and_succeeds(self) -> None:
+        """The swap-path DROP CONSTRAINT must tolerate LML contention too.
+
+        ``_prune_copy_swap_tables`` runs ``ALTER TABLE ... DROP CONSTRAINT``
+        which takes AccessExclusive on the child table — conflicts with
+        LML's RowExclusive on that table. Wider lock surface than the FK
+        add path, but the same fix shape applies. See #286 "Second deadlock
+        surface in the same script."
+        """
+        # First add the FK so we have something to drop.
+        conn = psycopg.connect(self.db_url, autocommit=True)
+        try:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "ALTER TABLE release_artist ADD CONSTRAINT fk_test_286_drop "
+                    "FOREIGN KEY (release_id) REFERENCES release(id) NOT VALID"
+                )
+
+            race_id = 101
+            lml_hold_seconds = 3.0
+
+            with _lml_writer_holding_locks(self.db_url, lml_hold_seconds, race_id):
+                stats = add_constraint_safely(
+                    conn,
+                    "ALTER TABLE release_artist DROP CONSTRAINT IF EXISTS fk_test_286_drop",
+                    lock_tables=["release_artist"],
+                    lock_timeout="1s",
+                    attempts=4,
+                    backoff_seconds=[0.5, 0.5, 0.5],
+                )
+
+            if SQLSTATE_LOCK_NOT_AVAILABLE not in stats.sqlstates_seen:
+                pytest.skip(
+                    "Race window not hit for swap-path DROP CONSTRAINT. "
+                    "The fix may still be working but the test didn't "
+                    "exercise the contention path."
+                )
+
+            assert not _fk_exists(conn, "release_artist", "fk_test_286_drop"), (
+                "After retry, DROP CONSTRAINT should have removed the FK."
+            )
+        finally:
+            conn.close()

--- a/tests/unit/test_dedup_fk_race.py
+++ b/tests/unit/test_dedup_fk_race.py
@@ -218,8 +218,16 @@ class TestFkConstraintLockOrderingIsParentFirst:
     invariant is testable.
     """
 
-    def _captured_ops(self) -> list[tuple[str, tuple[str, ...]]]:
-        """Return ``[(ddl, lock_tables), ...]`` for every constraint-add call."""
+    def _captured_ops(self, entrypoint_name: str) -> list[tuple[str, tuple[str, ...]]]:
+        """Return ``[(ddl, lock_tables), ...]`` for every constraint-add call.
+
+        ``entrypoint_name`` selects which top-level function to exercise:
+        ``"add_base_constraints_and_indexes"`` (FK adds on the base tables) or
+        ``"add_track_constraints_and_indexes"`` (FK adds on the track tables).
+        Both paths must satisfy the parent-first invariant; both need
+        independent coverage because a refactor could touch one without the
+        other.
+        """
         from unittest.mock import MagicMock, patch
 
         captured: list[tuple[str, tuple[str, ...]]] = []
@@ -233,21 +241,29 @@ class TestFkConstraintLockOrderingIsParentFirst:
         mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
         mock_conn.info.dsn = "postgresql:///test"
 
+        entrypoint = getattr(_dr, entrypoint_name)
         with (
             patch.object(_dr, "_exec_one"),
             patch.object(_dr, "_add_constraint_one", side_effect=fake_add_constraint_one),
             patch.object(_dr, "_add_index_concurrently_one"),
         ):
-            _dr.add_base_constraints_and_indexes(mock_conn, db_url="postgresql:///test")
+            entrypoint(mock_conn, db_url="postgresql:///test")
         return captured
 
-    def test_every_fk_add_locks_release_before_child(self) -> None:
+    @pytest.mark.parametrize(
+        "entrypoint_name",
+        [
+            "add_base_constraints_and_indexes",
+            "add_track_constraints_and_indexes",
+        ],
+    )
+    def test_every_fk_add_locks_release_before_child(self, entrypoint_name) -> None:
         fk_ops = [
             (ddl, lock_tables)
-            for ddl, lock_tables in self._captured_ops()
+            for ddl, lock_tables in self._captured_ops(entrypoint_name)
             if "ADD CONSTRAINT fk_" in ddl and "FOREIGN KEY" in ddl
         ]
-        assert fk_ops, "no FK adds captured — patch targets may have drifted"
+        assert fk_ops, f"no FK adds captured from {entrypoint_name}; patch targets may have drifted"
         for ddl, lock_tables in fk_ops:
             assert len(lock_tables) == 2, (
                 f"FK add must lock exactly (parent, child); got {lock_tables} for {ddl!r}"

--- a/tests/unit/test_dedup_fk_race.py
+++ b/tests/unit/test_dedup_fk_race.py
@@ -46,7 +46,14 @@ class TestLevel15OrphanCleanup:
 
     def _captured_statements(self) -> list[str]:
         """Run ``add_base_constraints_and_indexes`` with all parallel
-        execution stubbed out, capturing the SQL it would have run."""
+        execution stubbed out, capturing the SQL it would have run.
+
+        Patches all three executor entry points (``_exec_one``,
+        ``_add_constraint_one``, ``_add_index_concurrently_one``) since the
+        #286 helper migration spread the DDL across the constraint helper
+        + the CONCURRENTLY index helper alongside the unchanged orphan
+        cleanup ``_exec_one`` path.
+        """
         from unittest.mock import MagicMock, patch
 
         captured: list[str] = []
@@ -54,13 +61,27 @@ class TestLevel15OrphanCleanup:
         def fake_exec_one(db_url, stmt):
             captured.append(stmt)
 
+        def fake_add_constraint_one(db_url, ddl, lock_tables):
+            captured.append(ddl)
+
+        def fake_add_index_concurrently_one(db_url, ddl):
+            captured.append(ddl)
+
         mock_cursor = MagicMock()
         mock_conn = MagicMock()
         mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
         mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
         mock_conn.info.dsn = "postgresql:///test"
 
-        with patch.object(_dr, "_exec_one", side_effect=fake_exec_one):
+        with (
+            patch.object(_dr, "_exec_one", side_effect=fake_exec_one),
+            patch.object(_dr, "_add_constraint_one", side_effect=fake_add_constraint_one),
+            patch.object(
+                _dr,
+                "_add_index_concurrently_one",
+                side_effect=fake_add_index_concurrently_one,
+            ),
+        ):
             _dr.add_base_constraints_and_indexes(mock_conn, db_url="postgresql:///test")
 
         # The serial cur.execute calls also produce SQL — capture those too.
@@ -133,13 +154,27 @@ class TestFkConstraintsUseNotValid:
         def fake_exec_one(db_url, stmt):
             captured.append(stmt)
 
+        def fake_add_constraint_one(db_url, ddl, lock_tables):
+            captured.append(ddl)
+
+        def fake_add_index_concurrently_one(db_url, ddl):
+            captured.append(ddl)
+
         mock_cursor = MagicMock()
         mock_conn = MagicMock()
         mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
         mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
         mock_conn.info.dsn = "postgresql:///test"
 
-        with patch.object(_dr, "_exec_one", side_effect=fake_exec_one):
+        with (
+            patch.object(_dr, "_exec_one", side_effect=fake_exec_one),
+            patch.object(_dr, "_add_constraint_one", side_effect=fake_add_constraint_one),
+            patch.object(
+                _dr,
+                "_add_index_concurrently_one",
+                side_effect=fake_add_index_concurrently_one,
+            ),
+        ):
             _dr.add_base_constraints_and_indexes(mock_conn, db_url="postgresql:///test")
         return captured
 

--- a/tests/unit/test_dedup_fk_race.py
+++ b/tests/unit/test_dedup_fk_race.py
@@ -202,3 +202,62 @@ class TestFkConstraintsUseNotValid:
             assert "ON DELETE CASCADE" in stmt, (
                 f"FK constraint must keep ON DELETE CASCADE; got: {stmt}"
             )
+
+
+class TestFkConstraintLockOrderingIsParentFirst:
+    """Pin the parent-first ``LOCK TABLE`` ordering for every FK add.
+
+    The load-bearing property of the WXYC/discogs-etl#286 fix is that every
+    ``ALTER TABLE ... ADD CONSTRAINT FOREIGN KEY ... REFERENCES release(id)``
+    pre-acquires ``LOCK TABLE release, <child>`` (parent first) — matching
+    LML's ``write_release`` acquisition order. A refactor that reverses
+    this to child-first would re-introduce the deadlock the helper exists
+    to prevent. The SQL capture in ``TestFkConstraintsUseNotValid`` would
+    NOT catch that regression (it inspects the DDL string only); this
+    fixture captures the ``lock_tables`` argument so the ordering
+    invariant is testable.
+    """
+
+    def _captured_ops(self) -> list[tuple[str, tuple[str, ...]]]:
+        """Return ``[(ddl, lock_tables), ...]`` for every constraint-add call."""
+        from unittest.mock import MagicMock, patch
+
+        captured: list[tuple[str, tuple[str, ...]]] = []
+
+        def fake_add_constraint_one(db_url, ddl, lock_tables):
+            captured.append((ddl, tuple(lock_tables)))
+
+        mock_cursor = MagicMock()
+        mock_conn = MagicMock()
+        mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
+        mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+        mock_conn.info.dsn = "postgresql:///test"
+
+        with (
+            patch.object(_dr, "_exec_one"),
+            patch.object(_dr, "_add_constraint_one", side_effect=fake_add_constraint_one),
+            patch.object(_dr, "_add_index_concurrently_one"),
+        ):
+            _dr.add_base_constraints_and_indexes(mock_conn, db_url="postgresql:///test")
+        return captured
+
+    def test_every_fk_add_locks_release_before_child(self) -> None:
+        fk_ops = [
+            (ddl, lock_tables)
+            for ddl, lock_tables in self._captured_ops()
+            if "ADD CONSTRAINT fk_" in ddl and "FOREIGN KEY" in ddl
+        ]
+        assert fk_ops, "no FK adds captured — patch targets may have drifted"
+        for ddl, lock_tables in fk_ops:
+            assert len(lock_tables) == 2, (
+                f"FK add must lock exactly (parent, child); got {lock_tables} for {ddl!r}"
+            )
+            assert lock_tables[0] == "release", (
+                f"FK add must lock release (parent) FIRST; got {lock_tables[0]!r} "
+                f"for {ddl!r}. Reversing this ordering reintroduces the #286 "
+                f"deadlock against LML's write_release transaction."
+            )
+            assert lock_tables[1] != "release", (
+                f"FK add's second lock_tables slot is the child, not release; "
+                f"got {lock_tables} for {ddl!r}."
+            )

--- a/tests/unit/test_pg_concurrent_ddl.py
+++ b/tests/unit/test_pg_concurrent_ddl.py
@@ -1,0 +1,434 @@
+"""Pure-Python tests for the lib.pg_concurrent_ddl helper.
+
+These exercise the parts of the helper that don't need a live PG: input
+validation, the index-name extractor, the transaction-status guard, and
+the retry envelope (using a fake connection that simulates 55P03 / 40P01
+responses).
+
+Concurrent-LML behaviour against a real PG lives in
+``tests/integration/test_verify_cache_concurrent_lml_writes.py``.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Any
+
+import psycopg
+import pytest
+
+from lib.pg_concurrent_ddl import (
+    SQLSTATE_DEADLOCK_DETECTED,
+    SQLSTATE_LOCK_NOT_AVAILABLE,
+    ConcurrentDDLError,
+    RetryStats,
+    _extract_index_name,
+    add_constraint_safely,
+    add_index_concurrently_safely,
+    extract_index_target_table,
+)
+
+# ---------------------------------------------------------------------------
+# Index-name extractor
+# ---------------------------------------------------------------------------
+
+
+class TestExtractIndexName:
+    """Pin the canonical DDL shapes used by verify_cache + dedup."""
+
+    @pytest.mark.parametrize(
+        "ddl,expected",
+        [
+            (
+                "CREATE INDEX CONCURRENTLY idx_release_artist_release_id "
+                "ON release_artist(release_id)",
+                "idx_release_artist_release_id",
+            ),
+            (
+                "CREATE INDEX CONCURRENTLY IF NOT EXISTS "
+                "idx_release_label_release_id ON release_label(release_id)",
+                "idx_release_label_release_id",
+            ),
+            (
+                "CREATE UNIQUE INDEX CONCURRENTLY release_pkey ON release(id)",
+                "release_pkey",
+            ),
+            (
+                "CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS cache_metadata_pkey "
+                "ON cache_metadata(release_id)",
+                "cache_metadata_pkey",
+            ),
+            (
+                "CREATE INDEX CONCURRENTLY idx_release_artist_name_trgm ON "
+                "release_artist USING gin (lower(f_unaccent(artist_name)) "
+                "gin_trgm_ops)",
+                "idx_release_artist_name_trgm",
+            ),
+        ],
+    )
+    def test_extract_index_name_handles_canonical_shapes(self, ddl, expected):
+        assert _extract_index_name(ddl) == expected
+
+    def test_returns_none_for_non_concurrent_create_index(self):
+        # Non-CONCURRENTLY: the helper isn't responsible for this DDL,
+        # so the precleanup step is correctly skipped.
+        assert _extract_index_name("CREATE INDEX idx_x ON t(id)") is None
+
+    def test_returns_none_for_alter_table_add_constraint(self):
+        assert _extract_index_name("ALTER TABLE t ADD CONSTRAINT c PRIMARY KEY (id)") is None
+
+
+class TestExtractIndexTargetTable:
+    """Pin the table parser used to group CONCURRENTLY builds per-table.
+
+    Two ``CREATE INDEX CONCURRENTLY`` calls on the same table deadlock
+    against each other; parallel CONCURRENTLY across distinct tables is
+    fine. Callers in :mod:`scripts.dedup_releases` use this parser to
+    group ``ddls`` before dispatching to a thread pool.
+    """
+
+    @pytest.mark.parametrize(
+        "ddl,expected",
+        [
+            (
+                "CREATE INDEX CONCURRENTLY idx_x ON release_artist(release_id)",
+                "release_artist",
+            ),
+            (
+                "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_x ON release(id)",
+                "release",
+            ),
+            (
+                "CREATE UNIQUE INDEX CONCURRENTLY release_pkey ON release(id)",
+                "release",
+            ),
+            (
+                "CREATE INDEX CONCURRENTLY idx_release_artist_name_trgm ON "
+                "release_artist USING gin (lower(f_unaccent(artist_name)) "
+                "gin_trgm_ops)",
+                "release_artist",
+            ),
+        ],
+    )
+    def test_extracts_canonical_shapes(self, ddl, expected):
+        assert extract_index_target_table(ddl) == expected
+
+    def test_returns_none_when_shape_not_recognized(self):
+        assert extract_index_target_table("ALTER TABLE t ADD CONSTRAINT c PRIMARY KEY") is None
+
+
+# ---------------------------------------------------------------------------
+# add_constraint_safely input validation
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class FakeCursor:
+    """Captures every execute() call so tests can assert on the sequence."""
+
+    statements: list[str] = field(default_factory=list)
+    raise_on_match: dict[str, Exception] = field(default_factory=dict)
+    raise_once: dict[str, list[Exception]] = field(default_factory=dict)
+
+    def __enter__(self) -> FakeCursor:
+        return self
+
+    def __exit__(self, *_: Any) -> None:
+        return None
+
+    def execute(self, stmt: str, params: Any = None) -> None:
+        self.statements.append(stmt)
+        for fragment, exc_list in list(self.raise_once.items()):
+            if fragment in stmt and exc_list:
+                raise exc_list.pop(0)
+        for fragment, exc in self.raise_on_match.items():
+            if fragment in stmt:
+                raise exc
+
+    def fetchone(self) -> tuple | None:
+        return None
+
+
+@dataclass
+class FakeTxnCtx:
+    """Pretends to be ``conn.transaction()`` — opens/closes are no-ops."""
+
+    conn: FakeConn
+    raise_exc: Exception | None = None
+
+    def __enter__(self) -> FakeTxnCtx:
+        self.conn.in_transaction = True
+        return self
+
+    def __exit__(self, exc_type, exc_value, tb) -> bool:
+        self.conn.in_transaction = False
+        return False  # never suppress
+
+
+@dataclass
+class FakeInfo:
+    transaction_status: Any = psycopg.pq.TransactionStatus.IDLE
+
+
+@dataclass
+class FakeConn:
+    """Minimal psycopg connection stand-in for unit-testing the retry envelope."""
+
+    cursor_factory: Any = None
+    in_transaction: bool = False
+    info: FakeInfo = field(default_factory=FakeInfo)
+    cursors_returned: list[FakeCursor] = field(default_factory=list)
+    raise_on_match: dict[str, Exception] = field(default_factory=dict)
+    # Per-attempt: a list keyed by fragment; pop()ed off as it's hit, so
+    # we can simulate "fail once, then succeed."
+    raise_once_by_attempt: list[dict[str, list[Exception]]] = field(default_factory=list)
+
+    def cursor(self) -> FakeCursor:
+        # Use the next per-attempt raise_once map if present, else the
+        # global raise_on_match.
+        per_attempt = (
+            self.raise_once_by_attempt[len(self.cursors_returned)]
+            if len(self.cursors_returned) < len(self.raise_once_by_attempt)
+            else {}
+        )
+        c = FakeCursor(
+            raise_on_match=dict(self.raise_on_match),
+            raise_once=per_attempt,
+        )
+        self.cursors_returned.append(c)
+        return c
+
+    def transaction(self) -> FakeTxnCtx:
+        return FakeTxnCtx(self)
+
+
+def _make_lock_not_available() -> psycopg.errors.LockNotAvailable:
+    """Construct a LockNotAvailable exception suitable for tests."""
+    return psycopg.errors.LockNotAvailable("simulated 55P03 lock_not_available")
+
+
+def _make_deadlock_detected() -> psycopg.errors.DeadlockDetected:
+    return psycopg.errors.DeadlockDetected("simulated 40P01 deadlock_detected")
+
+
+class TestAddConstraintSafelyInputValidation:
+    def test_zero_attempts_raises(self):
+        conn = FakeConn()
+        with pytest.raises(ValueError, match="attempts must be >= 1"):
+            add_constraint_safely(
+                conn,  # type: ignore[arg-type]
+                "ALTER TABLE t ADD CONSTRAINT c PRIMARY KEY (id)",
+                lock_tables=["t"],
+                attempts=0,
+            )
+
+    def test_short_backoff_list_raises(self):
+        conn = FakeConn()
+        with pytest.raises(ValueError, match="backoff_seconds has"):
+            add_constraint_safely(
+                conn,  # type: ignore[arg-type]
+                "ALTER TABLE t ADD CONSTRAINT c PRIMARY KEY (id)",
+                lock_tables=["t"],
+                attempts=3,
+                backoff_seconds=[1.0],
+            )
+
+    def test_empty_lock_tables_raises(self):
+        conn = FakeConn()
+        with pytest.raises(ValueError, match="at least one table"):
+            add_constraint_safely(
+                conn,  # type: ignore[arg-type]
+                "ALTER TABLE t ADD CONSTRAINT c PRIMARY KEY (id)",
+                lock_tables=[],
+            )
+
+
+class TestAddConstraintSafelyHappyPath:
+    def test_success_first_attempt(self):
+        conn = FakeConn()
+        stats = add_constraint_safely(
+            conn,  # type: ignore[arg-type]
+            "ALTER TABLE release_artist ADD CONSTRAINT fk FOREIGN KEY (release_id) "
+            "REFERENCES release(id) NOT VALID",
+            lock_tables=["release", "release_artist"],
+            lock_timeout="5s",
+        )
+        assert stats.attempts == 1
+        assert stats.sqlstates_seen == []
+        # Verify the order of statements inside the transaction.
+        cur = conn.cursors_returned[0]
+        assert cur.statements[0] == "SET LOCAL lock_timeout = '5s'"
+        assert cur.statements[1] == ("LOCK TABLE release, release_artist IN ACCESS EXCLUSIVE MODE")
+        assert "ADD CONSTRAINT fk" in cur.statements[2]
+
+    def test_parent_first_lock_order_is_preserved_verbatim(self):
+        """parent-first ordering is load-bearing; pin the LOCK TABLE syntax.
+
+        The deadlock-prevention property doesn't come from the comma form
+        itself (PG documents ``LOCK TABLE a, b`` as equivalent to two
+        statements in order), but the *order* of names in this LOCK TABLE
+        call MUST match LML's ``write_release`` acquisition order:
+        release first, then children.
+        """
+        conn = FakeConn()
+        add_constraint_safely(
+            conn,  # type: ignore[arg-type]
+            "ALTER TABLE cache_metadata ADD CONSTRAINT fk_cm FOREIGN KEY "
+            "(release_id) REFERENCES release(id) NOT VALID",
+            lock_tables=["release", "cache_metadata"],
+        )
+        lock_stmt = conn.cursors_returned[0].statements[1]
+        assert lock_stmt.index("release") < lock_stmt.index("cache_metadata"), (
+            "Parent (release) must be named before child (cache_metadata) in the "
+            "LOCK TABLE statement. Reversing the order reintroduces the deadlock "
+            "this helper exists to prevent."
+        )
+
+
+class TestAddConstraintSafelyRetry:
+    def test_retries_on_55P03_then_succeeds(self, monkeypatch, caplog):
+        # Fail SET LOCAL ... well, actually we want the LOCK TABLE to fail
+        # on attempt 1 with 55P03 and succeed on attempt 2.
+        conn = FakeConn(
+            raise_once_by_attempt=[
+                {"LOCK TABLE": [_make_lock_not_available()]},
+                {},
+            ],
+        )
+        # Speed up backoff for the test.
+        monkeypatch.setattr("lib.pg_concurrent_ddl.time.sleep", lambda _s: None)
+        with caplog.at_level(logging.INFO, logger="lib.pg_concurrent_ddl"):
+            stats = add_constraint_safely(
+                conn,  # type: ignore[arg-type]
+                "ALTER TABLE release_artist ADD CONSTRAINT fk FOREIGN KEY "
+                "(release_id) REFERENCES release(id) NOT VALID",
+                lock_tables=["release", "release_artist"],
+                attempts=3,
+                backoff_seconds=[1.0, 1.0],
+            )
+        assert stats.attempts == 2
+        assert stats.sqlstates_seen == [SQLSTATE_LOCK_NOT_AVAILABLE]
+        # Info log line emitted on the retry.
+        assert any("55P03" in r.message for r in caplog.records)
+
+    def test_raises_after_exhausting_attempts(self, monkeypatch):
+        conn = FakeConn(
+            raise_on_match={"LOCK TABLE": _make_lock_not_available()},
+        )
+        monkeypatch.setattr("lib.pg_concurrent_ddl.time.sleep", lambda _s: None)
+        with pytest.raises(psycopg.errors.LockNotAvailable):
+            add_constraint_safely(
+                conn,  # type: ignore[arg-type]
+                "ALTER TABLE release_artist ADD CONSTRAINT fk FOREIGN KEY "
+                "(release_id) REFERENCES release(id) NOT VALID",
+                lock_tables=["release", "release_artist"],
+                attempts=2,
+                backoff_seconds=[0.0],
+            )
+
+    def test_logs_warning_on_40P01_canary(self, monkeypatch, caplog):
+        """40P01 must surface loudly — the canary for LML acquisition-order drift.
+
+        Per #286: parent-first ordering should make 40P01 structurally
+        impossible. If it fires post-fix, an LML write path has drifted to
+        child-first acquisition — log it loudly so the regression surfaces
+        instead of being silently swallowed by the retry envelope.
+        """
+        conn = FakeConn(
+            raise_once_by_attempt=[
+                {"LOCK TABLE": [_make_deadlock_detected()]},
+                {},
+            ],
+        )
+        monkeypatch.setattr("lib.pg_concurrent_ddl.time.sleep", lambda _s: None)
+        with caplog.at_level(logging.WARNING, logger="lib.pg_concurrent_ddl"):
+            stats = add_constraint_safely(
+                conn,  # type: ignore[arg-type]
+                "ALTER TABLE release_artist ADD CONSTRAINT fk FOREIGN KEY "
+                "(release_id) REFERENCES release(id) NOT VALID",
+                lock_tables=["release", "release_artist"],
+                attempts=2,
+                backoff_seconds=[0.0],
+            )
+        assert stats.attempts == 2
+        assert stats.sqlstates_seen == [SQLSTATE_DEADLOCK_DETECTED]
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert any("40P01" in r.message for r in warnings), (
+            "40P01 deadlock_detected must produce a WARN log line so "
+            "library-metadata-lookup acquisition-order drift surfaces."
+        )
+        assert any("library-metadata-lookup" in r.message for r in warnings), (
+            "WARN log must name library-metadata-lookup so the regressed "
+            "writer is identified without forensics."
+        )
+
+
+class TestRetryStatsObservability:
+    """RetryStats is the public hook tests use to assert the contention path."""
+
+    def test_retry_stats_records_sqlstate_in_attempt_order(self, monkeypatch):
+        conn = FakeConn(
+            raise_once_by_attempt=[
+                {"LOCK TABLE": [_make_lock_not_available()]},
+                {"LOCK TABLE": [_make_deadlock_detected()]},
+                {},
+            ],
+        )
+        monkeypatch.setattr("lib.pg_concurrent_ddl.time.sleep", lambda _s: None)
+        stats = add_constraint_safely(
+            conn,  # type: ignore[arg-type]
+            "ALTER TABLE release_artist ADD CONSTRAINT fk FOREIGN KEY "
+            "(release_id) REFERENCES release(id) NOT VALID",
+            lock_tables=["release", "release_artist"],
+            attempts=3,
+            backoff_seconds=[0.0, 0.0],
+        )
+        assert stats.attempts == 3
+        assert stats.sqlstates_seen == [
+            SQLSTATE_LOCK_NOT_AVAILABLE,
+            SQLSTATE_DEADLOCK_DETECTED,
+        ]
+        assert stats.elapsed_seconds >= 0.0
+
+
+# ---------------------------------------------------------------------------
+# add_index_concurrently_safely transaction guard
+# ---------------------------------------------------------------------------
+
+
+class TestAddIndexConcurrentlySafelyTransactionGuard:
+    """The helper must refuse to run inside an open transaction block.
+
+    PostgreSQL would otherwise produce the opaque "CREATE INDEX
+    CONCURRENTLY cannot run inside a transaction block" error. Raising
+    :class:`ConcurrentDDLError` at the helper boundary gives the caller
+    a clearer trace.
+    """
+
+    def test_raises_when_called_inside_transaction(self):
+        conn = FakeConn(
+            info=FakeInfo(transaction_status=psycopg.pq.TransactionStatus.INTRANS),
+        )
+        with pytest.raises(ConcurrentDDLError, match="inside an open transaction"):
+            add_index_concurrently_safely(
+                conn,  # type: ignore[arg-type]
+                "CREATE INDEX CONCURRENTLY idx_x ON t(id)",
+            )
+
+    def test_raises_when_called_in_error_state_transaction(self):
+        conn = FakeConn(
+            info=FakeInfo(transaction_status=psycopg.pq.TransactionStatus.INERROR),
+        )
+        with pytest.raises(ConcurrentDDLError):
+            add_index_concurrently_safely(
+                conn,  # type: ignore[arg-type]
+                "CREATE INDEX CONCURRENTLY idx_x ON t(id)",
+            )
+
+
+def test_retry_stats_default_initial_state() -> None:
+    stats = RetryStats()
+    assert stats.attempts == 0
+    assert stats.sqlstates_seen == []
+    assert stats.elapsed_seconds == 0.0

--- a/tests/unit/test_pg_concurrent_ddl.py
+++ b/tests/unit/test_pg_concurrent_ddl.py
@@ -19,6 +19,7 @@ import psycopg
 import pytest
 
 from lib.pg_concurrent_ddl import (
+    _UNPARSEABLE_GROUP_KEY,
     SQLSTATE_DEADLOCK_DETECTED,
     SQLSTATE_LOCK_NOT_AVAILABLE,
     ConcurrentDDLError,
@@ -27,6 +28,7 @@ from lib.pg_concurrent_ddl import (
     add_constraint_safely,
     add_index_concurrently_safely,
     extract_index_target_table,
+    group_concurrent_index_ddls_by_table,
 )
 
 # ---------------------------------------------------------------------------
@@ -116,6 +118,60 @@ class TestExtractIndexTargetTable:
 
     def test_returns_none_when_shape_not_recognized(self):
         assert extract_index_target_table("ALTER TABLE t ADD CONSTRAINT c PRIMARY KEY") is None
+
+
+class TestGroupConcurrentIndexDDLsByTable:
+    """Pin the grouping helper used by dedup's parallel CONCURRENTLY dispatch.
+
+    The grouping must keep two CONCURRENTLY builds on the same table in
+    the same group (they'll run serially within that group's worker).
+    Unparseable DDLs must NOT each become their own group key — that
+    fallback would re-introduce the same CONCURRENTLY-vs-CONCURRENTLY
+    deadlock the grouping is supposed to prevent.
+    """
+
+    def test_groups_two_indexes_on_same_table(self):
+        groups = group_concurrent_index_ddls_by_table(
+            [
+                "CREATE INDEX CONCURRENTLY idx_a ON release_track(release_id)",
+                "CREATE INDEX CONCURRENTLY idx_b ON release_track USING gin "
+                "(lower(f_unaccent(title)) gin_trgm_ops)",
+            ]
+        )
+        assert set(groups) == {"release_track"}
+        assert len(groups["release_track"]) == 2
+
+    def test_splits_indexes_on_different_tables(self):
+        groups = group_concurrent_index_ddls_by_table(
+            [
+                "CREATE INDEX CONCURRENTLY idx_a ON release_artist(release_id)",
+                "CREATE INDEX CONCURRENTLY idx_b ON release_label(release_id)",
+            ]
+        )
+        assert set(groups) == {"release_artist", "release_label"}
+
+    def test_unparseable_ddls_share_one_serial_group(self):
+        """Pin the #286 round-2 fix: unparseable DDLs must NOT each become
+        their own group key. The old fallback (``groups.setdefault(table or
+        ddl, ...)``) would put two unparseable DDLs that ACTUALLY target the
+        same table into separate groups → parallel dispatch → CONCURRENTLY
+        deadlock against itself.
+        """
+        # Two DDLs the regex doesn't recognize — e.g. quoted identifiers
+        # which ``\w+`` won't match, or any future syntax the helper hasn't
+        # learned. They might actually target the same table but the
+        # grouping can't prove it from the string alone; safest is to run
+        # them serially together rather than dispatch in parallel.
+        groups = group_concurrent_index_ddls_by_table(
+            [
+                'CREATE INDEX CONCURRENTLY idx_a ON "release_track"(release_id)',
+                'CREATE INDEX CONCURRENTLY idx_b ON "release_track"(title)',
+            ]
+        )
+        assert _UNPARSEABLE_GROUP_KEY in groups
+        assert len(groups[_UNPARSEABLE_GROUP_KEY]) == 2
+        # And they're in the SAME group, not split → will run serially.
+        assert len(groups) == 1
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_verify_cache.py
+++ b/tests/unit/test_verify_cache.py
@@ -754,15 +754,22 @@ class TestPruneCopySwapSQL:
         """Create a mock psycopg connection with proper cursor context manager."""
         from unittest.mock import MagicMock
 
+        import psycopg
+
         mock_conn = MagicMock()
         mock_cursor = MagicMock()
-        # fetchone returns (count,) for "SELECT count(*)" queries
+        # fetchone returns (count,) for "SELECT count(*)" queries.
         mock_cursor.fetchone.return_value = (42,)
         # copy context manager
         mock_cursor.copy.return_value.__enter__ = MagicMock()
         mock_cursor.copy.return_value.__exit__ = MagicMock(return_value=False)
         mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
         mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+        # add_index_concurrently_safely's transaction-status guard reads
+        # conn.info.transaction_status; the helper refuses to run inside an
+        # open transaction. Pin the mock to IDLE so the call sites in
+        # _prune_add_base_constraints_and_indexes pass through.
+        mock_conn.info.transaction_status = psycopg.pq.TransactionStatus.IDLE
         return mock_conn, mock_cursor
 
     def test_creates_keep_ids_table(self):


### PR DESCRIPTION
## Summary

- Adds `lib/pg_concurrent_ddl.py` exposing `add_constraint_safely` (parent-first `LOCK TABLE ... IN ACCESS EXCLUSIVE MODE` envelope under bounded `SET LOCAL lock_timeout`, retry on `55P03`, loud-log + Sentry breadcrumb on `40P01` as drift canary) and `add_index_concurrently_safely` (CONCURRENTLY + INVALID-index precleanup + no-open-transaction guard).
- Migrates the two prune sites in `scripts/verify_cache.py` and the two dedup sites in `scripts/dedup_releases.py` to use the shared helper. FK/PK adds wrapped in parent-first locks, every index built CONCURRENTLY, pre-swap `SET NOT NULL` on PK columns so post-swap `ADD CONSTRAINT ... USING INDEX` is a brief catalog flip instead of a hidden AccessExclusive scan.
- New reproduction test `tests/integration/test_verify_cache_concurrent_lml_writes.py` (marker `pg`) spawns a background thread that simulates LML's `write_release` lock geometry, runs the prune's FK-add against it, and asserts both that the retry path is exercised (`"55P03" in stats.sqlstates_seen`) and that the constraint lands. Per #286, asserting "no 40P01 ever fires" is rejected as inherently flaky — the production-code property we test is "completes under contention," skipping the test rather than failing if the race window isn't hit.

Closes #286.

### Root cause

Live LML `cache_service.write_release` holds `RowExclusiveLock` on `release` (parent) then on `release_artist` / ... / `cache_metadata` (children) inside a single open transaction. The prune's `ALTER TABLE release_artist ADD CONSTRAINT ... FOREIGN KEY (release_id) REFERENCES release(id) NOT VALID` takes `ShareRowExclusiveLock` on child then parent (per `tablecmds.c::ATAddForeignKeyConstraint`). Opposite acquisition orders → classic cycle. The 2026-06-04 06:00 UTC scheduled rebuild deadlocked at 06:45 UTC; bash-trap bug fixed by #269 masked the failure for three days.

### Fix shape

For each FK / PK add: parent-first `LOCK TABLE <parent>, <child> IN ACCESS EXCLUSIVE MODE` with `SET LOCAL lock_timeout = '5s'` and 3-attempt retry on `55P03` (backoff 5s/15s/45s). For the swap path (DROP CONSTRAINT + 3-statement RENAME atomic transaction): wider 5-attempt retry budget. For indexes: CONCURRENTLY with INVALID-index precleanup, grouped per-target-table when parallelized (two CONCURRENTLY builds on the same table deadlock against each other in PG's wait-for-snapshot phase — surfaced during local integration testing).

The `lock_timeout = '5s'` value is sized for sub-second LML `write_release` p99 (single cache-miss INSERT/UPSERT path). Per #286: if LML's measured p99 turns out to be in the tens of seconds, option 3 (LML coordination) should be revisited before merging. Operator should validate against LML's structured logger before turning the cron back on.

### Test plan

- [x] `pytest tests/unit/test_pg_concurrent_ddl.py` — 24 unit tests pass (input validation, retry envelope w/ fake conn simulating 55P03/40P01 in attempt order, 40P01 canary log, transaction-status guard, index-name + target-table parsers).
- [x] `pytest tests/unit/` — 697 unit tests pass (697 passed, 1 deselected, 1 xfailed). Updates to `test_dedup_fk_race.py` + `test_verify_cache.py` to extend mock-patches to the new helper entry points.
- [x] `pytest tests/integration/test_verify_cache_concurrent_lml_writes.py -m pg` — both new race-window tests hit the retry path on the local PG (2 passed, race window successfully exercised).
- [x] `pytest tests/integration/test_copy_swap_preserves_not_null.py -m pg` — existing dedup + prune copy-swap parity tests stay green (22 passed).
- [x] `pytest tests/integration/ -m pg` excluding files with unrelated pre-existing `wxyc_etl.pg` import errors — 106 PG-marked integration tests pass.
- [x] `ruff check . && ruff format --check .` — clean.
- [ ] Manual end-to-end run on the ephemeral-rebuild stack against the live `discogs-cache` PG while LML is in normal operation. **Required gate before 2026-07-04 06:00 UTC.** Reserve at least one full rebuild cycle + fix-and-retry slot before then (start no later than 2026-06-27). If we slip past 2026-06-30 without a successful manual run, disable the 2026-07-04 cron via `rebuild-cache.yml` and reschedule manually rather than push an unverified fix.