### PR TITLE
fix(sync-library): read streaming_availability.db from the Railway volume, hard-fail thin copies

### DIFF
--- a/.github/workflows/sync-library.yml
+++ b/.github/workflows/sync-library.yml
@@ -40,10 +40,30 @@ jobs:
 
       - name: Set up streaming links enrichment
         run: |
+          set -euo pipefail
           git clone --depth 1 --branch main https://github.com/WXYC/library-metadata-lookup.git /tmp/library-metadata-lookup
-          gh release download streaming-data-v1 --repo WXYC/library-metadata-lookup --dir /tmp/library-metadata-lookup
+          # streaming_availability.db is read from the Railway volume (the canonical
+          # copy, LML#672), not the GitHub Release. Hard-fail on a non-200 or an
+          # empty/invalid file: a naive `curl -o` exits 0 on HTTP 404/500 and writes
+          # the error body, which would silently strip all streaming links from prod.
+          # On a Railway outage the step aborts and prod keeps yesterday's library.db.
+          dest=/tmp/library-metadata-lookup/streaming_availability.db
+          http_code=$(curl -sS -w '%{http_code}' -o "$dest" \
+            -H "Authorization: Bearer $ADMIN_TOKEN" \
+            "$PRODUCTION_URL/admin/download-streaming-db")
+          if [ "$http_code" != "200" ]; then
+            echo "::error::download-streaming-db returned HTTP $http_code"
+            head -c 2000 "$dest" || true
+            exit 1
+          fi
+          if [ ! -s "$dest" ]; then
+            echo "::error::downloaded streaming_availability.db is empty"
+            exit 1
+          fi
+          python -c "import sqlite3,sys; n=sqlite3.connect(sys.argv[1]).execute('SELECT count(*) FROM albums').fetchone()[0]; print('volume streaming_availability.db OK: %d albums' % n); sys.exit(0 if n>0 else 'downloaded streaming_availability.db has 0 albums')" "$dest"
         env:
-          GH_TOKEN: ${{ github.token }}
+          ADMIN_TOKEN: ${{ secrets.ADMIN_TOKEN }}
+          PRODUCTION_URL: ${{ secrets.PRODUCTION_URL }}
 
       - name: Run library sync
         run: scripts/sync-library.sh

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -50,6 +50,8 @@ The workflow can also be triggered manually: `gh workflow run sync-library.yml`
 
 The `--notify` flag is always passed, so Slack notifications are sent on failure when `SLACK_MONITORING_WEBHOOK` is configured.
 
+**Streaming-links enrichment (WXYC/library-metadata-lookup#672):** before upload, the exported `library.db` is enriched with streaming URLs from `streaming_availability.db`. That file is read from the LML Railway **volume** via `GET /admin/download-streaming-db` (the canonical copy), not the GitHub Release — the "Set up streaming links enrichment" step authenticates with `ADMIN_TOKEN` against `PRODUCTION_URL`. The download **hard-fails** on a non-200 response, an empty file, or a non-SQLite/zero-albums body (a naive `curl -o` exits 0 on HTTP 404/500 and writes the error body), so a Railway outage at sync time **aborts the run** and production keeps **yesterday's** `library.db` (which still has its streaming links) rather than publishing a zero-link database. After enrichment, `sync-library.sh` asserts the `streaming_links.apple_music_url` count exceeds `STREAMING_APPLE_FLOOR` (default `100`) and aborts before upload if it doesn't; set `STREAMING_APPLE_FLOOR=0` to opt out (e.g. a local run with no streaming db).
+
 **Required GitHub secrets:**
 
 | Secret | Description |

--- a/scripts/sync-library.sh
+++ b/scripts/sync-library.sh
@@ -162,6 +162,21 @@ else
     log "Skipping streaming links (streaming_availability.db not found)"
 fi
 
+# Post-enrichment floor assertion (LML#672, belt-and-suspenders). A zero/low
+# apple_music_url count means enrichment silently produced a thin library.db
+# (download flake, missing streaming db, export bug); fail BEFORE upload rather
+# than strip prod's streaming links. STREAMING_APPLE_FLOOR is an absolute floor
+# at the consumption layer, complementary to LML's relative upload-coverage guard.
+# Set STREAMING_APPLE_FLOOR=0 to opt out (e.g. a local run with no streaming db).
+STREAMING_APPLE_FLOOR="${STREAMING_APPLE_FLOOR:-100}"
+APPLE_COUNT=$($PYTHON -c "import sqlite3,sys; c=sqlite3.connect(sys.argv[1]); t=c.execute(\"SELECT name FROM sqlite_master WHERE type='table' AND name='streaming_links'\").fetchone(); print(c.execute('SELECT COUNT(apple_music_url) FROM streaming_links').fetchone()[0] if t else 0)" "$DB_PATH" 2>>"$LOG_FILE") || APPLE_COUNT=""
+log "Streaming links apple_music_url count: ${APPLE_COUNT:-<error>} (floor $STREAMING_APPLE_FLOOR)"
+if [[ -z "$APPLE_COUNT" || "$APPLE_COUNT" -lt "$STREAMING_APPLE_FLOOR" ]]; then
+    rm -f "$DB_PATH"
+    notify_error "Streaming enrichment produced only ${APPLE_COUNT:-0} apple_music_url links (< floor $STREAMING_APPLE_FLOOR); aborting before upload to avoid stripping prod streaming links"
+    exit 1
+fi
+
 # Upload to staging (if URL configured)
 if [[ -n "$STAGING_URL" ]]; then
     upload_library_db "$STAGING_URL" "staging" "$DB_PATH" || EXIT_CODE=1


### PR DESCRIPTION
Consumption (discogs-etl) side of WXYC/library-metadata-lookup#672 — making the LML Railway **volume** the single canonical `streaming_availability.db` lineage. Pairs with the LML PR WXYC/library-metadata-lookup#676.

## Problem

The daily library sync read `streaming_availability.db` from the `streaming-data-v1` GitHub Release, which CI populated **Spotify/Deezer-only**, so prod `library.db` silently carried **zero Apple Music links** while the rich copy (Apple + `track_results`) sat on the LML volume.

## Changes

- **`sync-library.yml`**: replace `gh release download streaming-data-v1` with `GET /admin/download-streaming-db` against `PRODUCTION_URL`. The step **hard-fails** on a non-200, an empty file, or a non-SQLite/zero-albums body — a naive `curl -o` exits 0 on HTTP 404/500 and writes the error body, which would silently strip prod's streaming links. On a Railway outage the step aborts and prod keeps **yesterday's** `library.db` (which still has links). Adds `ADMIN_TOKEN` + `PRODUCTION_URL` to the step env.
- **`sync-library.sh`**: post-enrichment floor assertion — if `streaming_links.apple_music_url` count is below `STREAMING_APPLE_FLOOR` (default 100) the run aborts **before upload** rather than overwrite prod with a thin db. `STREAMING_APPLE_FLOOR=0` opts out (e.g. a local run with no streaming db). This absolute consumption-layer floor complements LML's relative upload-coverage guard.

## Validation

`actionlint`, `bash -n`, `shellcheck` (no new findings — the two warnings are pre-existing). Floor logic verified across 4 scenarios (above floor → pass; below floor → abort; missing table → abort; floor=0 opt-out → pass).

## Merge order

Land **after** WXYC/library-metadata-lookup#676 (the volume must be written before this reads it; #676 keeps dual-writing the release as a safety net during the transition). After this merges, verify one sync cycle yields a non-zero `apple_music_url` count in prod `library.db` before LML drops the release write.