### PR TITLE
feat: read release_artist.role from converter output

### DIFF
--- a/docs/test-fixtures.md
+++ b/docs/test-fixtures.md
@@ -14,16 +14,18 @@ When writing inline test data or new fixture rows, use these defaults matching t
 5006,Accepted,Duke Ellington & John Coltrane,US,1963,,Correct,8005,LP
 ```
 
-**`release_artist` table** (release_id, artist_id, artist_name, extra, anv, position, join_field):
+**`release_artist` table** (release_id, artist_id, artist_name, extra, anv, position, join_field, role):
 ```
-5001,101,Juana Molina,0,,1,
-5002,102,Stereolab,0,,1,
-5003,103,Cat Power,0,,1,
-5004,104,Jessica Pratt,0,,1,
-5005,105,Chuquimamani-Condori,0,,1,
-5006,106,Duke Ellington,0,,1,
-5006,107,John Coltrane,0,,2, &
+5001,101,Juana Molina,0,,1,,
+5002,102,Stereolab,0,,1,,
+5003,103,Cat Power,0,,1,,
+5004,104,Jessica Pratt,0,,1,,
+5005,105,Chuquimamani-Condori,0,,1,,
+5006,106,Duke Ellington,0,,1, &,
+5006,107,John Coltrane,0,,2,,
+5006,108,Billy Strayhorn,1,,3,,Written-By
 ```
+Column `role` carries release-level extra-credit attribution (e.g. `Written-By`, `Producer`) for `extra=1` rows; main artists (`extra=0`) have `role` NULL. The loader reads it via `optional_csv_columns`, so a pre-role CSV still imports — the same `(extra, role)` semantics as `release_track_artist` below.
 
 **`release_label` table** (release_id, label, catno):
 ```

--- a/scripts/import_csv.py
+++ b/scripts/import_csv.py
@@ -103,18 +103,21 @@ BASE_TABLES: list[TableConfig] = [
     {
         "csv_file": "release_artist.csv",
         "table": "release_artist",
-        # The schema has a ``role`` column for extra-credit attribution
-        # ("Producer", "Mixed By", etc.), but the converter
-        # (WXYC/discogs-xml-converter v0.1.0) doesn't emit it. Listing
-        # ``role`` here caused the import to bail out with "Missing
-        # columns" and write zero release_artist rows (see #204). Keep
-        # the schema column nullable so a future converter version can
-        # populate it without a schema migration.
         "csv_columns": ["release_id", "artist_id", "artist_name", "extra"],
         "db_columns": ["release_id", "artist_id", "artist_name", "extra"],
         "required": ["release_id", "artist_name"],
         "transforms": {},
         "unique_key": ["release_id", "artist_name"],
+        # The converter now emits the source ``<role>`` for release-level
+        # extra credits (writer/composer/producer). ``role`` is listed as
+        # OPTIONAL — not in the required ``csv_columns`` above — so the loader
+        # reads it when present and tolerates its absence in older CSVs
+        # (PG default ``role=NULL``) rather than bailing with "Missing
+        # columns" and writing zero rows (the #204 failure mode). Mirrors
+        # ``release_track_artist`` (WXYC/discogs-etl#218); populates
+        # ``release_artist.role`` for the release-level composer fallback
+        # (WXYC/library-metadata-lookup#699).
+        "optional_csv_columns": ["role"],
     },
     {
         "csv_file": "release_label.csv",

--- a/tests/unit/test_import_csv.py
+++ b/tests/unit/test_import_csv.py
@@ -640,8 +640,8 @@ class TestImportCsvOptionalColumns:
         csv_path = tmp_path / "release_artist.csv"
         csv_path.write_text(
             "release_id,artist_id,artist_name,extra,role\n"
-            "9100,10,Main Performer,0,\n"
-            "9100,20,Jane Writer,1,Written-By\n"
+            "9100,10,Stereolab,0,\n"
+            "9100,20,Tim Gane,1,Written-By\n"
         )
 
         captured_columns: dict[str, str] = {}
@@ -682,8 +682,61 @@ class TestImportCsvOptionalColumns:
         # COPY SQL lists the optional role column.
         assert "release_id, artist_id, artist_name, extra, role" in captured_columns["sql"]
         # Main artist: empty role → NULL. Writer credit: source role preserved.
-        assert captured_rows[0] == ("9100", "10", "Main Performer", "0", None)
-        assert captured_rows[1] == ("9100", "20", "Jane Writer", "1", "Written-By")
+        assert captured_rows[0] == ("9100", "10", "Stereolab", "0", None)
+        assert captured_rows[1] == ("9100", "20", "Tim Gane", "1", "Written-By")
+
+    def test_legacy_release_artist_csv_without_role_still_imports(self, tmp_path) -> None:
+        """A pre-role ``release_artist`` CSV (no ``role`` column) must still
+        import: the loader drops ``role`` from the COPY so the schema default
+        (NULL) takes over, instead of bailing with "Missing columns" and
+        writing zero rows. This is the exact #204 failure mode that left
+        ``release_artist`` empty in the 2026-05-13 rebuild, pinned at the
+        behavioral level (the config-pin tests above never run the loader).
+        Release-level analogue of ``test_legacy_csv_without_optional_columns_still_imports``."""
+        from unittest.mock import MagicMock
+
+        csv_path = tmp_path / "release_artist.csv"
+        csv_path.write_text("release_id,artist_id,artist_name,extra\n9100,10,Stereolab,0\n")
+
+        captured_columns: dict[str, str] = {}
+        captured_rows: list[tuple] = []
+
+        class _RecordingCopy:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *exc):
+                return False
+
+            def write_row(self, row):
+                captured_rows.append(tuple(row))
+
+        def _cur_copy(sql, *_):
+            captured_columns["sql"] = sql
+            return _RecordingCopy()
+
+        mock_cursor = MagicMock()
+        mock_cursor.copy.side_effect = _cur_copy
+        mock_conn = MagicMock()
+        mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
+        mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+
+        count = import_csv(
+            mock_conn,
+            csv_path,
+            table="release_artist",
+            csv_columns=["release_id", "artist_id", "artist_name", "extra"],
+            db_columns=["release_id", "artist_id", "artist_name", "extra"],
+            required_columns=["release_id", "artist_name"],
+            transforms={},
+            optional_csv_columns=["role"],
+        )
+
+        assert count == 1
+        # COPY SQL omits the absent optional column; the schema NULL default takes over.
+        assert "role" not in captured_columns["sql"]
+        # Row has only the 4 base columns.
+        assert captured_rows[0] == ("9100", "10", "Stereolab", "0")
 
 
 class TestImportCsvMissingColumns:

--- a/tests/unit/test_import_csv.py
+++ b/tests/unit/test_import_csv.py
@@ -35,29 +35,28 @@ CSV_DIR = FIXTURES_DIR / "csv"
 # ---------------------------------------------------------------------------
 
 
-class TestReleaseArtistColumnsMatchConverterOutput:
-    """The ``release_artist`` table config must NOT include a column the
-    converter doesn't emit.
+class TestReleaseArtistRoleColumn:
+    """``release_artist.role`` is read via ``optional_csv_columns``: present
+    in the converter's CSV header → loaded; absent (older CSV) → PG default
+    NULL. It must stay OUT of the required ``csv_columns`` / ``db_columns``
+    so a pre-role CSV still imports instead of bailing with "Missing columns"
+    and writing zero rows (the #204 failure mode).
 
-    WXYC/discogs-xml-converter v0.1.0 writes release_artist.csv with
-    ``release_id, artist_id, artist_name, extra, anv, position, join_field``.
-    Any column listed in ``csv_columns`` that's missing from the CSV header
-    causes ``import_csv`` to bail out at line 257 with ``return 0`` — the
-    failure mode that left release_artist empty in the 2026-05-13 rebuild
-    (#204). The schema's ``role`` column stays nullable; this test pins
-    that the importer doesn't try to read it.
+    The converter began emitting release-level ``<role>`` so release-level
+    writer/composer credits reach ``release_artist.role`` (the release-level
+    composer fallback, WXYC/library-metadata-lookup#699), mirroring the
+    ``release_track_artist`` handling from WXYC/discogs-etl#218.
     """
 
-    def test_release_artist_csv_columns_exclude_role(self) -> None:
+    def test_role_declared_as_optional_csv_column(self) -> None:
         ra_config = next(t for t in BASE_TABLES if t["table"] == "release_artist")
-        assert "role" not in ra_config["csv_columns"], (
-            "'role' must not appear in csv_columns until the converter writes it; see #204"
-        )
+        assert ra_config.get("optional_csv_columns") == ["role"]
 
-    def test_release_artist_db_columns_exclude_role(self) -> None:
-        """db_columns must mirror csv_columns (positional mapping). The schema's
-        ``role`` column accepts NULL so the import succeeds without it."""
+    def test_role_stays_out_of_required_columns(self) -> None:
+        """Role is optional, not required: keeping it out of csv_columns /
+        db_columns is what lets a pre-role CSV still import (#204)."""
         ra_config = next(t for t in BASE_TABLES if t["table"] == "release_artist")
+        assert "role" not in ra_config["csv_columns"]
         assert "role" not in ra_config["db_columns"]
 
 
@@ -630,6 +629,61 @@ class TestImportCsvOptionalColumns:
         output — a regression of WXYC/discogs-etl#218."""
         rta_config = next(t for t in TRACK_TABLES if t["table"] == "release_track_artist")
         assert rta_config.get("optional_csv_columns") == ["extra", "role"]
+
+    def test_new_release_artist_csv_with_role_appends_it_to_copy(self, tmp_path) -> None:
+        """A ``release_artist`` CSV carrying release-level ``role`` loads it;
+        an empty role coerces to NULL, and main artists (extra=0) carry none.
+        This is the release-level analogue of the per-track case above
+        (WXYC/library-metadata-lookup#699)."""
+        from unittest.mock import MagicMock
+
+        csv_path = tmp_path / "release_artist.csv"
+        csv_path.write_text(
+            "release_id,artist_id,artist_name,extra,role\n"
+            "9100,10,Main Performer,0,\n"
+            "9100,20,Jane Writer,1,Written-By\n"
+        )
+
+        captured_columns: dict[str, str] = {}
+        captured_rows: list[tuple] = []
+
+        class _RecordingCopy:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *exc):
+                return False
+
+            def write_row(self, row):
+                captured_rows.append(tuple(row))
+
+        def _cur_copy(sql, *_):
+            captured_columns["sql"] = sql
+            return _RecordingCopy()
+
+        mock_cursor = MagicMock()
+        mock_cursor.copy.side_effect = _cur_copy
+        mock_conn = MagicMock()
+        mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
+        mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+
+        count = import_csv(
+            mock_conn,
+            csv_path,
+            table="release_artist",
+            csv_columns=["release_id", "artist_id", "artist_name", "extra"],
+            db_columns=["release_id", "artist_id", "artist_name", "extra"],
+            required_columns=["release_id", "artist_name"],
+            transforms={},
+            optional_csv_columns=["role"],
+        )
+
+        assert count == 2
+        # COPY SQL lists the optional role column.
+        assert "release_id, artist_id, artist_name, extra, role" in captured_columns["sql"]
+        # Main artist: empty role → NULL. Writer credit: source role preserved.
+        assert captured_rows[0] == ("9100", "10", "Main Performer", "0", None)
+        assert captured_rows[1] == ("9100", "20", "Jane Writer", "1", "Written-By")
 
 
 class TestImportCsvMissingColumns:


### PR DESCRIPTION
Closes #291. Depends on WXYC/discogs-xml-converter#74 (emits the `role` column).

`release_artist.role` exists in the schema but was never populated — the loader didn't read a `role` column (listing it as required bailed the import with "Missing columns", #204). The converter now emits the source `<role>` for release-level extra credits, so `release_artist.csv` carries a `role` column.

## What changed

- `release_artist` config opts into `optional_csv_columns: ["role"]` (`scripts/import_csv.py`) — the generic, already-proven mechanism; no loader-logic change. `role` stays out of the required `csv_columns`, so a pre-role CSV still imports (PG default `role=NULL`).
- Replaced the obsolete role-exclusion guard tests with the new contract (role optional, empty→NULL) and added a positive load test mirroring `release_track_artist`.

## Tests

- `ruff check` / `ruff format --check` clean; full unit suite **812 passed**.

## Coordination

Independently safe (the optional column tolerates present-or-absent), so merge order vs WXYC/discogs-xml-converter#74 is flexible; role data appears once both land and a re-import runs. Unblocks the release-level composer fallback in WXYC/library-metadata-lookup#699.

Note: `release_artist.role` is present in `schema/create_database.sql`; worth a `\d release_artist` against the populated cache before the next rebuild. If any deployed DB lacks it, a trivial idempotent `ADD COLUMN IF NOT EXISTS role text` migration covers it.
