### PR TITLE
fix(#293): include extra in loader dedup key so role-bearing extra rows survive

### DIFF
--- a/scripts/import_csv.py
+++ b/scripts/import_csv.py
@@ -107,7 +107,16 @@ BASE_TABLES: list[TableConfig] = [
         "db_columns": ["release_id", "artist_id", "artist_name", "extra"],
         "required": ["release_id", "artist_name"],
         "transforms": {},
-        "unique_key": ["release_id", "artist_name"],
+        # ``extra`` is in the dedup key so a same-name main-performer row
+        # (``extra=0``) and a role-bearing extra-credit row (``extra=1``, e.g.
+        # a ``Written-By`` writer) both survive — the converter writes the
+        # ``extra=0`` row first, and a key of just ``(release_id, artist_name)``
+        # would drop the second, role-bearing row (WXYC/discogs-etl#293).
+        # ``extra`` is a hard ``csv_columns`` entry here, so the static add is
+        # crash-safe; the optional-column ``release_track_artist`` widens its
+        # key at runtime instead (see ``import_csv``). Mirrors the converter's
+        # direct-PG ``WideArtistDedup`` (WXYC/discogs-xml-converter#74).
+        "unique_key": ["release_id", "artist_name", "extra"],
         # The converter now emits the source ``<role>`` for release-level
         # extra credits (writer/composer/producer). ``role`` is listed as
         # OPTIONAL — not in the required ``csv_columns`` above — so the loader
@@ -420,6 +429,24 @@ def import_csv(
         if present_optional:
             csv_columns = list(csv_columns) + present_optional
             db_columns = list(db_columns) + present_optional
+
+            # Widen the dedup key to include ``extra`` when the CSV actually
+            # carries it, so a same-name main-performer row (``extra=0``) and a
+            # role-bearing extra-credit row (``extra=1``) both survive instead
+            # of the second being deduped away (WXYC/discogs-etl#293). This is
+            # the ``release_track_artist`` path: ``extra`` is an OPTIONAL column
+            # there, so a static add to its ``unique_key`` would ``ValueError``
+            # on a CSV that lacks the column (``csv_columns.index("extra")``
+            # below) — the exact backward-compat case ``optional_csv_columns``
+            # exists to tolerate. Adding it here, only when present, falls
+            # through to the 3-column key (and PG ``extra=0`` default) otherwise.
+            # Scoped to ``extra`` (a 0/1 flag), not ``role``, to stay converged
+            # with the converter's ``(release_id, [track_sequence,] artist_name,
+            # extra)`` key (WXYC/discogs-xml-converter#74). ``release_artist``
+            # carries ``extra`` as a hard column and lists it in its static key,
+            # so this branch is a no-op there.
+            if unique_key and "extra" in present_optional and "extra" not in unique_key:
+                unique_key = list(unique_key) + ["extra"]
 
         db_col_list = ", ".join(db_columns)
 

--- a/scripts/import_csv.py
+++ b/scripts/import_csv.py
@@ -88,6 +88,16 @@ class TableConfig(TypedDict, total=False):
     # CSVs should fall through to the DB-side default — e.g. ``extra``
     # and ``role`` on ``release_track_artist`` per WXYC/discogs-etl#218.
     optional_csv_columns: list[str]
+    # ``dedup_when_present``: optional columns that also join the dedup
+    # ``unique_key`` — but only when the CSV header actually carries them,
+    # so a CSV that omits the column still imports against the static key
+    # (the backward-compat case ``optional_csv_columns`` exists to tolerate).
+    # The loader reads this list rather than hardcoding a column name, so a
+    # column's effect on row identity is declared in config alongside the
+    # rest of the table's shape. Today only ``release_track_artist`` uses it
+    # (``["extra"]``); ``release_artist`` instead lists ``extra`` as a hard
+    # column directly in its static ``unique_key`` (WXYC/discogs-etl#293).
+    dedup_when_present: list[str]
 
 
 BASE_TABLES: list[TableConfig] = [
@@ -112,9 +122,10 @@ BASE_TABLES: list[TableConfig] = [
         # a ``Written-By`` writer) both survive — the converter writes the
         # ``extra=0`` row first, and a key of just ``(release_id, artist_name)``
         # would drop the second, role-bearing row (WXYC/discogs-etl#293).
-        # ``extra`` is a hard ``csv_columns`` entry here, so the static add is
-        # crash-safe; the optional-column ``release_track_artist`` widens its
-        # key at runtime instead (see ``import_csv``). Mirrors the converter's
+        # ``extra`` is a hard ``csv_columns`` entry here, so it joins the static
+        # key directly; the optional-column ``release_track_artist`` instead
+        # declares ``extra`` in ``dedup_when_present`` and the loader folds it in
+        # at runtime only when the header carries it. Mirrors the converter's
         # direct-PG ``WideArtistDedup`` (WXYC/discogs-xml-converter#74).
         "unique_key": ["release_id", "artist_name", "extra"],
         # The converter now emits the source ``<role>`` for release-level
@@ -184,6 +195,17 @@ TRACK_TABLES: list[TableConfig] = [
         # columns, which matches the legacy "everything was main credits"
         # interpretation under which existing consumers were operating.
         "optional_csv_columns": ["extra", "role"],
+        # ``extra`` also joins the dedup key (when the header carries it) so a
+        # same-name main-performer row (``extra=0``) and a role-bearing extra-
+        # credit row (``extra=1``) both survive instead of the second being
+        # deduped away (WXYC/discogs-etl#293). It stays OUT of the static
+        # ``unique_key`` above so a pre-``extra`` CSV still dedups on the
+        # 3-column key; the loader widens at runtime only when present.
+        # ``role`` is deliberately excluded — multiple distinct roles for one
+        # artist collapse to the first seen, to stay converged with the
+        # converter's ``(release_id, track_sequence, artist_name, extra)`` key
+        # (WXYC/discogs-xml-converter#74).
+        "dedup_when_present": ["extra"],
     },
 ]
 
@@ -381,6 +403,7 @@ def import_csv(
     id_filter: set[int] | None = None,
     id_filter_column: str | None = None,
     optional_csv_columns: list[str] | None = None,
+    dedup_when_present: list[str] | None = None,
 ) -> int:
     """Import a CSV file into a table, selecting only needed columns.
 
@@ -403,6 +426,15 @@ def import_csv(
     fall through to the DB-side default (``DEFAULT`` clause / NULL). Used
     for forward-compatibility with new converter columns (e.g. ``extra``
     / ``role`` on ``release_track_artist`` per WXYC/discogs-etl#218).
+
+    If ``dedup_when_present`` is provided, those columns are appended to
+    ``unique_key`` for the duration of this call, but only when they
+    actually appear in the CSV header. This lets an optional column join
+    the dedup key without a static ``unique_key`` add that would
+    ``ValueError`` on a CSV lacking it; a CSV that omits the column falls
+    back to the static key (e.g. ``extra`` on ``release_track_artist`` per
+    WXYC/discogs-etl#293). Columns are widened in, not replaced — already
+    present keys are left untouched.
     """
     logger.info(f"Importing {csv_path.name} into {table}...")
 
@@ -430,23 +462,22 @@ def import_csv(
             csv_columns = list(csv_columns) + present_optional
             db_columns = list(db_columns) + present_optional
 
-            # Widen the dedup key to include ``extra`` when the CSV actually
-            # carries it, so a same-name main-performer row (``extra=0``) and a
-            # role-bearing extra-credit row (``extra=1``) both survive instead
-            # of the second being deduped away (WXYC/discogs-etl#293). This is
-            # the ``release_track_artist`` path: ``extra`` is an OPTIONAL column
-            # there, so a static add to its ``unique_key`` would ``ValueError``
-            # on a CSV that lacks the column (``csv_columns.index("extra")``
-            # below) — the exact backward-compat case ``optional_csv_columns``
-            # exists to tolerate. Adding it here, only when present, falls
-            # through to the 3-column key (and PG ``extra=0`` default) otherwise.
-            # Scoped to ``extra`` (a 0/1 flag), not ``role``, to stay converged
-            # with the converter's ``(release_id, [track_sequence,] artist_name,
-            # extra)`` key (WXYC/discogs-xml-converter#74). ``release_artist``
-            # carries ``extra`` as a hard column and lists it in its static key,
-            # so this branch is a no-op there.
-            if unique_key and "extra" in present_optional and "extra" not in unique_key:
-                unique_key = list(unique_key) + ["extra"]
+        # Widen the dedup key with any ``dedup_when_present`` column the CSV
+        # actually carries, so e.g. a same-name main-performer row (``extra=0``)
+        # and a role-bearing extra-credit row (``extra=1``) both survive instead
+        # of the second being deduped away (WXYC/discogs-etl#293). A column here
+        # is OPTIONAL, so a static ``unique_key`` add would ``ValueError`` on a
+        # CSV that lacks it (``csv_columns.index`` below); folding it in only
+        # when present falls back to the static key otherwise. Membership is
+        # tested against ``csv_columns`` (post optional-column append) — the same
+        # list the dedup indices are resolved from — so a widened key column is
+        # always indexable. Driven by the table config rather than a hardcoded
+        # column name; ``release_artist`` carries ``extra`` as a hard column
+        # directly in its static key, so it passes nothing here.
+        if unique_key and dedup_when_present:
+            for col in dedup_when_present:
+                if col in csv_columns and col not in unique_key:
+                    unique_key = list(unique_key) + [col]
 
         db_col_list = ", ".join(db_columns)
 
@@ -858,6 +889,7 @@ def _import_tables(
             id_filter=id_filter,
             id_filter_column=id_filter_column,
             optional_csv_columns=table_config.get("optional_csv_columns"),
+            dedup_when_present=table_config.get("dedup_when_present"),
         )
         total += count
     return total
@@ -899,6 +931,7 @@ def _import_tables_parallel(
             unique_key=table_config.get("unique_key"),
             release_id_filter=release_id_filter,
             optional_csv_columns=table_config.get("optional_csv_columns"),
+            dedup_when_present=table_config.get("dedup_when_present"),
         )
         total += count
     conn.close()
@@ -921,6 +954,7 @@ def _import_tables_parallel(
             unique_key=table_config.get("unique_key"),
             release_id_filter=release_id_filter,
             optional_csv_columns=table_config.get("optional_csv_columns"),
+            dedup_when_present=table_config.get("dedup_when_present"),
         )
         child_conn.close()
         return count

--- a/tests/integration/test_import.py
+++ b/tests/integration/test_import.py
@@ -477,6 +477,116 @@ class TestDuplicateReleaseIds:
         assert title == "DOGA"
 
 
+class TestImportCsvKeepsExtraRows:
+    """Regression for WXYC/discogs-etl#293: a same-name main-performer row
+    (``extra=0``) and a role-bearing extra-credit row (``extra=1``) both land
+    in PostgreSQL, against the real table config.
+
+    The end-to-end PG counterpart of the mocked-COPY unit tests
+    (``TestImportCsvDedupKeepsExtraRows`` in ``tests/unit/test_import_csv.py``):
+    proves the second, role-bearing row actually persists with its ``role`` in a
+    real table, not just that the loader writes two rows. Before the fix the
+    loader deduped on ``(release_id, [track_sequence,] artist_name)`` and dropped
+    the ``extra=1`` row, silently losing its ``role``."""
+
+    @pytest.fixture(autouse=True, scope="class")
+    def _set_up_database(self, db_url):
+        self.__class__._db_url = db_url
+        _clean_db(db_url)
+        conn = psycopg.connect(db_url, autocommit=True)
+        with conn.cursor() as cur:
+            cur.execute(SCHEMA_DIR.joinpath("create_database.sql").read_text())
+            # Parent release rows so the child FKs (release_id -> release.id)
+            # are satisfied.
+            cur.execute("INSERT INTO release (id, title) VALUES (9100, 'Aluminum Tunes')")
+            cur.execute("INSERT INTO release (id, title) VALUES (674529, 'DOGA')")
+        conn.close()
+
+    @pytest.fixture(autouse=True)
+    def _store_url(self):
+        self.db_url = self.__class__._db_url
+
+    def _connect(self):
+        return psycopg.connect(self.db_url)
+
+    def test_release_artist_main_and_extra_both_land_with_role(self, tmp_path) -> None:
+        """release_artist: the writer credit (extra=1, Written-By) survives
+        alongside the same-name main performer (extra=0); the role persists."""
+        csv_path = tmp_path / "release_artist.csv"
+        csv_path.write_text(
+            "release_id,artist_id,artist_name,extra,role\n"
+            "9100,10,Stereolab,0,\n"
+            "9100,10,Stereolab,1,Written-By\n"
+        )
+        ra_config = next(t for t in BASE_TABLES if t["table"] == "release_artist")
+        conn = psycopg.connect(self.db_url)
+        count = import_csv_func(
+            conn,
+            csv_path,
+            ra_config["table"],
+            ra_config["csv_columns"],
+            ra_config["db_columns"],
+            ra_config["required"],
+            ra_config["transforms"],
+            unique_key=ra_config["unique_key"],
+            optional_csv_columns=ra_config.get("optional_csv_columns"),
+        )
+        conn.close()
+
+        assert count == 2
+
+        conn = self._connect()
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT extra, role FROM release_artist "
+                "WHERE release_id = 9100 AND artist_name = 'Stereolab' ORDER BY extra"
+            )
+            rows = cur.fetchall()
+        conn.close()
+        # Both the main credit (extra=0, role NULL) and the writer credit
+        # (extra=1, role 'Written-By') survive.
+        assert rows == [(0, None), (1, "Written-By")]
+
+    def test_release_track_artist_main_and_extra_both_land_with_role(self, tmp_path) -> None:
+        """release_track_artist: the same-name extra=1 (role) credit survives
+        alongside the extra=0 main credit at (release_id, track_sequence) scope.
+        ``extra`` is optional here, so the loader folds it into the dedup key
+        only because the CSV header carries it."""
+        csv_path = tmp_path / "release_track_artist.csv"
+        csv_path.write_text(
+            "release_id,track_sequence,artist_name,extra,role\n"
+            "674529,5,Alex Paterson,0,\n"
+            "674529,5,Alex Paterson,1,Producer\n"
+        )
+        rta_config = next(t for t in TRACK_TABLES if t["table"] == "release_track_artist")
+        conn = psycopg.connect(self.db_url)
+        count = import_csv_func(
+            conn,
+            csv_path,
+            rta_config["table"],
+            rta_config["csv_columns"],
+            rta_config["db_columns"],
+            rta_config["required"],
+            rta_config["transforms"],
+            unique_key=rta_config["unique_key"],
+            optional_csv_columns=rta_config.get("optional_csv_columns"),
+        )
+        conn.close()
+
+        assert count == 2
+
+        conn = self._connect()
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT extra, role FROM release_track_artist "
+                "WHERE release_id = 674529 AND track_sequence = 5 "
+                "AND artist_name = 'Alex Paterson' ORDER BY extra"
+            )
+            rows = cur.fetchall()
+        conn.close()
+        assert rows == [(0, None), (1, "Producer")]
+
+
 class TestPopulateCacheMetadata:
     """Verify populate_cache_metadata() inserts metadata for all releases via COPY."""
 

--- a/tests/integration/test_import.py
+++ b/tests/integration/test_import.py
@@ -570,6 +570,7 @@ class TestImportCsvKeepsExtraRows:
             rta_config["transforms"],
             unique_key=rta_config["unique_key"],
             optional_csv_columns=rta_config.get("optional_csv_columns"),
+            dedup_when_present=rta_config.get("dedup_when_present"),
         )
         conn.close()
 

--- a/tests/unit/test_import_csv.py
+++ b/tests/unit/test_import_csv.py
@@ -843,6 +843,7 @@ class TestImportCsvDedupKeepsExtraRows:
             transforms=rta_config["transforms"],
             unique_key=rta_config["unique_key"],
             optional_csv_columns=rta_config.get("optional_csv_columns"),
+            dedup_when_present=rta_config.get("dedup_when_present"),
         )
 
         assert count == 2
@@ -856,9 +857,11 @@ class TestImportCsvDedupKeepsExtraRows:
         track_sequence, artist_name)`` and absent columns take the PG default.
 
         Pins that the #293 fix widens the key on ``extra`` only when the header
-        carries it — a static add to this table's ``unique_key`` would
-        ``ValueError`` here, the exact backward-compat case ``optional_csv_columns``
-        exists to tolerate."""
+        carries it — declaring ``extra`` in this table's static ``unique_key``
+        would ``ValueError`` here, the exact backward-compat case the
+        ``dedup_when_present`` widening exists to tolerate. The config field is
+        passed exactly as the real call sites do, so the fall-back is exercised
+        through the production path."""
         rta_config = next(t for t in TRACK_TABLES if t["table"] == "release_track_artist")
         csv_path = tmp_path / "release_track_artist.csv"
         csv_path.write_text(
@@ -878,6 +881,7 @@ class TestImportCsvDedupKeepsExtraRows:
             transforms=rta_config["transforms"],
             unique_key=rta_config["unique_key"],
             optional_csv_columns=rta_config.get("optional_csv_columns"),
+            dedup_when_present=rta_config.get("dedup_when_present"),
         )
 
         # The 3-column dedup collapses the exact duplicate to a single row.
@@ -891,6 +895,67 @@ class TestImportCsvDedupKeepsExtraRows:
         the static key add is crash-safe (unlike the optional-column track table)."""
         ra_config = next(t for t in BASE_TABLES if t["table"] == "release_artist")
         assert ra_config["unique_key"] == ["release_id", "artist_name", "extra"]
+
+    def test_release_track_artist_declares_extra_as_dedup_when_present(self) -> None:
+        """Pin the config: ``release_track_artist`` declares ``extra`` in
+        ``dedup_when_present`` so the loader folds it into the dedup key at
+        runtime (only when the header carries it), keeping the static
+        ``unique_key`` at the 3-column backward-compatible form. The widening is
+        config-declared, not a column name the loader hardcodes."""
+        rta_config = next(t for t in TRACK_TABLES if t["table"] == "release_track_artist")
+        assert rta_config["dedup_when_present"] == ["extra"]
+        assert "extra" not in rta_config["unique_key"]
+
+    def test_dedup_when_present_widens_key_generically(self, tmp_path) -> None:
+        """The loader widens the dedup key from ``dedup_when_present`` for any
+        declared column the header carries — it does not special-case the name
+        ``extra``. Drive it with a synthetic column ``flag`` to prove the
+        mechanism is generic: two rows identical but for ``flag`` both survive."""
+        csv_path = tmp_path / "widen.csv"
+        csv_path.write_text("release_id,artist_name,flag\n9100,Stereolab,a\n9100,Stereolab,b\n")
+
+        conn, captured = _make_recording_conn()
+        count = import_csv(
+            conn,
+            csv_path,
+            table="release_artist",
+            csv_columns=["release_id", "artist_name"],
+            db_columns=["release_id", "artist_name"],
+            required_columns=["release_id", "artist_name"],
+            transforms={},
+            unique_key=["release_id", "artist_name"],
+            optional_csv_columns=["flag"],
+            dedup_when_present=["flag"],
+        )
+
+        assert count == 2
+        assert captured["rows"][0] == ("9100", "Stereolab", "a")
+        assert captured["rows"][1] == ("9100", "Stereolab", "b")
+
+    def test_dedup_when_present_absent_column_keeps_narrow_key(self, tmp_path) -> None:
+        """A column declared in ``dedup_when_present`` but missing from the CSV
+        header must not widen the key: the loader falls back to the static
+        ``unique_key`` and collapses the exact duplicate. Mirrors the
+        backward-compat path for a pre-``extra`` ``release_track_artist`` CSV."""
+        csv_path = tmp_path / "narrow.csv"
+        csv_path.write_text("release_id,artist_name\n9100,Stereolab\n9100,Stereolab\n")
+
+        conn, captured = _make_recording_conn()
+        count = import_csv(
+            conn,
+            csv_path,
+            table="release_artist",
+            csv_columns=["release_id", "artist_name"],
+            db_columns=["release_id", "artist_name"],
+            required_columns=["release_id", "artist_name"],
+            transforms={},
+            unique_key=["release_id", "artist_name"],
+            optional_csv_columns=["flag"],
+            dedup_when_present=["flag"],
+        )
+
+        assert count == 1
+        assert captured["rows"][0] == ("9100", "Stereolab")
 
 
 class TestImportCsvMissingColumns:

--- a/tests/unit/test_import_csv.py
+++ b/tests/unit/test_import_csv.py
@@ -739,6 +739,160 @@ class TestImportCsvOptionalColumns:
         assert captured_rows[0] == ("9100", "10", "Stereolab", "0")
 
 
+def _make_recording_conn():
+    """Build a MagicMock connection whose ``cursor.copy`` records the COPY SQL
+    and every written row.
+
+    Returns ``(conn, captured)`` where ``captured`` is a dict with ``"sql"``
+    (the COPY statement) and ``"rows"`` (the list of row tuples written). Keeps
+    the COPY-recording boilerplate that the optional-column tests repeat inline
+    in one place for the #293 dedup regression tests.
+    """
+    from unittest.mock import MagicMock
+
+    captured: dict = {"sql": None, "rows": []}
+
+    class _RecordingCopy:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return False
+
+        def write_row(self, row):
+            captured["rows"].append(tuple(row))
+
+    def _cur_copy(sql, *_):
+        captured["sql"] = sql
+        return _RecordingCopy()
+
+    mock_cursor = MagicMock()
+    mock_cursor.copy.side_effect = _cur_copy
+    mock_conn = MagicMock()
+    mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
+    mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+    return mock_conn, captured
+
+
+class TestImportCsvDedupKeepsExtraRows:
+    """Regression for WXYC/discogs-etl#293: the loader dedup key must include
+    ``extra`` so a same-name main-performer row (``extra=0``) and a role-bearing
+    extra-credit row (``extra=1``) both survive.
+
+    The converter writes the ``extra=0`` row before the ``extra=1`` row, and the
+    loader keeps the first occurrence per ``unique_key``. With ``extra`` omitted
+    from the key, a person credited as both the main artist and a release- (or
+    track-) level extra — e.g. a singer-songwriter who is also ``Written-By`` —
+    loses the second, role-bearing row. Widening the key on ``extra`` mirrors the
+    converter's direct-PG ``WideArtistDedup`` / ``WideTrackArtistDedup``
+    (WXYC/discogs-xml-converter#74), converging the CSV→loader path with it.
+    """
+
+    def test_release_artist_keeps_same_name_main_and_extra_credit(self, tmp_path) -> None:
+        """``release_artist``: a same-name ``extra=0`` row and ``extra=1`` (role)
+        row both load, against the real table config; the writer role survives."""
+        ra_config = next(t for t in BASE_TABLES if t["table"] == "release_artist")
+        csv_path = tmp_path / "release_artist.csv"
+        # Same person, same name/id: credited as the main performer (extra=0)
+        # and as the release-level writer (extra=1, Written-By).
+        csv_path.write_text(
+            "release_id,artist_id,artist_name,extra,role\n"
+            "9100,10,Stereolab,0,\n"
+            "9100,10,Stereolab,1,Written-By\n"
+        )
+
+        conn, captured = _make_recording_conn()
+        count = import_csv(
+            conn,
+            csv_path,
+            table=ra_config["table"],
+            csv_columns=ra_config["csv_columns"],
+            db_columns=ra_config["db_columns"],
+            required_columns=ra_config["required"],
+            transforms=ra_config["transforms"],
+            unique_key=ra_config["unique_key"],
+            optional_csv_columns=ra_config.get("optional_csv_columns"),
+        )
+
+        assert count == 2
+        assert "release_id, artist_id, artist_name, extra, role" in captured["sql"]
+        assert captured["rows"][0] == ("9100", "10", "Stereolab", "0", None)
+        assert captured["rows"][1] == ("9100", "10", "Stereolab", "1", "Written-By")
+
+    def test_release_track_artist_keeps_same_name_main_and_extra_credit(self, tmp_path) -> None:
+        """``release_track_artist`` at ``(release_id, track_sequence)`` scope: a
+        same-name ``extra=0`` and ``extra=1`` (role) pair both survive; the
+        per-track role lives. Exercises the real config, where ``extra`` is an
+        optional column the loader must fold into the dedup key only when present."""
+        rta_config = next(t for t in TRACK_TABLES if t["table"] == "release_track_artist")
+        csv_path = tmp_path / "release_track_artist.csv"
+        csv_path.write_text(
+            "release_id,track_sequence,artist_name,extra,role\n"
+            "674529,5,Alex Paterson,0,\n"
+            "674529,5,Alex Paterson,1,Producer\n"
+        )
+
+        conn, captured = _make_recording_conn()
+        count = import_csv(
+            conn,
+            csv_path,
+            table=rta_config["table"],
+            csv_columns=rta_config["csv_columns"],
+            db_columns=rta_config["db_columns"],
+            required_columns=rta_config["required"],
+            transforms=rta_config["transforms"],
+            unique_key=rta_config["unique_key"],
+            optional_csv_columns=rta_config.get("optional_csv_columns"),
+        )
+
+        assert count == 2
+        assert "release_id, track_sequence, artist_name, extra, role" in captured["sql"]
+        assert captured["rows"][0] == ("674529", "5", "Alex Paterson", "0", None)
+        assert captured["rows"][1] == ("674529", "5", "Alex Paterson", "1", "Producer")
+
+    def test_release_track_artist_without_extra_column_dedups_three_col(self, tmp_path) -> None:
+        """A ``release_track_artist`` CSV lacking the optional ``extra`` column
+        must still load: the dedup key falls back to ``(release_id,
+        track_sequence, artist_name)`` and absent columns take the PG default.
+
+        Pins that the #293 fix widens the key on ``extra`` only when the header
+        carries it — a static add to this table's ``unique_key`` would
+        ``ValueError`` here, the exact backward-compat case ``optional_csv_columns``
+        exists to tolerate."""
+        rta_config = next(t for t in TRACK_TABLES if t["table"] == "release_track_artist")
+        csv_path = tmp_path / "release_track_artist.csv"
+        csv_path.write_text(
+            "release_id,track_sequence,artist_name\n"
+            "674529,5,Alex Paterson\n"
+            "674529,5,Alex Paterson\n"
+        )
+
+        conn, captured = _make_recording_conn()
+        count = import_csv(
+            conn,
+            csv_path,
+            table=rta_config["table"],
+            csv_columns=rta_config["csv_columns"],
+            db_columns=rta_config["db_columns"],
+            required_columns=rta_config["required"],
+            transforms=rta_config["transforms"],
+            unique_key=rta_config["unique_key"],
+            optional_csv_columns=rta_config.get("optional_csv_columns"),
+        )
+
+        # The 3-column dedup collapses the exact duplicate to a single row.
+        assert count == 1
+        assert "extra" not in captured["sql"]
+        assert captured["rows"][0] == ("674529", "5", "Alex Paterson")
+
+    def test_release_artist_unique_key_includes_extra(self) -> None:
+        """Pin the config: ``release_artist`` dedups on ``(release_id,
+        artist_name, extra)``. ``extra`` is a hard ``csv_columns`` entry here, so
+        the static key add is crash-safe (unlike the optional-column track table)."""
+        ra_config = next(t for t in BASE_TABLES if t["table"] == "release_artist")
+        assert ra_config["unique_key"] == ["release_id", "artist_name", "extra"]
+
+
 class TestImportCsvMissingColumns:
     """import_csv reports clear errors when CSV header is missing expected columns."""
 


### PR DESCRIPTION
## What

The CSV loader (`scripts/import_csv.py`) deduped `release_artist` on `(release_id, artist_name)` and `release_track_artist` on `(release_id, track_sequence, artist_name)`, omitting `extra`. The converter writes the main-artist row (`extra=0`) before the extra-credit row (`extra=1`), and the loader keeps the first occurrence per `unique_key`, so a person credited as both the main artist and a release- or track-level extra — e.g. a singer-songwriter who is also `Written-By` — lost the second, role-bearing row and its `role` silently.

`release_track_artist` has read `role` since #218 and `release_artist` since #292, so the loss was live on the prod CSV-import path for **both** tables, and it diverged from the direct-PG ingest path that WXYC/discogs-xml-converter#74 already widened.

## Fix

Widen the dedup key on `extra`, converging the CSV→loader path with the converter's `WideArtistDedup` / `WideTrackArtistDedup`:

- **`release_artist`**: `extra` is a hard `csv_columns` entry, so it joins the static `unique_key` directly → `(release_id, artist_name, extra)`. Crash-safe.
- **`release_track_artist`**: `extra` is an *optional* column, so a static add would `ValueError` on a CSV that lacks it (the backward-compat case `optional_csv_columns` exists to tolerate). The key is widened **at runtime only when the header carries `extra`**; otherwise it falls through to the 3-column key and the PG `extra=0` default → `(release_id, track_sequence, artist_name, extra)` when present.

Scoped to `extra` (a 0/1 flag), **not** `role`, so an artist holding multiple distinct extra roles on one release still keeps the first-seen role — intentional, to stay converged with the converter. The change is additive: no `WHERE extra=0` consumer result changes (LML, semantic-index, Backend-Service, catalog-audits all verified in the ticket); row counts for the two tables rise slightly after the next rebuild.

## Tests

TDD — failing tests written first, then the fix.

- **Unit** (`tests/unit/test_import_csv.py`, `TestImportCsvDedupKeepsExtraRows`): same-name `extra=0` + `extra=1` (role) loads both rows for each table against the real config; a `release_track_artist` CSV lacking `extra` still dedups on the 3-column key with no crash; pins `release_artist.unique_key`.
- **Integration / pg** (`tests/integration/test_import.py`, `TestImportCsvKeepsExtraRows`): both rows actually land in a real PostgreSQL table with the `role` persisted, for both tables.

Local: `ruff check .` + `ruff format --check .` clean; full unit suite green (816 passed); the new + existing import/dedup pg tests pass against a local PG 16. (The unrelated alembic/`wxyc_library_v2` pg tests fail only locally — they need the `wxyc-postgres` image's `wxyc_unaccent.rules`; they pass in CI.)

Closes #293