### PR TITLE
fix(#293): add extra to the CSV loader dedup key so role-bearing extra rows survive

### DIFF
--- a/scripts/import_csv.py
+++ b/scripts/import_csv.py
@@ -88,6 +88,14 @@ class TableConfig(TypedDict, total=False):
     # CSVs should fall through to the DB-side default — e.g. ``extra``
     # and ``role`` on ``release_track_artist`` per WXYC/discogs-etl#218.
     optional_csv_columns: list[str]
+    # ``optional_unique_key``: optional columns that should join the dedup
+    # ``unique_key`` *only when present in the CSV header* (i.e. a subset of
+    # ``optional_csv_columns`` that are key-bearing). Lets a table widen its
+    # dedup key for new converter output without crashing legacy CSVs that
+    # lack the column — ``csv_columns.index(col)`` would raise. See
+    # WXYC/discogs-etl#293 and the converter's ``WideTrackArtistDedup``
+    # (discogs-xml-converter#74).
+    optional_unique_key: list[str]
 
 
 BASE_TABLES: list[TableConfig] = [
@@ -107,7 +115,15 @@ BASE_TABLES: list[TableConfig] = [
         "db_columns": ["release_id", "artist_id", "artist_name", "extra"],
         "required": ["release_id", "artist_name"],
         "transforms": {},
-        "unique_key": ["release_id", "artist_name"],
+        # ``extra`` is in the dedup key so a person who is both the main
+        # artist (``extra=0``) and a same-release extra credit (``extra=1``,
+        # e.g. ``Written-By``) keeps *both* rows — the converter writes the
+        # ``extra=0`` row first, and a key without ``extra`` would drop the
+        # role-bearing ``extra=1`` row (WXYC/discogs-etl#293). Safe as a
+        # static key because ``extra`` is always in ``csv_columns`` above
+        # (unlike ``release_track_artist``, where it is optional). Converges
+        # with the converter's ``WideArtistDedup`` (discogs-xml-converter#74).
+        "unique_key": ["release_id", "artist_name", "extra"],
         # The converter now emits the source ``<role>`` for release-level
         # extra credits (writer/composer/producer). ``role`` is listed as
         # OPTIONAL — not in the required ``csv_columns`` above — so the loader
@@ -175,6 +191,12 @@ TRACK_TABLES: list[TableConfig] = [
         # columns, which matches the legacy "everything was main credits"
         # interpretation under which existing consumers were operating.
         "optional_csv_columns": ["extra", "role"],
+        # Widen the dedup key with ``extra`` so a same-track main+extra credit
+        # for one person keeps both rows (WXYC/discogs-etl#293), but *only*
+        # when the column is present — a static ``extra`` key would crash a
+        # legacy 3-column CSV at ``csv_columns.index("extra")``. Mirrors the
+        # converter's ``WideTrackArtistDedup`` (discogs-xml-converter#74).
+        "optional_unique_key": ["extra"],
     },
 ]
 
@@ -372,6 +394,7 @@ def import_csv(
     id_filter: set[int] | None = None,
     id_filter_column: str | None = None,
     optional_csv_columns: list[str] | None = None,
+    optional_unique_key: list[str] | None = None,
 ) -> int:
     """Import a CSV file into a table, selecting only needed columns.
 
@@ -394,6 +417,12 @@ def import_csv(
     fall through to the DB-side default (``DEFAULT`` clause / NULL). Used
     for forward-compatibility with new converter columns (e.g. ``extra``
     / ``role`` on ``release_track_artist`` per WXYC/discogs-etl#218).
+
+    If ``optional_unique_key`` is provided, those columns are appended to
+    ``unique_key`` for the dedup — but only the ones that are actually
+    present in this CSV's header (a subset of ``optional_csv_columns``).
+    This lets a table widen its dedup key for new converter output without
+    crashing on a legacy CSV that lacks the column (WXYC/discogs-etl#293).
     """
     logger.info(f"Importing {csv_path.name} into {table}...")
 
@@ -420,6 +449,13 @@ def import_csv(
         if present_optional:
             csv_columns = list(csv_columns) + present_optional
             db_columns = list(db_columns) + present_optional
+            # Widen the dedup key with any optional key-columns that showed up
+            # this run (WXYC/discogs-etl#293). Scoped to present_optional so a
+            # CSV lacking the column keeps the static key and never hits the
+            # ValueError from csv_columns.index() on a missing column.
+            extra_key_cols = [c for c in (optional_unique_key or []) if c in present_optional]
+            if extra_key_cols and unique_key is not None:
+                unique_key = list(unique_key) + extra_key_cols
 
         db_col_list = ", ".join(db_columns)
 
@@ -831,6 +867,7 @@ def _import_tables(
             id_filter=id_filter,
             id_filter_column=id_filter_column,
             optional_csv_columns=table_config.get("optional_csv_columns"),
+            optional_unique_key=table_config.get("optional_unique_key"),
         )
         total += count
     return total
@@ -872,6 +909,7 @@ def _import_tables_parallel(
             unique_key=table_config.get("unique_key"),
             release_id_filter=release_id_filter,
             optional_csv_columns=table_config.get("optional_csv_columns"),
+            optional_unique_key=table_config.get("optional_unique_key"),
         )
         total += count
     conn.close()
@@ -894,6 +932,7 @@ def _import_tables_parallel(
             unique_key=table_config.get("unique_key"),
             release_id_filter=release_id_filter,
             optional_csv_columns=table_config.get("optional_csv_columns"),
+            optional_unique_key=table_config.get("optional_unique_key"),
         )
         child_conn.close()
         return count

--- a/tests/unit/test_import_csv.py
+++ b/tests/unit/test_import_csv.py
@@ -739,6 +739,242 @@ class TestImportCsvOptionalColumns:
         assert captured_rows[0] == ("9100", "10", "Stereolab", "0")
 
 
+def _recording_conn():
+    """Build a MagicMock conn whose ``cur.copy(...)`` records the COPY SQL and
+    every written row.
+
+    Returns ``(conn, captured)`` where ``captured["sql"]`` is the COPY
+    statement and ``captured["rows"]`` is the list of written row tuples,
+    both populated as ``import_csv`` runs. Mirrors the inline
+    ``_RecordingCopy`` spy used by ``TestImportCsvOptionalColumns``.
+    """
+    from unittest.mock import MagicMock
+
+    captured: dict = {"sql": None, "rows": []}
+
+    class _RecordingCopy:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return False
+
+        def write_row(self, row):
+            captured["rows"].append(tuple(row))
+
+    def _cur_copy(sql, *_):
+        captured["sql"] = sql
+        return _RecordingCopy()
+
+    mock_cursor = MagicMock()
+    mock_cursor.copy.side_effect = _cur_copy
+    mock_conn = MagicMock()
+    mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
+    mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+    return mock_conn, captured
+
+
+class TestImportCsvExtraDedupKey:
+    """WXYC/discogs-etl#293: the loader must keep a role-bearing ``extra=1``
+    row that collides on name with a same-release (or same-track) ``extra=0``
+    main-artist row.
+
+    The converter writes the main-artist row (``extra=0``) before the
+    extra-credit row (``extra=1``); the loader keeps the *first* occurrence of
+    each ``unique_key``. With ``extra`` absent from the key, a singer-songwriter
+    who is also ``Written-By`` lost the ``extra=1`` row — and its ``role``.
+    Widening the dedup key on ``extra`` converges the CSV->loader path (prod)
+    with the converter's direct-PG dedup (discogs-xml-converter#74's
+    ``WideArtistDedup`` / ``WideTrackArtistDedup``).
+
+    The same-name collision is the load-bearing fixture: the existing
+    optional-column tests use *two different* names (``The Orb`` / ``Alex
+    Paterson``), which never collide and so cannot reproduce the loss. These
+    tests use a self-credit collision (``Jessica Pratt`` at both ``extra=0``
+    and ``extra=1``), and pass a real ``unique_key`` so the dedup branch
+    actually runs.
+    """
+
+    def test_release_artist_keeps_same_name_extra_row(self, tmp_path) -> None:
+        """A ``release_artist`` CSV with the same name at ``extra=0`` and
+        ``extra=1`` (role) keeps **both** rows; the writer credit's ``role``
+        survives. Driven from the real config so the static ``unique_key``
+        widening is what makes this pass. RED on current ``main`` (1 row, role
+        lost), GREEN after widening the key with ``extra``."""
+        ra_config = next(t for t in BASE_TABLES if t["table"] == "release_artist")
+
+        csv_path = tmp_path / "release_artist.csv"
+        csv_path.write_text(
+            "release_id,artist_id,artist_name,extra,role\n"
+            "5512,1,Jessica Pratt,0,\n"
+            "5512,1,Jessica Pratt,1,Written-By\n"
+        )
+
+        conn, captured = _recording_conn()
+        count = import_csv(
+            conn,
+            csv_path,
+            table="release_artist",
+            csv_columns=ra_config["csv_columns"],
+            db_columns=ra_config["db_columns"],
+            required_columns=ra_config["required"],
+            transforms=ra_config["transforms"],
+            unique_key=ra_config["unique_key"],
+            optional_csv_columns=ra_config.get("optional_csv_columns"),
+        )
+
+        assert count == 2
+        assert captured["rows"][0] == ("5512", "1", "Jessica Pratt", "0", None)
+        assert captured["rows"][1] == ("5512", "1", "Jessica Pratt", "1", "Written-By")
+
+    def test_release_track_artist_keeps_same_name_extra_row(self, tmp_path) -> None:
+        """A ``release_track_artist`` CSV with the same name at one
+        ``(release_id, track_sequence)`` and both ``extra`` values keeps both
+        rows with the role preserved. Driven from the real config: the static
+        key stays ``(release_id, track_sequence, artist_name)`` and is widened
+        with ``extra`` only because the header carries it and the config opts
+        in via ``optional_unique_key``. RED on current ``main`` (no
+        ``optional_unique_key`` param / config), GREEN after."""
+        rta_config = next(t for t in TRACK_TABLES if t["table"] == "release_track_artist")
+
+        csv_path = tmp_path / "release_track_artist.csv"
+        csv_path.write_text(
+            "release_id,track_sequence,artist_name,extra,role\n"
+            "5512,3,Jessica Pratt,0,\n"
+            "5512,3,Jessica Pratt,1,Written-By\n"
+        )
+
+        conn, captured = _recording_conn()
+        count = import_csv(
+            conn,
+            csv_path,
+            table="release_track_artist",
+            csv_columns=rta_config["csv_columns"],
+            db_columns=rta_config["db_columns"],
+            required_columns=rta_config["required"],
+            transforms=rta_config["transforms"],
+            unique_key=rta_config["unique_key"],
+            optional_csv_columns=rta_config.get("optional_csv_columns"),
+            optional_unique_key=rta_config.get("optional_unique_key"),
+        )
+
+        assert count == 2
+        assert captured["rows"][0] == ("5512", "3", "Jessica Pratt", "0", None)
+        assert captured["rows"][1] == ("5512", "3", "Jessica Pratt", "1", "Written-By")
+
+    def test_release_track_artist_legacy_csv_without_extra_still_imports(self, tmp_path) -> None:
+        """The asymmetry guard: a legacy 3-column ``release_track_artist`` CSV
+        (no ``extra`` column) must still load even though the config now sets
+        ``optional_unique_key=["extra"]``. Because ``extra`` is absent from the
+        header it never joins the dedup key, so ``csv_columns.index("extra")``
+        is never reached and no ``ValueError`` is raised. The key falls back to
+        ``(release_id, track_sequence, artist_name)``, so a genuine duplicate
+        still collapses, and the COPY omits ``extra`` / ``role`` (PG defaults
+        apply). This is RED if anyone reverts the conditional path to a static
+        ``extra`` key."""
+        rta_config = next(t for t in TRACK_TABLES if t["table"] == "release_track_artist")
+
+        csv_path = tmp_path / "release_track_artist.csv"
+        csv_path.write_text(
+            "release_id,track_sequence,artist_name\n5512,3,Jessica Pratt\n5512,3,Jessica Pratt\n"
+        )
+
+        conn, captured = _recording_conn()
+        count = import_csv(
+            conn,
+            csv_path,
+            table="release_track_artist",
+            csv_columns=rta_config["csv_columns"],
+            db_columns=rta_config["db_columns"],
+            required_columns=rta_config["required"],
+            transforms=rta_config["transforms"],
+            unique_key=rta_config["unique_key"],
+            optional_csv_columns=rta_config.get("optional_csv_columns"),
+            optional_unique_key=rta_config.get("optional_unique_key"),
+        )
+
+        # Fallback dedup on (release_id, track_sequence, artist_name) collapses
+        # the two identical rows to one — no crash on the missing column.
+        assert count == 1
+        assert "extra" not in captured["sql"]
+        assert "role" not in captured["sql"]
+        assert captured["rows"][0] == ("5512", "3", "Jessica Pratt")
+
+    def test_release_artist_genuine_duplicate_still_collapses(self, tmp_path) -> None:
+        """Over-widening guard: two rows identical on ``(release_id,
+        artist_name, extra)`` are still a true duplicate and collapse to one.
+        Widening the key on ``extra`` must not turn genuine duplicates into
+        survivors."""
+        ra_config = next(t for t in BASE_TABLES if t["table"] == "release_artist")
+
+        csv_path = tmp_path / "release_artist.csv"
+        csv_path.write_text(
+            "release_id,artist_id,artist_name,extra,role\n"
+            "5512,1,Jessica Pratt,0,\n"
+            "5512,1,Jessica Pratt,0,\n"
+        )
+
+        conn, captured = _recording_conn()
+        count = import_csv(
+            conn,
+            csv_path,
+            table="release_artist",
+            csv_columns=ra_config["csv_columns"],
+            db_columns=ra_config["db_columns"],
+            required_columns=ra_config["required"],
+            transforms=ra_config["transforms"],
+            unique_key=ra_config["unique_key"],
+            optional_csv_columns=ra_config.get("optional_csv_columns"),
+        )
+
+        assert count == 1
+        assert captured["rows"][0] == ("5512", "1", "Jessica Pratt", "0", None)
+
+    def test_release_artist_different_names_kept_distinct(self, tmp_path) -> None:
+        """Sanity: two genuinely different artists at the same ``extra`` are
+        not duplicates and both survive — confirms the key was widened, not
+        broken."""
+        ra_config = next(t for t in BASE_TABLES if t["table"] == "release_artist")
+
+        csv_path = tmp_path / "release_artist.csv"
+        csv_path.write_text(
+            "release_id,artist_id,artist_name,extra,role\n"
+            "5512,1,Stereolab,0,\n"
+            "5512,2,Cat Power,0,\n"
+        )
+
+        conn, captured = _recording_conn()
+        count = import_csv(
+            conn,
+            csv_path,
+            table="release_artist",
+            csv_columns=ra_config["csv_columns"],
+            db_columns=ra_config["db_columns"],
+            required_columns=ra_config["required"],
+            transforms=ra_config["transforms"],
+            unique_key=ra_config["unique_key"],
+            optional_csv_columns=ra_config.get("optional_csv_columns"),
+        )
+
+        assert count == 2
+
+    def test_release_artist_config_unique_key_includes_extra(self) -> None:
+        """Config pin: ``release_artist`` dedups on ``extra`` so a future edit
+        that drops it from the static key trips this test rather than silently
+        reintroducing the loss. ``extra`` is a hard ``csv_columns`` entry, so
+        the static key is safe."""
+        ra_config = next(t for t in BASE_TABLES if t["table"] == "release_artist")
+        assert ra_config["unique_key"] == ["release_id", "artist_name", "extra"]
+
+    def test_release_track_artist_config_declares_optional_unique_key(self) -> None:
+        """Config pin: ``release_track_artist`` opts into widening the dedup key
+        with ``extra`` only when the column is present (the conditional path
+        that keeps legacy 3-column CSVs loading). Mirrors
+        ``WideTrackArtistDedup`` in discogs-xml-converter#74."""
+        rta_config = next(t for t in TRACK_TABLES if t["table"] == "release_track_artist")
+        assert rta_config.get("optional_unique_key") == ["extra"]
+
+
 class TestImportCsvMissingColumns:
     """import_csv reports clear errors when CSV header is missing expected columns."""
 

--- a/tests/unit/test_import_csv.py
+++ b/tests/unit/test_import_csv.py
@@ -522,8 +522,6 @@ class TestImportCsvOptionalColumns:
     def test_new_csv_with_optional_columns_appends_them_to_copy(self, tmp_path) -> None:
         """When the CSV header carries the optional columns, they are
         appended to the COPY column list and the values are written."""
-        from unittest.mock import MagicMock
-
         csv_path = tmp_path / "release_track_artist.csv"
         csv_path.write_text(
             "release_id,track_sequence,artist_name,extra,role\n"
@@ -531,31 +529,9 @@ class TestImportCsvOptionalColumns:
             "674529,5,Alex Paterson,1,Producer\n"
         )
 
-        captured_columns: dict[str, str] = {}
-        captured_rows: list[tuple] = []
-
-        class _RecordingCopy:
-            def __enter__(self):
-                return self
-
-            def __exit__(self, *exc):
-                return False
-
-            def write_row(self, row):
-                captured_rows.append(tuple(row))
-
-        def _cur_copy(sql, *_):
-            captured_columns["sql"] = sql
-            return _RecordingCopy()
-
-        mock_cursor = MagicMock()
-        mock_cursor.copy.side_effect = _cur_copy
-        mock_conn = MagicMock()
-        mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
-        mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
-
+        conn, captured = _recording_conn()
         count = import_csv(
-            mock_conn,
+            conn,
             csv_path,
             table="release_track_artist",
             csv_columns=["release_id", "track_sequence", "artist_name"],
@@ -567,45 +543,21 @@ class TestImportCsvOptionalColumns:
 
         assert count == 2
         # COPY SQL lists the optional columns
-        assert "release_id, track_sequence, artist_name, extra, role" in captured_columns["sql"]
+        assert "release_id, track_sequence, artist_name, extra, role" in captured["sql"]
         # Row values include the extra/role data
-        assert captured_rows[0] == ("674529", "5", "The Orb", "0", None)
-        assert captured_rows[1] == ("674529", "5", "Alex Paterson", "1", "Producer")
+        assert captured["rows"][0] == ("674529", "5", "The Orb", "0", None)
+        assert captured["rows"][1] == ("674529", "5", "Alex Paterson", "1", "Producer")
 
     def test_legacy_csv_without_optional_columns_still_imports(self, tmp_path) -> None:
         """A 3-column CSV from a pre-#55 converter must still load. The
         loader drops the optional columns from the COPY so the PG defaults
         (``extra=0``, ``role=NULL``) take over for absent values."""
-        from unittest.mock import MagicMock
-
         csv_path = tmp_path / "release_track_artist.csv"
         csv_path.write_text("release_id,track_sequence,artist_name\n674529,5,Alex Paterson\n")
 
-        captured_columns: dict[str, str] = {}
-        captured_rows: list[tuple] = []
-
-        class _RecordingCopy:
-            def __enter__(self):
-                return self
-
-            def __exit__(self, *exc):
-                return False
-
-            def write_row(self, row):
-                captured_rows.append(tuple(row))
-
-        def _cur_copy(sql, *_):
-            captured_columns["sql"] = sql
-            return _RecordingCopy()
-
-        mock_cursor = MagicMock()
-        mock_cursor.copy.side_effect = _cur_copy
-        mock_conn = MagicMock()
-        mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
-        mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
-
+        conn, captured = _recording_conn()
         count = import_csv(
-            mock_conn,
+            conn,
             csv_path,
             table="release_track_artist",
             csv_columns=["release_id", "track_sequence", "artist_name"],
@@ -617,10 +569,10 @@ class TestImportCsvOptionalColumns:
 
         assert count == 1
         # COPY SQL omits the optional columns; PG defaults take over.
-        assert "extra" not in captured_columns["sql"]
-        assert "role" not in captured_columns["sql"]
+        assert "extra" not in captured["sql"]
+        assert "role" not in captured["sql"]
         # Row has only the 3 base columns.
-        assert captured_rows[0] == ("674529", "5", "Alex Paterson")
+        assert captured["rows"][0] == ("674529", "5", "Alex Paterson")
 
     def test_release_track_artist_table_config_declares_extra_and_role(self) -> None:
         """Pin that the table config opts into the optional columns. If a
@@ -635,8 +587,6 @@ class TestImportCsvOptionalColumns:
         an empty role coerces to NULL, and main artists (extra=0) carry none.
         This is the release-level analogue of the per-track case above
         (WXYC/library-metadata-lookup#699)."""
-        from unittest.mock import MagicMock
-
         csv_path = tmp_path / "release_artist.csv"
         csv_path.write_text(
             "release_id,artist_id,artist_name,extra,role\n"
@@ -644,31 +594,9 @@ class TestImportCsvOptionalColumns:
             "9100,20,Tim Gane,1,Written-By\n"
         )
 
-        captured_columns: dict[str, str] = {}
-        captured_rows: list[tuple] = []
-
-        class _RecordingCopy:
-            def __enter__(self):
-                return self
-
-            def __exit__(self, *exc):
-                return False
-
-            def write_row(self, row):
-                captured_rows.append(tuple(row))
-
-        def _cur_copy(sql, *_):
-            captured_columns["sql"] = sql
-            return _RecordingCopy()
-
-        mock_cursor = MagicMock()
-        mock_cursor.copy.side_effect = _cur_copy
-        mock_conn = MagicMock()
-        mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
-        mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
-
+        conn, captured = _recording_conn()
         count = import_csv(
-            mock_conn,
+            conn,
             csv_path,
             table="release_artist",
             csv_columns=["release_id", "artist_id", "artist_name", "extra"],
@@ -680,10 +608,10 @@ class TestImportCsvOptionalColumns:
 
         assert count == 2
         # COPY SQL lists the optional role column.
-        assert "release_id, artist_id, artist_name, extra, role" in captured_columns["sql"]
+        assert "release_id, artist_id, artist_name, extra, role" in captured["sql"]
         # Main artist: empty role → NULL. Writer credit: source role preserved.
-        assert captured_rows[0] == ("9100", "10", "Stereolab", "0", None)
-        assert captured_rows[1] == ("9100", "20", "Tim Gane", "1", "Written-By")
+        assert captured["rows"][0] == ("9100", "10", "Stereolab", "0", None)
+        assert captured["rows"][1] == ("9100", "20", "Tim Gane", "1", "Written-By")
 
     def test_legacy_release_artist_csv_without_role_still_imports(self, tmp_path) -> None:
         """A pre-role ``release_artist`` CSV (no ``role`` column) must still
@@ -693,36 +621,12 @@ class TestImportCsvOptionalColumns:
         ``release_artist`` empty in the 2026-05-13 rebuild, pinned at the
         behavioral level (the config-pin tests above never run the loader).
         Release-level analogue of ``test_legacy_csv_without_optional_columns_still_imports``."""
-        from unittest.mock import MagicMock
-
         csv_path = tmp_path / "release_artist.csv"
         csv_path.write_text("release_id,artist_id,artist_name,extra\n9100,10,Stereolab,0\n")
 
-        captured_columns: dict[str, str] = {}
-        captured_rows: list[tuple] = []
-
-        class _RecordingCopy:
-            def __enter__(self):
-                return self
-
-            def __exit__(self, *exc):
-                return False
-
-            def write_row(self, row):
-                captured_rows.append(tuple(row))
-
-        def _cur_copy(sql, *_):
-            captured_columns["sql"] = sql
-            return _RecordingCopy()
-
-        mock_cursor = MagicMock()
-        mock_cursor.copy.side_effect = _cur_copy
-        mock_conn = MagicMock()
-        mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
-        mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
-
+        conn, captured = _recording_conn()
         count = import_csv(
-            mock_conn,
+            conn,
             csv_path,
             table="release_artist",
             csv_columns=["release_id", "artist_id", "artist_name", "extra"],
@@ -734,9 +638,9 @@ class TestImportCsvOptionalColumns:
 
         assert count == 1
         # COPY SQL omits the absent optional column; the schema NULL default takes over.
-        assert "role" not in captured_columns["sql"]
+        assert "role" not in captured["sql"]
         # Row has only the 4 base columns.
-        assert captured_rows[0] == ("9100", "10", "Stereolab", "0")
+        assert captured["rows"][0] == ("9100", "10", "Stereolab", "0")
 
 
 def _recording_conn():
@@ -833,8 +737,15 @@ class TestImportCsvExtraDedupKey:
         rows with the role preserved. Driven from the real config: the static
         key stays ``(release_id, track_sequence, artist_name)`` and is widened
         with ``extra`` only because the header carries it and the config opts
-        in via ``optional_unique_key``. RED on current ``main`` (no
-        ``optional_unique_key`` param / config), GREEN after."""
+        in via ``optional_unique_key``.
+
+        Note the RED differs from the ``release_artist`` case: on current
+        ``main`` this raises ``TypeError`` (the ``optional_unique_key`` param
+        does not exist yet), so it is the *missing param*, not the data loss,
+        that reds here. What it pins going forward is the conditional widening
+        itself — drop that logic but keep the param (a partial revert) and the
+        key falls back to ``(release_id, track_sequence, artist_name)``, the
+        two rows collapse, and ``assert count == 2`` fails."""
         rta_config = next(t for t in TRACK_TABLES if t["table"] == "release_track_artist")
 
         csv_path = tmp_path / "release_track_artist.csv"
@@ -901,17 +812,21 @@ class TestImportCsvExtraDedupKey:
         assert captured["rows"][0] == ("5512", "3", "Jessica Pratt")
 
     def test_release_artist_genuine_duplicate_still_collapses(self, tmp_path) -> None:
-        """Over-widening guard: two rows identical on ``(release_id,
-        artist_name, extra)`` are still a true duplicate and collapse to one.
-        Widening the key on ``extra`` must not turn genuine duplicates into
-        survivors."""
+        """Over-widening guard: two rows identical on the key ``(release_id,
+        artist_name, extra)`` collapse to one, keeping the first. The two rows
+        deliberately *differ* on the non-key columns ``artist_id`` (1 vs 2) and
+        ``role`` (``Vocals`` vs ``Guitar``) so that widening the key onto
+        either of those columns by mistake would split them into two rows and
+        fail this test — i.e. this catches over-widening on a column whose
+        value varies, not just on ``extra`` (which is constant here and already
+        in the key)."""
         ra_config = next(t for t in BASE_TABLES if t["table"] == "release_artist")
 
         csv_path = tmp_path / "release_artist.csv"
         csv_path.write_text(
             "release_id,artist_id,artist_name,extra,role\n"
-            "5512,1,Jessica Pratt,0,\n"
-            "5512,1,Jessica Pratt,0,\n"
+            "5512,1,Jessica Pratt,0,Vocals\n"
+            "5512,2,Jessica Pratt,0,Guitar\n"
         )
 
         conn, captured = _recording_conn()
@@ -928,7 +843,8 @@ class TestImportCsvExtraDedupKey:
         )
 
         assert count == 1
-        assert captured["rows"][0] == ("5512", "1", "Jessica Pratt", "0", None)
+        # First occurrence wins: the ``artist_id=1`` / ``role=Vocals`` row.
+        assert captured["rows"][0] == ("5512", "1", "Jessica Pratt", "0", "Vocals")
 
     def test_release_artist_different_names_kept_distinct(self, tmp_path) -> None:
         """Sanity: two genuinely different artists at the same ``extra`` are
@@ -956,7 +872,11 @@ class TestImportCsvExtraDedupKey:
             optional_csv_columns=ra_config.get("optional_csv_columns"),
         )
 
+        # Both distinct artists survive intact — assert the rows, not just the
+        # count, so a bug that wrote one row twice or mangled a name is caught.
         assert count == 2
+        assert captured["rows"][0] == ("5512", "1", "Stereolab", "0", None)
+        assert captured["rows"][1] == ("5512", "2", "Cat Power", "0", None)
 
     def test_release_artist_config_unique_key_includes_extra(self) -> None:
         """Config pin: ``release_artist`` dedups on ``extra`` so a future edit


### PR DESCRIPTION
Closes #293.

## Problem

The CSV loader (`scripts/import_csv.py`) dedups by keeping the **first** occurrence of each `unique_key`. The converter writes the main-artist row (`extra=0`) before the same-name extra-credit row (`extra=1`), and neither `release_artist` nor `release_track_artist` included `extra` in its dedup key:

- `release_artist`: `unique_key = ["release_id", "artist_name"]`
- `release_track_artist`: `unique_key = ["release_id", "track_sequence", "artist_name"]`

So when one person is both the main artist and a same-release (or same-track) extra credit — a singer-songwriter who is also `Written-By` — the `extra=0` row won and the role-bearing `extra=1` row was dropped, taking its `role` with it. `release_track_artist` has read `role` since #218; #292 extended `role` reading to `release_artist`, so the loss now applied to both.

This is the **production path**, not an edge tool: `import_release_via_upsert` TRUNCATEs the release child tables (both of these are in `_RELEASE_CHILD_TABLES`) and reloads each via `import_csv`, with every call site passing the config's `unique_key`. The converter's CSV writer does no in-memory dedup, so both rows reach the CSV intact — the loss was purely the loader's choice. The direct-PG ingest path was already fixed in [discogs-xml-converter#74](https://github.com/WXYC/discogs-xml-converter/pull/74); the two ingest modes had diverged. This re-converges them.

## The fix

Widen the dedup key on `extra`. The two tables are **asymmetric**, which turns a one-liner into a two-case fix:

1. **`release_artist` — static.** `extra` is a hard `csv_columns` entry, so `csv_columns.index("extra")` always resolves. The key becomes `["release_id", "artist_name", "extra"]`.
2. **`release_track_artist` — conditional.** `extra` is only an *optional* column here. A static `extra` key would raise `ValueError` on a legacy 3-column CSV that lacks the column (the exact pre-#55 backward-compat case `optional_csv_columns` exists to tolerate). Instead, a new `optional_unique_key` field on `TableConfig` (`["extra"]`) joins `extra` to the dedup key **only when the column is present in the header**, inside the existing `if present_optional:` block. `TableConfig` is `total=False`, so the new field is off-by-default for every other table.

The key widens on `extra` (a 0/1 flag), **not** `role` — matching the converter's `(release_id, name, extra)` key. An artist holding two distinct extra roles on one release (e.g. `Written-By` and `Producer`, both `extra=1`) still keeps only the first-seen role. Widening to `role` would *diverge* from direct-PG and is out of scope. Neither table has a UNIQUE/PK constraint, so widening the key only *keeps* rows — no constraint risk.

## Tests (TDD)

New cases in `tests/unit/test_import_csv.py` (`TestImportCsvExtraDedupKey`), each RED against `main` then GREEN after the fix. Two fixture differences from the existing optional-column tests are deliberate, because a verbatim copy would not reproduce the bug:

- **The existing optional-column tests pass no `unique_key`**, so the dedup branch never runs. The new tests pass a real `unique_key` (driven from the actual table config) so the dedup actually exercises.
- **The existing tests use two *different* names** (`The Orb` / `Alex Paterson`), which never collide. The loss only occurs on a same-name self-credit collision, so the repro fixture uses `Jessica Pratt` at both `extra=0` and `extra=1` (WXYC-representative per CLAUDE.md).

Coverage: both tables keep both rows with `role` preserved; the legacy 3-column track CSV still loads without `ValueError` and falls back to the base key (the asymmetry guard); genuine duplicates still collapse and different names stay distinct (we widened, not broke, the key); and config pins so a future edit that drops either key-widening trips a test. These are pure unit tests on the existing recording-copy spy — no `pg` marker needed.

## Impact

**Additive and small.** Row counts for the two tables rise slightly on the next rebuild (only self-credit collisions add rows). Downstream `WHERE extra=0` behavior is unchanged — keeping more `extra=1` rows changes no `extra=0` result. No backfill needed: the next normal rebuild reloads both tables from CSV and picks up the preserved rows. This unblocks the release-level composer fallback in [library-metadata-lookup#699](https://github.com/WXYC/library-metadata-lookup/issues/699).

## Checks

`ruff check .`, `ruff format --check .`, and the full unit suite (`pytest tests/unit/`, 820 passed) all green locally.