### PR TITLE
Guard the rebuild against a partial-reload empty-child-index state (#298)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ CLAUDE.md is a router for the always-loaded reference card. Topic depth lives in
 - **[`docs/observability.md`](docs/observability.md)** — `lib.observability` shim, JSON logger contract tags (`repo`, `tool`, `step`, `run_id`), `SENTRY_DSN` wiring, list of scripts that init the logger
 - **[`docs/test-fixtures.md`](docs/test-fixtures.md)** — Inline fixture data (CSV row examples for `release`, `release_artist`, `release_label`, `release_track`, `release_track_artist`, `library_artists.txt`, SQLite `library`) keyed off the canonical WXYC example artists
 
-Operator-facing runbooks live alongside in `docs/`: [`migrations-runbook.md`](docs/migrations-runbook.md), [`ec2-rebuild-runbook.md`](docs/ec2-rebuild-runbook.md), [`topup-artwork-runbook.md`](docs/topup-artwork-runbook.md), [`discogs-etl-technical-overview.md`](docs/discogs-etl-technical-overview.md), [`plan-223-wxyc-unaccent-railway-fix.md`](docs/plan-223-wxyc-unaccent-railway-fix.md), [`plan-multi-artist-splitting.md`](docs/plan-multi-artist-splitting.md).
+Operator-facing runbooks live alongside in `docs/`: [`migrations-runbook.md`](docs/migrations-runbook.md), [`ec2-rebuild-runbook.md`](docs/ec2-rebuild-runbook.md), [`topup-artwork-runbook.md`](docs/topup-artwork-runbook.md), [`discogs-etl-technical-overview.md`](docs/discogs-etl-technical-overview.md), [`plan-223-wxyc-unaccent-railway-fix.md`](docs/plan-223-wxyc-unaccent-railway-fix.md), [`plan-multi-artist-splitting.md`](docs/plan-multi-artist-splitting.md), [`plan-298-empty-child-index-recovery.md`](docs/plan-298-empty-child-index-recovery.md).
 
 Read the relevant topic doc before doing work in that area.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -65,6 +65,8 @@ The monthly rebuild is incremental by default: `release.artwork_url` and `releas
 2. `scripts/import_csv.py:import_release_via_upsert` reloads `release` via staging-table COPY + UPSERT with `artwork_url` + `artwork_checked_at` excluded from the SET list. Releases that fall out of the new dump are pruned via `DELETE … WHERE id NOT IN staging`; FK `ON DELETE CASCADE` removes their child rows. Child tables of `release` (`release_artist` + siblings, plus `cache_metadata`) are TRUNCATEd before re-COPY so duplicates don't accumulate.
 3. `scripts/import_csv.py:import_artwork` also stamps `artwork_checked_at = now()` whenever it sets `artwork_url` from the dump — matches the semantics LML's runtime `write_release` applies (LML#423) so freshly-imported rows aren't treated as "never asked" on the first lookup.
 
+**Reload invariant (discogs-etl#298)**: because the children are TRUNCATEd up front (step 2) and reloaded across several later steps, a run that aborts in that window leaves `release` full but the children empty — a state a naive row-count check reads as healthy. `scripts/run_pipeline.py` brackets the reload with a coverage check (`MIN_CHILD_COVERAGE_RATIO`, `evaluate_reload_invariant`): a **preflight** warning before the truncate if a prior abort left the cache degraded, and a **strict post-reload gate** before `report_sizes` that raises if `release` is populated but `release_track` / `release_artist` fall below the floor. Recovery: [`plan-298-empty-child-index-recovery.md`](plan-298-empty-child-index-recovery.md).
+
 Semantics matrix for `scripts/run_pipeline.py`:
 
 | Flag | Schema | Data | LML back-patches |

--- a/docs/ec2-rebuild-runbook.md
+++ b/docs/ec2-rebuild-runbook.md
@@ -280,6 +280,24 @@ move the cache off Railway.
 The destination DB hasn't been alembic-stamped. Apply the procedure in
 [`docs/migrations-runbook.md`](migrations-runbook.md) once.
 
+### Run fails with `[#298] cache reload invariant violated`
+
+The post-reload gate in `run_pipeline.py` found `release` populated but the
+`release_*` children empty (or below the `MIN_CHILD_COVERAGE_RATIO` floor) — a
+partial reload that would leave LML track search degraded. This is a loud,
+deliberate failure, not a false alarm. Do **not** re-dispatch blindly; the same
+empty-index state would just recur. See
+[`plan-298-empty-child-index-recovery.md`](plan-298-empty-child-index-recovery.md)
+for detection queries and the rotate-token → one-full-rebuild recovery. A
+`[#298] ... violated on entry` WARNING (not a failure) means a *prior* abort
+left the cache degraded and this run is repopulating it — expect the
+`:white_check_mark:` if it completes.
+
+### The cache has a full `release` but an empty track/artist index
+
+Independent of a running rebuild (e.g. reported as degraded LML track search).
+See [`plan-298-empty-child-index-recovery.md`](plan-298-empty-child-index-recovery.md).
+
 ## Decommissioning the legacy cron
 
 After two successful rebuilds via the ephemeral path

--- a/docs/plan-298-empty-child-index-recovery.md
+++ b/docs/plan-298-empty-child-index-recovery.md
@@ -1,0 +1,74 @@
+# discogs-etl#298 — empty track/artist index recovery — operator runbook
+
+The prod discogs-cache can end up with `release` fully populated but the `release_*` child tables (chiefly `release_track` / `release_artist`) empty. This runbook explains how to detect that state, why it happens, and how to recover. It pairs with the code guardrail shipped for [discogs-etl#298](https://github.com/WXYC/discogs-etl/issues/298), which makes the state loud instead of silent.
+
+## Symptom
+
+LML track search (`search_releases_by_track` → `TRACK_ON_COMPILATION`, `SONG_AS_TRACK`, `resolve_release_for_track`) is broadly degraded: album-less `/lookup`s surface thin write-back-only matches (e.g. a remix) instead of the in-library original. The tell is a `release`-full / children-empty cache.
+
+## Detection
+
+```bash
+psql "$DATABASE_URL_DISCOGS" -c "
+  SELECT (SELECT count(*)                     FROM release)        AS releases,
+         (SELECT count(DISTINCT release_id)   FROM release_track)  AS track_releases,
+         (SELECT count(DISTINCT release_id)   FROM release_artist) AS artist_releases;
+"
+```
+
+Healthy: `track_releases` and `artist_releases` are on the same order as `releases` (near 1:1 — every Discogs release carries ≥1 artist credit and essentially a tracklist). Degraded: the child counts are a tiny fraction (the [#298](https://github.com/WXYC/discogs-etl/issues/298) incident was 1,839 of 258,990 ≈ 0.7%, and those were only the rows LML's runtime `write_release` back-patched, all stamped in the current month).
+
+The guardrail now surfaces this automatically (see "What the guardrail does" below), but this query is the direct check.
+
+## Root cause
+
+`release` is upsert-not-truncate by design ([#252](https://github.com/WXYC/discogs-etl/issues/252)) so a rebuild preserves LML's runtime artwork back-patches. But the base stage (`scripts/import_csv.py:import_release_via_upsert`) `TRUNCATE ... CASCADE`s every `release_*` child table in a committed transaction and only reloads them across several later steps (`--base-only` children, then `dedup`, then `--tracks-only`). A run that aborts anywhere in that window leaves `release` full and the children empty — a state a naive row-count check reads as healthy.
+
+The end-of-run drift watchdog (`scripts/check_cache_drift.py`, invoked at `scripts/rebuild-cache.sh:333`) runs only after a *fully successful* pipeline, so a mid-run abort never triggers it. And no rebuild could self-heal while [#296](https://github.com/WXYC/discogs-etl/issues/296) (expired `GH_TOKEN`) blocked every monthly tick.
+
+## Recovery — there is no shortcut
+
+The child-table CSVs are converter-derived into an ephemeral `TemporaryDirectory` (deleted on exit), so there is no persisted artifact to re-import. The only safe, bounded path is: **rotate the expired PAT, then run one full rebuild.** The default rebuild path is idempotent and repopulates all children.
+
+> **Do NOT** run `import_csv.py --truncate-existing` against the base tables to "just reload." That wipes LML's artwork back-patches ([#252](https://github.com/WXYC/discogs-etl/issues/252)). If you must do a targeted child-only reload with fresh CSVs, use `--base-only` then `--tracks-only` **without** `--truncate-existing`, which preserves `release`.
+
+### 1. Rotate `GH_TOKEN` (unblocks [#296](https://github.com/WXYC/discogs-etl/issues/296))
+
+Replace the SSM SecureString at `/wxyc/discogs-rebuild/GH_TOKEN` (account `503977661500`) with a fresh fine-grained PAT granting `contents: read` on `WXYC/library-metadata-lookup` and `WXYC/discogs-xml-converter` (both needed by the two `gh release download` calls). No code change. See [`ec2-rebuild-runbook.md` → "`gh release download` fails with `HTTP 401`"](ec2-rebuild-runbook.md).
+
+```bash
+aws ssm put-parameter \
+  --name /wxyc/discogs-rebuild/GH_TOKEN \
+  --type SecureString \
+  --overwrite \
+  --value '<fresh-fine-grained-PAT>'
+```
+
+Set a calendar reminder for the PAT's expiry — this failure is only visible via the `:warning:` Slack post and the S3 log.
+
+### 2. Trigger one full rebuild
+
+Dispatch the ephemeral rebuild (EventBridge normally fires it monthly at `cron(0 6 4 * ? *)`; trigger it manually now). Follow the dispatch + monitoring procedure in [`ec2-rebuild-runbook.md`](ec2-rebuild-runbook.md). The run uses the default idempotent path (no `--truncate-existing`) — `import_release_via_upsert` upserts `release` while the `--base-only` / `dedup` / `--tracks-only` steps rebuild the children.
+
+Watch for the new preflight and post-reload log lines (`step=reload_invariant`) and the `:white_check_mark:` Slack success. A `:warning:` with `[#298] cache reload invariant violated` on the strict gate means the run finished with an empty index — investigate before retrying; do not paper over it by re-dispatching.
+
+### 3. Verify recovery
+
+Re-run the detection query — `track_releases` / `artist_releases` should be back on the order of `releases`.
+
+Then confirm the acceptance repro. A `/lookup` for **"me and mr. jones by plug"** (album-less) should return the in-library original *Drum 'n' Bass for Papa* (Discogs release `3192` → WXYC library id `38167`), not the row-less non-library remix *Me & Mr Sutton* (Discogs release `1643641`). Replaying LML's `search_releases_by_track` against the cache should now surface release `3192` from its repopulated `release_track` row for "Me & Mr Jones".
+
+## What the guardrail does (post-#298)
+
+`scripts/run_pipeline.py` now brackets the reload with a `release`-vs-children coverage invariant (`MIN_CHILD_COVERAGE_RATIO`, `evaluate_reload_invariant`):
+
+- **Preflight (warn):** before the truncating base step, if the DB is already in the `release`-full / children-empty state a prior abort left, it logs a loud `[#298] ... invariant violated on entry (recovering this run)` WARNING (`step=reload_invariant`). It does not raise — this run is about to repopulate — so operators see recovery is under way.
+- **Post-reload gate (raise):** after `set_tables_logged`, before `report_sizes` and the `:white_check_mark:`, it re-checks the final state consumers will read. A violation (e.g. an empty/missing tracks CSV COPYed as zero rows) raises, so the run fails **before** reporting success.
+
+Together these mean a partial-rebuild abort can no longer leave a `release`-full / children-empty state undetected.
+
+## Related
+
+- [#296](https://github.com/WXYC/discogs-etl/issues/296) — expired `GH_TOKEN`; must be rotated before any rebuild can complete.
+- [#252](https://github.com/WXYC/discogs-etl/issues/252) — why `release` is upsert-not-truncate.
+- [#226](https://github.com/WXYC/discogs-etl/issues/226) — the drift-watchdog gap (extends `check_cache_drift.py`); complementary to this guardrail.

--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -33,8 +33,8 @@ import subprocess
 import sys
 import tempfile
 import time
-from dataclasses import dataclass
 from pathlib import Path
+from typing import NamedTuple
 
 import psycopg
 from wxyc_etl.state import PipelineState
@@ -546,9 +546,16 @@ def report_sizes(db_url: str) -> None:
     conn.close()
 
 
-@dataclass(frozen=True)
-class ReloadInvariantResult:
+class ReloadInvariantResult(NamedTuple):
     """Outcome of the release-vs-children reload invariant (discogs-etl#298).
+
+    A ``NamedTuple`` rather than a ``@dataclass`` on purpose: several test
+    modules load ``run_pipeline`` via ``importlib`` without registering it in
+    ``sys.modules``, and under ``from __future__ import annotations`` the
+    dataclass machinery looks the module up there (``_is_type`` →
+    ``sys.modules.get(cls.__module__)``) and blows up at class-creation time.
+    ``NamedTuple`` resolves field names without that lookup, so it is robust to
+    any loader.
 
     Attributes:
         ok: True when child coverage meets the floor (or the cache is empty).

--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -33,6 +33,7 @@ import subprocess
 import sys
 import tempfile
 import time
+from dataclasses import dataclass
 from pathlib import Path
 
 import psycopg
@@ -60,6 +61,16 @@ SCHEMA_DIR = SCRIPT_DIR.parent / "schema"
 
 # Maximum seconds to wait for Postgres to become ready.
 PG_CONNECT_TIMEOUT = 30
+
+# Minimum fraction of ``release`` rows that must be covered by child-table
+# rows for the reload invariant to hold (discogs-etl#298). Every Discogs
+# release carries >=1 artist credit and (essentially) a tracklist, so a healthy
+# WXYC-filtered cache sits near 100% coverage for both children. The documented
+# catastrophe — a partial-rebuild abort that TRUNCATEd the children but never
+# reloaded them — was 0.7%. This floor sits comfortably between, so it catches
+# the empty-index state without false-positiving a legitimate rebuild (a false
+# positive would hard-fail the whole monthly rebuild).
+MIN_CHILD_COVERAGE_RATIO = 0.5
 
 # Tables managed by the pipeline (shared by run_vacuum, set_tables_unlogged,
 # set_tables_logged).
@@ -533,6 +544,170 @@ def report_sizes(db_url: str) -> None:
         for row in cur.fetchall():
             logger.info("  %-25s %10s rows   %s", row[0], f"{row[1]:,}", row[2])
     conn.close()
+
+
+@dataclass(frozen=True)
+class ReloadInvariantResult:
+    """Outcome of the release-vs-children reload invariant (discogs-etl#298).
+
+    Attributes:
+        ok: True when child coverage meets the floor (or the cache is empty).
+        release_count: rows in ``release``.
+        artist_coverage: distinct-release coverage of ``release_artist``
+            (``distinct release_id / release_count``), or ``None`` when the
+            cache is empty and coverage is undefined.
+        track_coverage: distinct-release coverage of ``release_track``, or
+            ``None`` when undefined.
+        reason: human-readable explanation naming the offending child
+            table(s); empty string when ``ok``.
+    """
+
+    ok: bool
+    release_count: int
+    artist_coverage: float | None
+    track_coverage: float | None
+    reason: str = ""
+
+
+def evaluate_reload_invariant(
+    *,
+    release_count: int,
+    artist_release_count: int,
+    track_release_count: int,
+    min_ratio: float = MIN_CHILD_COVERAGE_RATIO,
+) -> ReloadInvariantResult:
+    """Decide whether the ``release_*`` children cover enough of ``release``.
+
+    A partial-rebuild abort can leave ``release`` fully populated while the
+    child tables sit empty (they are TRUNCATEd up front, then reloaded across
+    later steps). This compares each child's distinct-release coverage against
+    ``release`` and flags the state when either falls below ``min_ratio``.
+
+    An empty cache (``release_count <= 0``) is a legitimate state — a fresh or
+    pre-import DB, or a ``--fresh-rebuild`` — so the invariant holds trivially.
+
+    Args:
+        release_count: rows in ``release``.
+        artist_release_count: distinct ``release_id`` in ``release_artist``.
+        track_release_count: distinct ``release_id`` in ``release_track``.
+        min_ratio: minimum acceptable ``child_releases / release_count``.
+
+    Returns:
+        A ``ReloadInvariantResult``.
+    """
+    if release_count <= 0:
+        return ReloadInvariantResult(
+            ok=True, release_count=release_count, artist_coverage=None, track_coverage=None
+        )
+
+    artist_coverage = artist_release_count / release_count
+    track_coverage = track_release_count / release_count
+
+    problems: list[str] = []
+    if artist_coverage < min_ratio:
+        problems.append(
+            f"release_artist covers {artist_coverage:.1%} of releases "
+            f"({artist_release_count:,}/{release_count:,})"
+        )
+    if track_coverage < min_ratio:
+        problems.append(
+            f"release_track covers {track_coverage:.1%} of releases "
+            f"({track_release_count:,}/{release_count:,})"
+        )
+
+    if problems:
+        return ReloadInvariantResult(
+            ok=False,
+            release_count=release_count,
+            artist_coverage=artist_coverage,
+            track_coverage=track_coverage,
+            reason=(
+                "; ".join(problems)
+                + f" — below the {min_ratio:.0%} floor. A partial-rebuild abort "
+                "likely TRUNCATEd the release_* children without reloading them."
+            ),
+        )
+
+    return ReloadInvariantResult(
+        ok=True,
+        release_count=release_count,
+        artist_coverage=artist_coverage,
+        track_coverage=track_coverage,
+    )
+
+
+def count_child_coverage(db_url: str) -> tuple[int, int, int]:
+    """Return ``(release_count, artist_release_count, track_release_count)``.
+
+    ``artist_release_count`` / ``track_release_count`` are the distinct
+    ``release_id`` counts in ``release_artist`` / ``release_track``. When the
+    ``release`` table does not exist yet (a fresh DB, before create_schema),
+    returns ``(0, 0, 0)`` so the preflight can run unconditionally.
+
+    Queries scan indexed columns on a ≤~260K-release cache — sub-second.
+    """
+    conn = psycopg.connect(db_url)
+    try:
+        with conn.cursor() as cur:
+            cur.execute("SELECT to_regclass('release')")
+            if cur.fetchone()[0] is None:
+                return (0, 0, 0)
+            cur.execute("SELECT count(*) FROM release")
+            release_count = cur.fetchone()[0]
+            cur.execute("SELECT count(DISTINCT release_id) FROM release_artist")
+            artist_release_count = cur.fetchone()[0]
+            cur.execute("SELECT count(DISTINCT release_id) FROM release_track")
+            track_release_count = cur.fetchone()[0]
+            return (release_count, artist_release_count, track_release_count)
+    finally:
+        conn.close()
+
+
+def check_reload_invariant(
+    db_url: str,
+    *,
+    raise_on_violation: bool,
+    min_ratio: float = MIN_CHILD_COVERAGE_RATIO,
+) -> ReloadInvariantResult:
+    """Read child coverage and enforce the reload invariant (discogs-etl#298).
+
+    ``raise_on_violation`` picks the failure mode:
+
+    * ``False`` (preflight, before the truncating base step): a violation
+      means a *prior* run left the ``release``-full / children-empty state.
+      This run is about to repopulate, so we log a loud WARNING (operators
+      see recovery is happening) and continue.
+    * ``True`` (post-reload gate, before ``report_sizes`` / the success
+      notification): a violation means *this* run finished with an empty
+      index — e.g. an empty/missing tracks CSV COPYed as zero rows. Raise so
+      the run fails before it reports success.
+    """
+    release_count, artist_release_count, track_release_count = count_child_coverage(db_url)
+    result = evaluate_reload_invariant(
+        release_count=release_count,
+        artist_release_count=artist_release_count,
+        track_release_count=track_release_count,
+        min_ratio=min_ratio,
+    )
+    if result.ok:
+        logger.info(
+            "reload invariant healthy: release=%d artist_cov=%s track_cov=%s",
+            result.release_count,
+            f"{result.artist_coverage:.1%}" if result.artist_coverage is not None else "n/a",
+            f"{result.track_coverage:.1%}" if result.track_coverage is not None else "n/a",
+            extra={"step": "reload_invariant"},
+        )
+        return result
+
+    if raise_on_violation:
+        raise RuntimeError(f"[#298] cache reload invariant violated: {result.reason}")
+
+    logger.warning(
+        "[#298] cache reload invariant violated on entry (recovering this run): %s",
+        result.reason,
+        extra={"step": "reload_invariant"},
+    )
+    return result
 
 
 def convert_and_filter(
@@ -1013,6 +1188,9 @@ def _run_database_build_post_import(
     # -- set_tables_logged (restore WAL durability for consumers)
     set_tables_logged(db_url)
 
+    # -- reload-invariant gate (discogs-etl#298) — see _run_database_build.
+    check_reload_invariant(db_url, raise_on_violation=True)
+
     # -- report
     report_sizes(db_url)
 
@@ -1078,6 +1256,16 @@ def _run_database_build(
         if state:
             state.mark_completed("create_schema")
             _save_state()
+
+    # -- reload-invariant preflight (discogs-etl#298)
+    # The base step below TRUNCATEs the release_* children in a committed
+    # transaction, then reloads them across several later steps. Before we do
+    # that, check whether the *current* DB is already in the release-full /
+    # children-empty state a prior partial-rebuild abort would have left. We
+    # warn rather than raise — this run is about to repopulate — so operators
+    # see that recovery is under way. Runs after create_schema so the tables
+    # exist; count_child_coverage tolerates a not-yet-created schema anyway.
+    check_reload_invariant(db_url, raise_on_violation=False)
 
     # -- set_tables_unlogged (skip WAL writes during bulk import)
     set_tables_unlogged(db_url)
@@ -1272,6 +1460,15 @@ def _run_database_build(
         if state:
             state.mark_completed("set_logged")
             _save_state()
+
+    # -- reload-invariant gate (discogs-etl#298)
+    # Final check on the state consumers will read (the target DB in copy-to
+    # mode, else the source). If release is populated but the children are
+    # empty — e.g. an empty/missing tracks CSV COPYed as zero rows without
+    # error — raise before report_sizes so the run fails loudly instead of
+    # reporting success with an empty track/artist index. Always runs (even on
+    # a fully-resumed build) as a last sanity gate.
+    check_reload_invariant(vacuum_db, raise_on_violation=True)
 
     # -- report
     report_sizes(vacuum_db)

--- a/tests/unit/test_run_pipeline.py
+++ b/tests/unit/test_run_pipeline.py
@@ -18,10 +18,6 @@ _spec = importlib.util.spec_from_file_location(
     Path(__file__).parent.parent.parent / "scripts" / "run_pipeline.py",
 )
 run_pipeline = importlib.util.module_from_spec(_spec)
-# Register before exec so the module's @dataclass definitions resolve their
-# own __module__ (dataclasses looks it up in sys.modules under
-# `from __future__ import annotations`). Mirrors test_check_cache_drift.py.
-sys.modules["run_pipeline"] = run_pipeline
 _spec.loader.exec_module(run_pipeline)
 
 run_sql_statements_parallel = run_pipeline.run_sql_statements_parallel

--- a/tests/unit/test_run_pipeline.py
+++ b/tests/unit/test_run_pipeline.py
@@ -18,6 +18,10 @@ _spec = importlib.util.spec_from_file_location(
     Path(__file__).parent.parent.parent / "scripts" / "run_pipeline.py",
 )
 run_pipeline = importlib.util.module_from_spec(_spec)
+# Register before exec so the module's @dataclass definitions resolve their
+# own __module__ (dataclasses looks it up in sys.modules under
+# `from __future__ import annotations`). Mirrors test_check_cache_drift.py.
+sys.modules["run_pipeline"] = run_pipeline
 _spec.loader.exec_module(run_pipeline)
 
 run_sql_statements_parallel = run_pipeline.run_sql_statements_parallel
@@ -1307,3 +1311,294 @@ class TestParseArgsValidation:
                     "--pair-filter",
                 ]
             )
+
+
+# ---------------------------------------------------------------------------
+# Reload invariant (discogs-etl#298)
+#
+# The base stage TRUNCATEs the release_* child tables in a committed
+# transaction, then reloads them across several later subprocess steps. A run
+# that aborts (or silently COPYs an empty tracks CSV) can leave `release` full
+# while release_artist / release_track are empty — the 0.7%-coverage prod state
+# #298 documents. These guard against that going undetected.
+# ---------------------------------------------------------------------------
+
+
+class TestEvaluateReloadInvariant:
+    """Pure decision logic: child-table release coverage vs the release count."""
+
+    def test_default_min_ratio_is_half(self) -> None:
+        """The floor sits between the 0.7% catastrophe and ~100% healthy."""
+        assert run_pipeline.MIN_CHILD_COVERAGE_RATIO == 0.5
+
+    def test_healthy_cache_is_ok(self) -> None:
+        result = run_pipeline.evaluate_reload_invariant(
+            release_count=258_990,
+            artist_release_count=258_990,
+            track_release_count=248_000,
+        )
+        assert result.ok
+        assert result.reason == ""
+
+    def test_empty_cache_is_ok(self) -> None:
+        """release_count == 0 is a legitimate state (fresh / pre-import DB)."""
+        result = run_pipeline.evaluate_reload_invariant(
+            release_count=0, artist_release_count=0, track_release_count=0
+        )
+        assert result.ok
+        # coverage is undefined when there are no releases to cover
+        assert result.artist_coverage is None
+        assert result.track_coverage is None
+
+    def test_prod_degraded_state_fails_naming_both_children(self) -> None:
+        """The exact #298 state: 1,839 of 258,990 releases have child rows."""
+        result = run_pipeline.evaluate_reload_invariant(
+            release_count=258_990,
+            artist_release_count=1_839,
+            track_release_count=1_839,
+        )
+        assert not result.ok
+        assert "release_artist" in result.reason
+        assert "release_track" in result.reason
+
+    def test_track_empty_but_artist_full_fails_naming_only_track(self) -> None:
+        result = run_pipeline.evaluate_reload_invariant(
+            release_count=250_000,
+            artist_release_count=250_000,
+            track_release_count=1_000,
+        )
+        assert not result.ok
+        assert "release_track" in result.reason
+        assert "release_artist" not in result.reason
+
+    def test_boundary_at_ratio_is_ok(self) -> None:
+        """Exactly at the floor passes (>= min_ratio)."""
+        result = run_pipeline.evaluate_reload_invariant(
+            release_count=1_000,
+            artist_release_count=500,
+            track_release_count=500,
+            min_ratio=0.5,
+        )
+        assert result.ok
+
+    def test_just_below_ratio_fails(self) -> None:
+        result = run_pipeline.evaluate_reload_invariant(
+            release_count=1_000,
+            artist_release_count=499,
+            track_release_count=1_000,
+            min_ratio=0.5,
+        )
+        assert not result.ok
+        assert "release_artist" in result.reason
+
+    def test_coverage_fields_populated(self) -> None:
+        result = run_pipeline.evaluate_reload_invariant(
+            release_count=1_000,
+            artist_release_count=900,
+            track_release_count=800,
+        )
+        assert result.release_count == 1_000
+        assert result.artist_coverage == pytest.approx(0.9)
+        assert result.track_coverage == pytest.approx(0.8)
+
+
+class TestCountChildCoverage:
+    """count_child_coverage() reads (release, artist-releases, track-releases)."""
+
+    def _mock_conn(self, fetchone_side_effect):
+        mock_cursor = MagicMock()
+        mock_cursor.fetchone.side_effect = fetchone_side_effect
+        mock_conn = MagicMock()
+        mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
+        mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+        return mock_conn
+
+    def test_missing_release_table_returns_zeros(self) -> None:
+        """A fresh DB (release table absent) short-circuits to (0, 0, 0) so the
+        preflight can run before create_schema without erroring."""
+        mock_conn = self._mock_conn([[None]])  # to_regclass('release') IS NULL
+        with patch.object(run_pipeline.psycopg, "connect", return_value=mock_conn):
+            assert run_pipeline.count_child_coverage("postgresql:///t") == (0, 0, 0)
+        mock_conn.close.assert_called_once()
+
+    def test_counts_returned_when_table_present(self) -> None:
+        mock_conn = self._mock_conn(
+            [["release"], [1_000], [900], [800]]  # regclass, release, artist, track
+        )
+        with patch.object(run_pipeline.psycopg, "connect", return_value=mock_conn):
+            assert run_pipeline.count_child_coverage("postgresql:///t") == (1_000, 900, 800)
+        mock_conn.close.assert_called_once()
+
+
+class TestCheckReloadInvariant:
+    """check_reload_invariant() warns (preflight) or raises (post-reload)."""
+
+    def test_violation_raises_when_strict(self) -> None:
+        with patch.object(
+            run_pipeline, "count_child_coverage", return_value=(258_990, 1_839, 1_839)
+        ):
+            with pytest.raises(RuntimeError, match="invariant"):
+                run_pipeline.check_reload_invariant("postgresql:///t", raise_on_violation=True)
+
+    def test_violation_warns_when_not_strict(self, caplog) -> None:
+        with (
+            patch.object(
+                run_pipeline, "count_child_coverage", return_value=(258_990, 1_839, 1_839)
+            ),
+            caplog.at_level(logging.WARNING, logger=run_pipeline.logger.name),
+        ):
+            result = run_pipeline.check_reload_invariant(
+                "postgresql:///t", raise_on_violation=False
+            )
+        assert not result.ok
+        assert any("invariant" in r.message for r in caplog.records)
+
+    def test_healthy_never_raises(self) -> None:
+        with patch.object(run_pipeline, "count_child_coverage", return_value=(1_000, 1_000, 990)):
+            result = run_pipeline.check_reload_invariant("postgresql:///t", raise_on_violation=True)
+        assert result.ok
+
+    def test_missing_table_is_ok_even_when_strict(self) -> None:
+        with patch.object(run_pipeline, "count_child_coverage", return_value=(0, 0, 0)):
+            result = run_pipeline.check_reload_invariant("postgresql:///t", raise_on_violation=True)
+        assert result.ok
+
+
+class TestReloadInvariantWiring:
+    """_run_database_build brackets the reload with a preflight (warn) before
+    the truncating base step and a strict post-reload gate before report_sizes.
+    """
+
+    def _run_capturing_order(self, *, check_side_effect=None, events=None):
+        import psycopg
+
+        if events is None:
+            events = []
+
+        def fake_run_step(name, cmd, *a, **k):
+            events.append(("run_step", cmd))
+
+        def default_check(db_url, *, raise_on_violation, **k):
+            events.append(("check", raise_on_violation))
+            return run_pipeline.ReloadInvariantResult(
+                ok=True, release_count=1, artist_coverage=1.0, track_coverage=1.0
+            )
+
+        def fake_report(db_url):
+            events.append(("report", db_url))
+
+        mock_cursor = MagicMock()
+        mock_cursor.fetchone.return_value = [True]
+        mock_cursor.fetchall.return_value = [
+            ("idx_release_artist_name_trgm",),
+            ("idx_release_title_trgm",),
+        ]
+        mock_conn = MagicMock()
+        mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
+        mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+
+        with (
+            patch.object(run_pipeline, "run_step", side_effect=fake_run_step),
+            patch.object(
+                run_pipeline,
+                "check_reload_invariant",
+                side_effect=check_side_effect or default_check,
+            ),
+            patch.object(run_pipeline, "wait_for_postgres"),
+            patch.object(run_pipeline, "run_sql_file"),
+            patch.object(run_pipeline, "run_sql_statements_parallel"),
+            patch.object(run_pipeline, "set_tables_unlogged"),
+            patch.object(run_pipeline, "set_tables_logged"),
+            patch.object(run_pipeline, "run_vacuum"),
+            patch.object(run_pipeline, "report_sizes", side_effect=fake_report),
+            patch.object(psycopg, "connect", return_value=mock_conn),
+        ):
+            run_pipeline._run_database_build(
+                "postgresql:///test", Path("/tmp/csv"), None, sys.executable
+            )
+        return events
+
+    def test_preflight_runs_before_base_import(self) -> None:
+        events = self._run_capturing_order()
+        checks = [i for i, (kind, _) in enumerate(events) if kind == "check"]
+        base_idx = next(
+            i for i, (kind, v) in enumerate(events) if kind == "run_step" and "--base-only" in v
+        )
+        assert checks, "expected a reload-invariant check"
+        # The first check is the non-strict preflight, and it precedes the
+        # truncating base step.
+        assert events[checks[0]] == ("check", False)
+        assert checks[0] < base_idx
+
+    def test_postreload_gate_is_strict_and_after_tracks_before_report(self) -> None:
+        events = self._run_capturing_order()
+        checks = [i for i, (kind, _) in enumerate(events) if kind == "check"]
+        tracks_idx = next(
+            i for i, (kind, v) in enumerate(events) if kind == "run_step" and "--tracks-only" in v
+        )
+        report_idx = next(i for i, (kind, _) in enumerate(events) if kind == "report")
+        # The last check is the strict post-reload gate: after tracks, before report.
+        assert events[checks[-1]] == ("check", True)
+        assert tracks_idx < checks[-1] < report_idx
+
+    def test_postreload_violation_raises_before_report_sizes(self) -> None:
+        """When the strict gate raises, report_sizes never runs, so the
+        success notification downstream is never reached."""
+        events: list[tuple] = []
+
+        def raising_check(db_url, *, raise_on_violation, **k):
+            events.append(("check", raise_on_violation))
+            if raise_on_violation:
+                raise RuntimeError("[#298] cache reload invariant violated")
+            return run_pipeline.ReloadInvariantResult(
+                ok=True, release_count=1, artist_coverage=1.0, track_coverage=1.0
+            )
+
+        with pytest.raises(RuntimeError, match="invariant"):
+            self._run_capturing_order(check_side_effect=raising_check, events=events)
+
+        assert ("check", True) in events
+        assert not any(kind == "report" for kind, _ in events)
+
+
+class TestPostImportReloadInvariant:
+    """The direct-pg tail (_run_database_build_post_import) also gates on the
+    strict post-reload invariant before report_sizes."""
+
+    def test_post_import_runs_strict_gate_before_report(self) -> None:
+        import psycopg
+
+        events: list[tuple] = []
+
+        def fake_check(db_url, *, raise_on_violation, **k):
+            events.append(("check", raise_on_violation))
+            return run_pipeline.ReloadInvariantResult(
+                ok=True, release_count=1, artist_coverage=1.0, track_coverage=1.0
+            )
+
+        def fake_report(db_url):
+            events.append(("report", db_url))
+
+        mock_cursor = MagicMock()
+        mock_cursor.fetchone.return_value = [True]
+        mock_conn = MagicMock()
+        mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
+        mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+
+        with (
+            patch.object(run_pipeline, "run_step"),
+            patch.object(run_pipeline, "check_reload_invariant", side_effect=fake_check),
+            patch.object(run_pipeline, "run_sql_statements_parallel"),
+            patch.object(run_pipeline, "run_vacuum"),
+            patch.object(run_pipeline, "set_tables_logged"),
+            patch.object(run_pipeline, "report_sizes", side_effect=fake_report),
+            patch.object(psycopg, "connect", return_value=mock_conn),
+        ):
+            run_pipeline._run_database_build_post_import(
+                "postgresql:///test", Path("/tmp/csv"), None, sys.executable
+            )
+
+        assert ("check", True) in events
+        check_idx = events.index(("check", True))
+        report_idx = next(i for i, (kind, _) in enumerate(events) if kind == "report")
+        assert check_idx < report_idx


### PR DESCRIPTION
## What

Closes **acceptance criterion 3** of #298 — *"a partial-rebuild abort can no longer leave a `release`-full / children-empty state undetected"* — and ships the operator recovery runbook for criteria 1 & 2.

### The gap

`scripts/import_csv.py:import_release_via_upsert` `TRUNCATE ... CASCADE`s every `release_*` child table in a committed transaction (so `release` itself stays upsert-not-truncate per #252), then reloads the children across several later subprocess steps (`--base-only` children → `dedup` → `--tracks-only`). A run that **aborts anywhere in that window** — or one that silently COPYs an empty/missing tracks CSV as zero rows — leaves `release` fully populated while `release_track` / `release_artist` sit empty. That's the 0.7%-coverage prod state #298 documents. The end-of-run drift watchdog (`check_cache_drift.py`) only fires after a *fully successful* pipeline, so the state went undetected.

### The guard

`scripts/run_pipeline.py` now brackets the reload with a release-vs-children coverage invariant (`MIN_CHILD_COVERAGE_RATIO = 0.5`, `evaluate_reload_invariant`):

- **Preflight (warn, non-raising)** — before the truncating base step. If the DB is already in the degraded state a prior abort left, it logs a loud `[#298] ... invariant violated on entry (recovering this run)` WARNING (`step=reload_invariant`). It does not raise: this run is about to repopulate, so operators just see recovery under way. Runs after `create_schema`; `count_child_coverage` tolerates a not-yet-created schema anyway.
- **Post-reload gate (raise)** — after `set_tables_logged`, before `report_sizes` and the `:white_check_mark:` notification, in **both** `_run_database_build` and `_run_database_build_post_import`. A violation raises `RuntimeError`, so the run fails **before** reporting success.

Floor rationale: every Discogs release carries ≥1 artist credit and (essentially) a tracklist, and dedup CASCADE-removes children in lockstep, so a healthy WXYC cache sits near 100% coverage for both children. The documented catastrophe was 0.7%. 0.5 sits comfortably between — it catches the empty-index state without false-positiving a legitimate rebuild (a false positive would hard-fail the whole monthly rebuild).

### Recovery runbook

`docs/plan-298-empty-child-index-recovery.md`: detection query, root cause, and the only safe recovery path — rotate the expired `GH_TOKEN` (#296), then run **one full rebuild** (never `--truncate-existing` against base tables, which wipes LML's artwork back-patches per #252) — plus the "me and mr. jones by plug" acceptance repro. Cross-linked from the CLAUDE.md router, the ec2-rebuild runbook (two new troubleshooting entries), and `architecture.md`.

## Tests

18 new unit tests in `tests/unit/test_run_pipeline.py`: pure `evaluate_reload_invariant` cases (healthy, empty cache, the exact prod degraded state, track-only-empty, boundary at the floor), `count_child_coverage` missing-table tolerance, `check_reload_invariant` raise-vs-warn, and wiring/placement (preflight before the base step; strict gate after tracks and before `report_sizes`; a gate violation raises before `report_sizes`). Full `test_run_pipeline.py` suite (98) + the rest of the unit tier (720) pass; `ruff check` / `ruff format --check` clean. The `pg`/e2e jobs exercise the new gate — fixtures give ~94% child coverage (15/16 releases), safely above the floor.

## Scope note

`Refs #298` (intentionally **not** `Closes`): this PR delivers criterion 3 + the runbook. Criteria 1 & 2 (repopulating prod, confirming the Plug lookup) are ops actions gated on the #296 token rotation + a full rebuild — keep #298 open until that lands.

Refs #298, #296, #252, #226