### PR TITLE
fix(import): prune releases with an indexed NOT EXISTS anti-join, not NOT IN

### DIFF
--- a/scripts/import_csv.py
+++ b/scripts/import_csv.py
@@ -719,6 +719,13 @@ def import_release_via_upsert(conn, csv_dir: Path) -> int:
             "cache, rerun with --fresh-rebuild."
         )
 
+    # Index the staging table on id so the prune's anti-join below runs as a
+    # hash/merge anti-join instead of a per-row scan of an unindexed temp table
+    # (release_staging is created LIKE release INCLUDING DEFAULTS — no index).
+    with conn.cursor() as cur:
+        cur.execute("CREATE INDEX ON release_staging (id)")
+        cur.execute("ANALYZE release_staging")
+
     logger.info(f"Upserting {rows:,} releases (preserving artwork columns)...")
     with conn.cursor() as cur:
         # artwork_url, artwork_checked_at intentionally NOT in the SET
@@ -741,7 +748,16 @@ def import_release_via_upsert(conn, csv_dir: Path) -> int:
                 not_found = EXCLUDED.not_found
             """
         )
-        cur.execute("DELETE FROM release WHERE id NOT IN (SELECT id FROM release_staging)")
+        # NOT EXISTS anti-join, not NOT IN (SELECT ...): the NOT IN form
+        # full-scans the (previously unindexed) staging table and is NULL-unsafe.
+        # At ~682K releases it ran 2h20m before Railway admin-killed the
+        # connection mid-rebuild (2026-07-06), aborting after the child-table
+        # TRUNCATE committed and leaving release_track / release_artist empty.
+        # See WXYC/discogs-etl#298.
+        cur.execute(
+            "DELETE FROM release r "
+            "WHERE NOT EXISTS (SELECT 1 FROM release_staging s WHERE s.id = r.id)"
+        )
         pruned = cur.rowcount
         cur.execute("DROP TABLE release_staging")
     conn.commit()

--- a/tests/unit/test_import_csv.py
+++ b/tests/unit/test_import_csv.py
@@ -1678,6 +1678,47 @@ class TestImportArtistDetailsProfileCopy:
         )
 
 
+class TestReleasePruneAntiJoin:
+    """Pin the release prune as an indexed anti-join.
+
+    ``DELETE FROM release WHERE id NOT IN (SELECT id FROM release_staging)``
+    full-scans an unindexed temp table and prunes ~nothing (staging is a
+    superset of ``release``). At ~682K releases it ran 2h20m before Railway
+    admin-killed the connection (2026-07-06 rebuild), aborting *after* the
+    child-table TRUNCATE committed and leaving ``release_track`` /
+    ``release_artist`` empty. The prune must be a ``NOT EXISTS`` anti-join
+    against an indexed ``release_staging``.
+    """
+
+    def _mock_conn(self):
+        from unittest.mock import MagicMock
+
+        mock_cursor = MagicMock()
+        mock_cursor.rowcount = 0
+        mock_conn = MagicMock()
+        mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
+        mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+        return mock_conn, mock_cursor
+
+    def test_prune_is_indexed_anti_join_not_in_subquery(self, tmp_path) -> None:
+        from unittest.mock import patch
+
+        (tmp_path / "release.csv").write_text("id,title\n1,X\n")
+        mock_conn, mock_cursor = self._mock_conn()
+        with patch.object(_ic, "import_csv", return_value=100):
+            _ic.import_release_via_upsert(mock_conn, tmp_path)
+
+        executed = " ".join(c.args[0] for c in mock_cursor.execute.call_args_list if c.args)
+        norm = " ".join(executed.split()).lower()
+        assert "not in (select" not in norm, (
+            f"prune must not use a NOT IN subquery (unindexed full-scan anti-join); SQL: {executed}"
+        )
+        assert "not exists" in norm, f"prune must use a NOT EXISTS anti-join; SQL: {executed}"
+        assert "create index" in norm and "release_staging" in norm, (
+            f"release_staging must be indexed so the anti-join is fast; SQL: {executed}"
+        )
+
+
 import contextlib  # noqa: E402 — module-level imports already at top; this is for test-only helpers
 
 


### PR DESCRIPTION
Fixes the base-stage prune that stalled the 2026-07-06 cache rebuild for 2h20m and left the track index empty (WXYC/discogs-etl#298).

`DELETE FROM release WHERE id NOT IN (SELECT id FROM release_staging)` → an unindexed full-scan anti-join that prunes ~nothing (staging is a superset) yet scans the whole table, and is NULL-unsafe. At 682K releases Railway admin-killed the connection; because the child-table TRUNCATE commits before the prune, the abort left `release_track`/`release_artist` empty.

**Changes**
- `NOT EXISTS` anti-join (fast + NULL-safe).
- `CREATE INDEX ON release_staging (id)` + `ANALYZE`.
- `TestReleasePruneAntiJoin` pins the SQL shape (regression to `NOT IN` fails).

Verified: full `tests/unit/test_import_csv.py` (102) green, ruff clean.

Closes #300 · Refs #298