### PR TITLE
Prune stale releases via NOT EXISTS anti-join, not NOT IN SubPlan (#302)

### DIFF
--- a/scripts/import_csv.py
+++ b/scripts/import_csv.py
@@ -665,6 +665,21 @@ _RELEASE_CHILD_TABLES: list[str] = [
 ] + ["cache_metadata"]
 
 
+# Prune releases that fell out of the new dump. Written as NOT EXISTS rather
+# than ``id NOT IN (SELECT id FROM release_staging)``: PostgreSQL cannot convert
+# a ``NOT IN (subquery)`` into an anti-join (SQL NULL semantics forbid it), so
+# NOT IN forces an O(n*m) per-row Materialized SubPlan. At ~260k releases that
+# is a ~2.1-billion-cost sequential scan that ran for 1.5-2h+ on-CPU and stalled
+# the monthly rebuild (surfaced during the discogs-etl#298 recovery; the DELETE
+# only exists on the upsert-not-truncate path from #252, and no rebuild had ever
+# completed it at scale). NOT EXISTS plans as a Hash Anti Join (~50,000x cheaper,
+# sub-second). ``release.id`` and ``release_staging.id`` are both NOT NULL, so
+# the two forms delete exactly the same rows.
+PRUNE_STALE_RELEASES_SQL = (
+    "DELETE FROM release r WHERE NOT EXISTS (SELECT 1 FROM release_staging s WHERE s.id = r.id)"
+)
+
+
 def import_release_via_upsert(conn, csv_dir: Path) -> int:
     """Reload ``release`` from CSV while preserving artwork columns.
 
@@ -741,7 +756,7 @@ def import_release_via_upsert(conn, csv_dir: Path) -> int:
                 not_found = EXCLUDED.not_found
             """
         )
-        cur.execute("DELETE FROM release WHERE id NOT IN (SELECT id FROM release_staging)")
+        cur.execute(PRUNE_STALE_RELEASES_SQL)
         pruned = cur.rowcount
         cur.execute("DROP TABLE release_staging")
     conn.commit()

--- a/tests/integration/test_import.py
+++ b/tests/integration/test_import.py
@@ -22,6 +22,7 @@ _spec.loader.exec_module(_ic)
 import_csv_func = _ic.import_csv
 import_artwork = _ic.import_artwork
 import_release_via_upsert = _ic.import_release_via_upsert
+PRUNE_STALE_RELEASES_SQL = _ic.PRUNE_STALE_RELEASES_SQL
 import_artist_details = _ic.import_artist_details
 create_track_count_table = _ic.create_track_count_table
 populate_cache_metadata = _ic.populate_cache_metadata
@@ -1357,4 +1358,58 @@ class TestImportClearsTombstones:
             f"Rebuild must clear the artist tombstone (not_found=FALSE); "
             f"got not_found={not_found!r}. The stub-INSERT in "
             f"import_artist_details must update not_found = FALSE on conflict."
+        )
+
+
+class TestPruneStaleReleasesPlan:
+    """The stale-release prune must plan as an anti-join, not a NOT IN SubPlan.
+
+    ``DELETE ... WHERE id NOT IN (SELECT id FROM release_staging)`` cannot be
+    planned as an anti-join by PostgreSQL (SQL NULL semantics), forcing an
+    O(n*m) per-row Materialized SubPlan. At ~260k releases that plan is a
+    ~2.1-billion-cost sequential scan that ran 1.5-2h+ on-CPU and stalled the
+    monthly rebuild — surfaced during the discogs-etl#298 recovery. The
+    ``NOT EXISTS`` form (``PRUNE_STALE_RELEASES_SQL``) plans as a Hash Anti
+    Join, ~50,000x cheaper. This pins the plan shape so a regression back to
+    ``NOT IN`` fails loudly instead of silently re-stalling a prod rebuild.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _set_up(self, db_url):
+        self.db_url = db_url
+        conn = psycopg.connect(db_url, autocommit=True)
+        with conn.cursor() as cur:
+            cur.execute(SCHEMA_DIR.joinpath("create_database.sql").read_text())
+        conn.close()
+
+    def test_prune_plans_as_anti_join_not_subplan(self) -> None:
+        conn = psycopg.connect(self.db_url)
+        try:
+            with conn.cursor() as cur:
+                # A handful of live releases; staging (the incoming dump) covers
+                # a subset, so the prune has a real anti-join to plan. EXPLAIN
+                # (no ANALYZE) computes the plan without executing the DELETE.
+                cur.execute(
+                    "INSERT INTO release (id, title) VALUES "
+                    "(9001, 'a'), (9002, 'b'), (9003, 'c') ON CONFLICT (id) DO NOTHING"
+                )
+                cur.execute("CREATE TEMP TABLE release_staging (LIKE release INCLUDING DEFAULTS)")
+                cur.execute(
+                    "INSERT INTO release_staging (id, title) VALUES (9001, 'a'), (9002, 'b')"
+                )
+                cur.execute("EXPLAIN " + PRUNE_STALE_RELEASES_SQL)
+                plan = "\n".join(row[0] for row in cur.fetchall())
+        finally:
+            conn.rollback()  # undo the release inserts; temp table drops on close
+            conn.close()
+
+        assert "Anti Join" in plan, (
+            "The stale-release prune must plan as an anti-join. NOT IN forces "
+            "an O(n*m) per-row SubPlan that stalled the rebuild (#298); use "
+            f"NOT EXISTS. Plan was:\n{plan}"
+        )
+        assert "SubPlan" not in plan, (
+            "The prune regressed to a NOT IN SubPlan (O(n*m), ~2.1B cost at "
+            "scale). Rewrite as NOT EXISTS (Hash Anti Join). Plan was:\n"
+            f"{plan}"
         )


### PR DESCRIPTION
## What

Fixes the query that stalled the monthly rebuild for 1.5–2h+ during the #298 recovery.

`import_release_via_upsert` pruned dropped releases with `DELETE FROM release WHERE id NOT IN (SELECT id FROM release_staging)`. PostgreSQL cannot plan `NOT IN (subquery)` as an anti-join (NULL semantics), so it uses an O(n×m) per-row Materialized SubPlan.

## Evidence (EXPLAIN on the prod cache)

| Query | Plan | Cost |
|---|---|---|
| `NOT IN`, staging unanalyzed *(old)* | Seq Scan + per-row SubPlan | **2,150,775,520** |
| `NOT IN`, staging analyzed | same SubPlan (ANALYZE no help) | **1,916,177,198** |
| `NOT EXISTS` *(this PR)* | **Hash Anti Join** | **41,028** |

~50,000× cheaper, sub-second instead of hours.

## Change

- `scripts/import_csv.py`: prune via `PRUNE_STALE_RELEASES_SQL` = `DELETE FROM release r WHERE NOT EXISTS (SELECT 1 FROM release_staging s WHERE s.id = r.id)`. `release.id` / `release_staging.id` are both `NOT NULL`, so identical rows are deleted — pure perf fix, no behavior change.
- `tests/integration/test_import.py`: `TestPruneStaleReleasesPlan` runs `EXPLAIN` on the real prune SQL and asserts an `Anti Join` (not a `SubPlan`) — red on `NOT IN`, green on `NOT EXISTS`. The existing `test_rebuild_purges_releases_not_in_dump` guards the delete set.

## Testing

Lint + format clean. The plan-assertion + prune tests are `pg`-marked; I verified the red/green **empirically against the prod cache** (the EXPLAIN table above) since the `pg` tier can't run in my local env (stale `wxyc_etl` wheel lacks `wxyc_etl.pg`). CI's `pg` job runs them.

## Why it was hidden

The `DELETE` only exists on the upsert-not-truncate path (#252), and per #296 no rebuild had ever completed it at scale — runs died earlier (#269, #286, a June-4 deadlock, #296 token). This is the next wall after the token fix.

Closes #302. Surfaced during #298 recovery; independent of #299 (the reload-invariant guardrail).