### PR TITLE
Pin the stale-release prune plan as an anti-join (regression guard)

### DIFF
--- a/scripts/import_csv.py
+++ b/scripts/import_csv.py
@@ -665,6 +665,21 @@ _RELEASE_CHILD_TABLES: list[str] = [
 ] + ["cache_metadata"]
 
 
+# Prune of releases absent from the incoming dump's staging table. It MUST use
+# NOT EXISTS (a Hash Anti Join), never NOT IN (SELECT ...): PostgreSQL cannot
+# plan NOT IN as an anti-join (SQL NULL semantics), so it falls back to an
+# O(n*m) per-row Materialized SubPlan. At ~682K releases that SubPlan ran
+# 2h20m on-CPU before Railway admin-killed the connection mid-rebuild
+# (2026-07-06), aborting after the child-table TRUNCATE committed and leaving
+# release_track / release_artist empty. release.id and release_staging.id are
+# both NOT NULL, so the two forms delete identical rows. See
+# WXYC/discogs-etl#298 / #302. TestPruneStaleReleasesPlan pins the plan shape
+# so a regression back to NOT IN fails loudly instead of re-stalling a rebuild.
+PRUNE_STALE_RELEASES_SQL = (
+    "DELETE FROM release r WHERE NOT EXISTS (SELECT 1 FROM release_staging s WHERE s.id = r.id)"
+)
+
+
 def import_release_via_upsert(conn, csv_dir: Path) -> int:
     """Reload ``release`` from CSV while preserving artwork columns.
 
@@ -748,16 +763,9 @@ def import_release_via_upsert(conn, csv_dir: Path) -> int:
                 not_found = EXCLUDED.not_found
             """
         )
-        # NOT EXISTS anti-join, not NOT IN (SELECT ...): the NOT IN form
-        # full-scans the (previously unindexed) staging table and is NULL-unsafe.
-        # At ~682K releases it ran 2h20m before Railway admin-killed the
-        # connection mid-rebuild (2026-07-06), aborting after the child-table
-        # TRUNCATE committed and leaving release_track / release_artist empty.
-        # See WXYC/discogs-etl#298.
-        cur.execute(
-            "DELETE FROM release r "
-            "WHERE NOT EXISTS (SELECT 1 FROM release_staging s WHERE s.id = r.id)"
-        )
+        # Prune releases absent from the new dump. NOT EXISTS, not NOT IN — see
+        # PRUNE_STALE_RELEASES_SQL for the incident rationale (WXYC/discogs-etl#298).
+        cur.execute(PRUNE_STALE_RELEASES_SQL)
         pruned = cur.rowcount
         cur.execute("DROP TABLE release_staging")
     conn.commit()

--- a/tests/integration/test_import.py
+++ b/tests/integration/test_import.py
@@ -1366,11 +1366,12 @@ class TestPruneStaleReleasesPlan:
 
     ``DELETE ... WHERE id NOT IN (SELECT id FROM release_staging)`` cannot be
     planned as an anti-join by PostgreSQL (SQL NULL semantics), forcing an
-    O(n*m) per-row Materialized SubPlan. At ~260k releases that plan is a
-    ~2.1-billion-cost sequential scan that ran 1.5-2h+ on-CPU and stalled the
-    monthly rebuild — surfaced during the discogs-etl#298 recovery. The
-    ``NOT EXISTS`` form (``PRUNE_STALE_RELEASES_SQL``) plans as a Hash Anti
-    Join, ~50,000x cheaper. This pins the plan shape so a regression back to
+    O(n*m) per-row Materialized SubPlan — a ~2.1-billion-cost sequential scan
+    on the prod cache that stalled the monthly rebuild. See
+    ``PRUNE_STALE_RELEASES_SQL`` for the incident narrative and release counts
+    (discogs-etl#298 / #302). The ``NOT EXISTS`` form
+    (``PRUNE_STALE_RELEASES_SQL``) plans as a Hash Anti Join (~41K cost,
+    ~50,000x cheaper). This pins the plan shape so a regression back to
     ``NOT IN`` fails loudly instead of silently re-stalling a prod rebuild.
     """
 

--- a/tests/integration/test_import.py
+++ b/tests/integration/test_import.py
@@ -22,6 +22,7 @@ _spec.loader.exec_module(_ic)
 import_csv_func = _ic.import_csv
 import_artwork = _ic.import_artwork
 import_release_via_upsert = _ic.import_release_via_upsert
+PRUNE_STALE_RELEASES_SQL = _ic.PRUNE_STALE_RELEASES_SQL
 import_artist_details = _ic.import_artist_details
 create_track_count_table = _ic.create_track_count_table
 populate_cache_metadata = _ic.populate_cache_metadata
@@ -1357,4 +1358,58 @@ class TestImportClearsTombstones:
             f"Rebuild must clear the artist tombstone (not_found=FALSE); "
             f"got not_found={not_found!r}. The stub-INSERT in "
             f"import_artist_details must update not_found = FALSE on conflict."
+        )
+
+
+class TestPruneStaleReleasesPlan:
+    """The stale-release prune must plan as an anti-join, not a NOT IN SubPlan.
+
+    ``DELETE ... WHERE id NOT IN (SELECT id FROM release_staging)`` cannot be
+    planned as an anti-join by PostgreSQL (SQL NULL semantics), forcing an
+    O(n*m) per-row Materialized SubPlan. At ~260k releases that plan is a
+    ~2.1-billion-cost sequential scan that ran 1.5-2h+ on-CPU and stalled the
+    monthly rebuild — surfaced during the discogs-etl#298 recovery. The
+    ``NOT EXISTS`` form (``PRUNE_STALE_RELEASES_SQL``) plans as a Hash Anti
+    Join, ~50,000x cheaper. This pins the plan shape so a regression back to
+    ``NOT IN`` fails loudly instead of silently re-stalling a prod rebuild.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _set_up(self, db_url):
+        self.db_url = db_url
+        conn = psycopg.connect(db_url, autocommit=True)
+        with conn.cursor() as cur:
+            cur.execute(SCHEMA_DIR.joinpath("create_database.sql").read_text())
+        conn.close()
+
+    def test_prune_plans_as_anti_join_not_subplan(self) -> None:
+        conn = psycopg.connect(self.db_url)
+        try:
+            with conn.cursor() as cur:
+                # A handful of live releases; staging (the incoming dump) covers
+                # a subset, so the prune has a real anti-join to plan. EXPLAIN
+                # (no ANALYZE) computes the plan without executing the DELETE.
+                cur.execute(
+                    "INSERT INTO release (id, title) VALUES "
+                    "(9001, 'a'), (9002, 'b'), (9003, 'c') ON CONFLICT (id) DO NOTHING"
+                )
+                cur.execute("CREATE TEMP TABLE release_staging (LIKE release INCLUDING DEFAULTS)")
+                cur.execute(
+                    "INSERT INTO release_staging (id, title) VALUES (9001, 'a'), (9002, 'b')"
+                )
+                cur.execute("EXPLAIN " + PRUNE_STALE_RELEASES_SQL)
+                plan = "\n".join(row[0] for row in cur.fetchall())
+        finally:
+            conn.rollback()  # undo the release inserts; temp table drops on close
+            conn.close()
+
+        assert "Anti Join" in plan, (
+            "The stale-release prune must plan as an anti-join. NOT IN forces "
+            "an O(n*m) per-row SubPlan that stalled the rebuild (#298); use "
+            f"NOT EXISTS. Plan was:\n{plan}"
+        )
+        assert "SubPlan" not in plan, (
+            "The prune regressed to a NOT IN SubPlan (O(n*m), ~2.1B cost at "
+            "scale). Rewrite as NOT EXISTS (Hash Anti Join). Plan was:\n"
+            f"{plan}"
         )


### PR DESCRIPTION
Extracts the stale-release prune SQL to a module-level `PRUNE_STALE_RELEASES_SQL` constant and adds a `pg`-marked regression test that `EXPLAIN`s it and asserts a Hash Anti Join with no `SubPlan`.

## Why

758ec84 (#301) rewrote the prune in `import_release_via_upsert` from `DELETE ... WHERE id NOT IN (SELECT id FROM release_staging)` to a `NOT EXISTS` anti-join — the `NOT IN` form degrades to an O(n×m) `SubPlan` (~2.1B cost at ~260k releases) that ran 2h+ on-CPU and stalled the monthly rebuild after the child-table `TRUNCATE` committed, emptying `release_track`/`release_artist` (#298). That fix shipped with no test pinning the plan shape, so a silent regression back to `NOT IN` would re-stall a prod rebuild with no CI signal.

## What

- `scripts/import_csv.py`: extract the prune to `PRUNE_STALE_RELEASES_SQL` (one source of truth for loader + test); call site now `cur.execute(PRUNE_STALE_RELEASES_SQL)`.
- `tests/integration/test_import.py`: `TestPruneStaleReleasesPlan` — `EXPLAIN`s the constant against a real Postgres, asserts `Anti Join` present and `SubPlan` absent.

No behavior change to the prune itself; `test_rebuild_purges_releases_not_in_dump` still covers the delete semantics.

The plan-assertion test was salvaged from the closed PR #303 (a duplicate of #301) and adapted to the merged inline SQL.

Closes #306.