### PR TITLE
fix(#305): index alternate_artist_name as an alias key in verify_cache

### DIFF
--- a/scripts/verify_cache.py
+++ b/scripts/verify_cache.py
@@ -231,13 +231,27 @@ class LibraryIndex:
 
     @classmethod
     def from_rows(
-        cls, rows: list[tuple[str, str]] | list[tuple[str, str, str | None]]
+        cls,
+        rows: list[tuple[str, str]]
+        | list[tuple[str, str, str | None]]
+        | list[tuple[str, str, str | None, str | None]],
     ) -> LibraryIndex:
-        """Build index from (artist, title) or (artist, title, format) row tuples.
+        """Build index from library row tuples.
+
+        Rows may be 2-, 3-, or 4-tuples:
+
+        - ``(raw_artist, raw_title)``
+        - ``(raw_artist, raw_title, raw_format)``
+        - ``(raw_artist, raw_title, raw_format, raw_alternate_artist_name)``
+
+        When present, ``raw_alternate_artist_name`` (the library's alias / ANV
+        for the same release, e.g. "Plug" for "Luke Vibert") is indexed as an
+        **additional exact-match artist key** for the same title, so a Discogs
+        release credited to the alias classifies KEEP rather than PRUNE. This is
+        an exact-key addition, not a fuzzy-threshold change. See discogs-etl#305.
 
         Args:
-            rows: List of (raw_artist, raw_title) or (raw_artist, raw_title, raw_format)
-                tuples from the library.
+            rows: List of library row tuples (see above).
         """
         exact_pairs: set[tuple[str, str]] = set()
         artist_to_titles: dict[str, set[str]] = {}
@@ -246,10 +260,31 @@ class LibraryIndex:
         compilation_titles: set[str] = set()
         format_by_pair: dict[tuple[str, str], set[str | None]] = {}
         has_format = len(rows) > 0 and len(rows[0]) >= 3
+        has_alternate = len(rows) > 0 and len(rows[0]) >= 4
+
+        def _index_pair(norm_artist: str, norm_title: str, raw_format: str | None) -> None:
+            """Index one (artist, title) key, recording format even on dedup."""
+            pair = (norm_artist, norm_title)
+
+            # Build format_by_pair before dedup check — same pair may have multiple formats
+            if has_format:
+                norm_format = normalize_library_format(raw_format)
+                format_by_pair.setdefault(pair, set()).add(norm_format)
+
+            if pair in exact_pairs:
+                return  # deduplicate (artist+title already indexed)
+
+            exact_pairs.add(pair)
+            artist_to_titles.setdefault(norm_artist, set()).add(norm_title)
+            artist_set.add(norm_artist)
+
+            combined = f"{norm_artist}{COMBINED_SEPARATOR}{norm_title}"
+            combined_to_original[combined] = pair
 
         for row in rows:
             raw_artist, raw_title = row[0], row[1]
             raw_format = row[2] if has_format else None
+            raw_alternate = row[3] if has_alternate else None
             if not raw_artist or not raw_title:
                 continue
 
@@ -261,22 +296,15 @@ class LibraryIndex:
                 continue
 
             norm_artist = normalize_artist(raw_artist)
-            pair = (norm_artist, norm_title)
+            _index_pair(norm_artist, norm_title, raw_format)
 
-            # Build format_by_pair before dedup check — same pair may have multiple formats
-            if has_format:
-                norm_format = normalize_library_format(raw_format)
-                format_by_pair.setdefault(pair, set()).add(norm_format)
-
-            if pair in exact_pairs:
-                continue  # deduplicate (artist+title already indexed)
-
-            exact_pairs.add(pair)
-            artist_to_titles.setdefault(norm_artist, set()).add(norm_title)
-            artist_set.add(norm_artist)
-
-            combined = f"{norm_artist}{COMBINED_SEPARATOR}{norm_title}"
-            combined_to_original[combined] = pair
+            # Index the library alias / ANV as an additional exact key for the
+            # same title (discogs-etl#305). Skip empties, compilation-style
+            # aliases, and aliases that collapse to the canonical artist.
+            if raw_alternate and not is_compilation_artist(raw_alternate):
+                norm_alternate = normalize_artist(raw_alternate)
+                if norm_alternate and norm_alternate != norm_artist:
+                    _index_pair(norm_alternate, norm_title, raw_format)
 
         combined_strings = list(combined_to_original.keys())
         all_artists = sorted(artist_set)
@@ -323,7 +351,12 @@ class LibraryIndex:
     def from_sqlite(cls, db_path: Path) -> LibraryIndex:
         """Build index from the library SQLite database.
 
-        Loads format column if present (3-tuples); falls back to artist+title only (2-tuples).
+        Prefers the widest column set available, degrading gracefully:
+
+        - ``artist, title, format, alternate_artist_name`` (4-tuples) — the alias
+          is indexed as an additional exact key (discogs-etl#305)
+        - ``artist, title, format`` (3-tuples)
+        - ``artist, title`` (2-tuples)
 
         Args:
             db_path: Path to library.db
@@ -332,9 +365,12 @@ class LibraryIndex:
         conn = sqlite3.connect(str(db_path))
         cur = conn.cursor()
         try:
-            cur.execute("SELECT artist, title, format FROM library")
+            cur.execute("SELECT artist, title, format, alternate_artist_name FROM library")
         except sqlite3.OperationalError:
-            cur.execute("SELECT artist, title FROM library")
+            try:
+                cur.execute("SELECT artist, title, format FROM library")
+            except sqlite3.OperationalError:
+                cur.execute("SELECT artist, title FROM library")
         rows = cur.fetchall()
         conn.close()
 

--- a/scripts/verify_cache.py
+++ b/scripts/verify_cache.py
@@ -262,8 +262,27 @@ class LibraryIndex:
         has_format = len(rows) > 0 and len(rows[0]) >= 3
         has_alternate = len(rows) > 0 and len(rows[0]) >= 4
 
-        def _index_pair(norm_artist: str, norm_title: str, raw_format: str | None) -> None:
-            """Index one (artist, title) key, recording format even on dedup."""
+        def _index_pair(
+            norm_artist: str,
+            norm_title: str,
+            raw_format: str | None,
+            index_combined: bool = True,
+        ) -> None:
+            """Index one (artist, title) key, recording format even on dedup.
+
+            ``norm_artist`` is always added to ``artist_set`` (``all_artists``),
+            which is both the exact-match routing key in ``classify_all_releases``
+            *and* the candidate list for the precise two-stage scorer — an alias
+            needs to be there or a Discogs release credited to it can never match.
+
+            ``index_combined`` gates only the ``combined_strings`` membership that
+            feeds the *loose* ``token_set`` / ``token_sort`` scorers. The alias
+            path passes False: a short/generic alias like "Plug" as a combined
+            "plug ||| <title>" string would fuzzy-match unrelated Discogs
+            releases sharing that title, inflating false KEEPs — the two-stage
+            scorer (which requires artist AND title agreement) is the safe way to
+            reach the alias. See discogs-etl#305.
+            """
             pair = (norm_artist, norm_title)
 
             # Build format_by_pair before dedup check — same pair may have multiple formats
@@ -277,6 +296,9 @@ class LibraryIndex:
             exact_pairs.add(pair)
             artist_to_titles.setdefault(norm_artist, set()).add(norm_title)
             artist_set.add(norm_artist)
+
+            if not index_combined:
+                return
 
             combined = f"{norm_artist}{COMBINED_SEPARATOR}{norm_title}"
             combined_to_original[combined] = pair
@@ -298,13 +320,18 @@ class LibraryIndex:
             norm_artist = normalize_artist(raw_artist)
             _index_pair(norm_artist, norm_title, raw_format)
 
-            # Index the library alias / ANV as an additional exact key for the
+            # Index the library alias / ANV as an additional *exact* key for the
             # same title (discogs-etl#305). Skip empties, compilation-style
             # aliases, and aliases that collapse to the canonical artist.
+            # index_combined=False keeps the alias out of combined_strings (the
+            # loose token_set / token_sort scorers) so a short alias doesn't
+            # become a fuzzy magnet for unrelated Discogs releases; it stays in
+            # all_artists for exact-match routing and the precise two-stage
+            # scorer.
             if raw_alternate and not is_compilation_artist(raw_alternate):
                 norm_alternate = normalize_artist(raw_alternate)
                 if norm_alternate and norm_alternate != norm_artist:
-                    _index_pair(norm_alternate, norm_title, raw_format)
+                    _index_pair(norm_alternate, norm_title, raw_format, index_combined=False)
 
         combined_strings = list(combined_to_original.keys())
         all_artists = sorted(artist_set)

--- a/tests/unit/test_verify_cache.py
+++ b/tests/unit/test_verify_cache.py
@@ -27,6 +27,7 @@ else:
 # Re-export for cleaner access in tests
 normalize_title = _vc.normalize_title
 normalize_artist = _vc.normalize_artist
+COMBINED_SEPARATOR = _vc.COMBINED_SEPARATOR
 LibraryIndex = _vc.LibraryIndex
 score_exact = _vc.score_exact
 score_token_set = _vc.score_token_set
@@ -1273,12 +1274,33 @@ class TestAlternateArtistNameIndex:
     rather than PRUNE. See discogs-etl#305.
     """
 
-    def test_alternate_name_added_as_artist_key(self):
-        """The alias name appears in all_artists alongside the canonical artist."""
+    def test_alternate_name_in_all_artists_for_exact_routing(self):
+        """The alias must be in all_artists so an alias-credited release routes to exact match.
+
+        ``all_artists`` is both the exact-match routing key in
+        ``classify_all_releases`` and the candidate list for the precise
+        two-stage scorer, so the alias belongs there (discogs-etl#305).
+        """
         rows = [("Luke Vibert", "Drum 'n' Bass for Papa", "CD", "Plug")]
         idx = LibraryIndex.from_rows(rows)
         assert "luke vibert" in idx.all_artists
         assert "plug" in idx.all_artists
+
+    def test_alternate_name_not_in_combined_strings(self):
+        """The alias must NOT enter combined_strings (the loose token_set/sort scorers).
+
+        A short/generic alias as a "alias ||| title" combined string would
+        fuzzy-match unrelated Discogs releases sharing that title, inflating
+        false KEEPs. The alias reaches classification via exact-pair lookup and
+        the precise two-stage scorer instead. See discogs-etl#305.
+        """
+        rows = [("Luke Vibert", "Drum 'n' Bass for Papa", "CD", "Plug")]
+        idx = LibraryIndex.from_rows(rows)
+        norm_title = normalize_title("Drum 'n' Bass for Papa")
+        combined_alias = f"plug{COMBINED_SEPARATOR}{norm_title}"
+        combined_canonical = f"luke vibert{COMBINED_SEPARATOR}{norm_title}"
+        assert combined_alias not in idx.combined_strings
+        assert combined_canonical in idx.combined_strings
 
     def test_alternate_name_pair_in_exact_pairs(self):
         """(alias, title) is an exact-match pair mapping to the same title."""

--- a/tests/unit/test_verify_cache.py
+++ b/tests/unit/test_verify_cache.py
@@ -1257,3 +1257,135 @@ class TestFormatFilterClassification:
         releases = [(1, "Autechre", "Confield", None)]
         report = classify_all_releases(releases, idx, matcher)
         assert 1 in report.keep_ids
+
+
+# ---------------------------------------------------------------------------
+# Step N: Alternate artist name (alias / ANV) matching -- discogs-etl#305
+# ---------------------------------------------------------------------------
+
+
+class TestAlternateArtistNameIndex:
+    """LibraryIndex indexes ``alternate_artist_name`` as an additional exact key.
+
+    A library row cataloged under a canonical artist but with an alias in
+    ``alternate_artist_name`` (e.g. Luke Vibert / Plug) must be reachable by
+    the alias, so a Discogs release credited to the alias classifies KEEP
+    rather than PRUNE. See discogs-etl#305.
+    """
+
+    def test_alternate_name_added_as_artist_key(self):
+        """The alias name appears in all_artists alongside the canonical artist."""
+        rows = [("Luke Vibert", "Drum 'n' Bass for Papa", "CD", "Plug")]
+        idx = LibraryIndex.from_rows(rows)
+        assert "luke vibert" in idx.all_artists
+        assert "plug" in idx.all_artists
+
+    def test_alternate_name_pair_in_exact_pairs(self):
+        """(alias, title) is an exact-match pair mapping to the same title."""
+        rows = [("Luke Vibert", "Drum 'n' Bass for Papa", "CD", "Plug")]
+        idx = LibraryIndex.from_rows(rows)
+        norm_title = normalize_title("Drum 'n' Bass for Papa")
+        assert ("plug", norm_title) in idx.exact_pairs
+        assert ("luke vibert", norm_title) in idx.exact_pairs
+
+    def test_alternate_name_maps_to_titles(self):
+        """artist_to_titles resolves the alias to the canonical row's titles."""
+        rows = [("Luke Vibert", "Drum 'n' Bass for Papa", "CD", "Plug")]
+        idx = LibraryIndex.from_rows(rows)
+        norm_title = normalize_title("Drum 'n' Bass for Papa")
+        assert norm_title in idx.artist_to_titles["plug"]
+
+    def test_alternate_name_inherits_format(self):
+        """The alias pair carries the same format data as the canonical pair."""
+        rows = [("Luke Vibert", "Drum 'n' Bass for Papa", "CD", "Plug")]
+        idx = LibraryIndex.from_rows(rows)
+        norm_title = normalize_title("Drum 'n' Bass for Papa")
+        assert idx.format_by_pair.get(("plug", norm_title)) == {"CD"}
+
+    def test_empty_alternate_name_is_noop(self):
+        """A NULL/empty alias does not pollute the index."""
+        rows = [
+            ("Stereolab", "Dots and Loops", "CD", None),
+            ("Cat Power", "Moon Pix", "CD", ""),
+        ]
+        idx = LibraryIndex.from_rows(rows)
+        # Only the two canonical artists, no stray keys.
+        assert set(idx.all_artists) == {"stereolab", "cat power"}
+
+    def test_alternate_equal_to_artist_does_not_duplicate(self):
+        """An alias identical to the canonical artist adds no duplicate pair."""
+        rows = [("Aphex Twin", "Windowlicker", "CD", "Aphex Twin")]
+        idx = LibraryIndex.from_rows(rows)
+        norm_title = normalize_title("Windowlicker")
+        assert ("aphex twin", norm_title) in idx.exact_pairs
+        assert idx.all_artists.count("aphex twin") == 1
+
+    def test_three_tuples_without_alias_unaffected(self):
+        """3-tuple rows (artist, title, format) still work with no alias column."""
+        rows = [("Autechre", "Confield", "CD")]
+        idx = LibraryIndex.from_rows(rows)
+        assert "autechre" in idx.all_artists
+        assert ("autechre", "confield") in idx.exact_pairs
+
+    def test_from_sqlite_reads_alternate_artist_name(self, tmp_path):
+        """from_sqlite indexes alternate_artist_name from library.db."""
+        import sqlite3
+
+        db_path = tmp_path / "library.db"
+        conn = sqlite3.connect(str(db_path))
+        cur = conn.cursor()
+        cur.execute(
+            "CREATE TABLE library (id INTEGER PRIMARY KEY, artist TEXT, title TEXT, "
+            "format TEXT, alternate_artist_name TEXT)"
+        )
+        cur.execute(
+            "INSERT INTO library (artist, title, format, alternate_artist_name) "
+            "VALUES ('Luke Vibert', \"Drum 'n' Bass for Papa\", 'CD', 'Plug')"
+        )
+        conn.commit()
+        conn.close()
+
+        idx = LibraryIndex.from_sqlite(db_path)
+        norm_title = normalize_title("Drum 'n' Bass for Papa")
+        assert "plug" in idx.all_artists
+        assert ("plug", norm_title) in idx.exact_pairs
+
+
+class TestAlternateArtistNameClassification:
+    """End-to-end classification via the alias (AC1 of discogs-etl#305)."""
+
+    def test_alias_credited_release_is_keep(self):
+        """A Discogs release credited to the alias with a matching title -> KEEP."""
+        # Library: canonical "Luke Vibert", alias "Plug".
+        rows = [("Luke Vibert", "Drum 'n' Bass for Papa", "CD", "Plug")]
+        idx = LibraryIndex.from_rows(rows)
+        matcher = MultiIndexMatcher(idx)
+        # Discogs release 3192 is credited to "Plug".
+        releases = [(3192, "Plug", "Drum 'n' Bass for Papa", "CD")]
+        report = classify_all_releases(releases, idx, matcher)
+        assert 3192 in report.keep_ids
+
+    def test_alias_credited_release_subset_title_is_keep(self):
+        """Real 3192 shape: Discogs title is a subset of the library title -> KEEP.
+
+        The library entry is "Drum 'n' Bass for Papa (+ Plug EPs 1,2 & 3)"; the
+        Discogs release drops the bracketed suffix. token_set within the alias's
+        albums recovers it.
+        """
+        rows = [
+            ("Luke Vibert", "Drum 'n' Bass for Papa (+ Plug EPs 1,2 & 3)", "CD", "Plug"),
+        ]
+        idx = LibraryIndex.from_rows(rows)
+        matcher = MultiIndexMatcher(idx)
+        releases = [(3192, "Plug", "Drum 'n' Bass for Papa", "CD")]
+        report = classify_all_releases(releases, idx, matcher)
+        assert 3192 in report.keep_ids
+
+    def test_alias_release_without_library_alias_is_pruned(self):
+        """Control: without the alias column, the same release still prunes."""
+        rows = [("Luke Vibert", "Drum 'n' Bass for Papa", "CD")]
+        idx = LibraryIndex.from_rows(rows)
+        matcher = MultiIndexMatcher(idx)
+        releases = [(3192, "Plug", "Drum 'n' Bass for Papa", "CD")]
+        report = classify_all_releases(releases, idx, matcher)
+        assert 3192 in report.prune_ids


### PR DESCRIPTION
## Summary

`scripts/verify_cache.py` built `LibraryIndex` from the library's **`artist` column only**, so any library release cataloged under a **canonical** artist name but **credited on Discogs to an alias/ANV** failed the artist match and was pruned from the cache. Concrete case: WXYC library id 38167 (*"Drum 'n' Bass for Papa (+ Plug EPs 1,2 & 3)"*, artist "Luke Vibert", `alternate_artist_name` "Plug") vs Discogs release 3192 (credited to "Plug") — 3192 was classified PRUNE and is absent from the prod cache. This is a systematic recall gap for every canonical-vs-alias catalog entry, and one organic source of the LML Discogs-flood cache misses.

## What changed

- `LibraryIndex.from_rows` now accepts an optional 4th tuple element (`alternate_artist_name`) and, when present, indexes it as an **additional exact-match artist key** for the same title + format. This is an exact-key addition, **not** a fuzzy-threshold loosening — KEEP/REVIEW precision is preserved across the ~86K-release import per the ticket's constraint.
- `LibraryIndex.from_sqlite` prefers `artist, title, format, alternate_artist_name` and degrades gracefully (3-tuple, then 2-tuple) when the column is absent.
- Empty aliases, compilation-style aliases, and aliases that collapse to the canonical artist are skipped.

## Tests

New `TestAlternateArtistNameIndex` and `TestAlternateArtistNameClassification` classes cover the index wiring, `from_sqlite` reading the column, the Plug/Luke Vibert end-to-end KEEP (both exact-title and the real subset-title 3192 shape), and controls (empty alias no-op, alias==artist dedup, 3-tuple back-compat, and the pre-fix PRUNE without the alias column). Full `test_verify_cache*` suite green; no regressions across the unit tier.

## Post-merge verification (needs a full cache rebuild — cannot run in this PR)

The remaining two acceptance criteria require a full Discogs-cache rebuild on the EC2 ephemeral instance and must be checked on the next rebuild:

- [ ] AC3: after a rebuild, `SELECT 1 FROM release WHERE id=3192` returns a row and it has `release_track` rows.
- [ ] AC4: KEEP/REVIEW/PRUNE set sizes stay near the 2026-07-06 baseline (KEEP=35,500 / REVIEW=4,667 / PRUNE=43,985) — no material false-KEEP inflation.

## Context

Cache-coverage lever (3 of 3) of the 2026-07-10 LML Discogs-flood work.

- Epic: #308 (cache coverage; children #305 + #217)
- Sibling levers: server-side load-shed WXYC/library-metadata-lookup#756 (done); caller-side reduction WXYC/Backend-Service#1591
- Surfaced by the rebuild in #298 / #301

Closes #305