### PR TITLE
fix(#304): guard ephemeral-rebuild launcher against concurrent instances

### DIFF
--- a/infra/ephemeral-rebuild/README.md
+++ b/infra/ephemeral-rebuild/README.md
@@ -8,7 +8,7 @@ The stack itself does no work — it provisions the infra (Launch Template, two 
 
 | Resource | Purpose |
 |---|---|
-| `LauncherFunction` (Lambda) | Fired by EventBridge `cron(0 6 4 * ? *)`. Calls `RunInstances` on the launch template with a tiny user-data stub. |
+| `LauncherFunction` (Lambda) | Fired by EventBridge `cron(0 6 4 * ? *)`. Prechecks for an already-running rebuild (`Project=discogs-rebuild`, pending/running) and aborts cleanly with a `LaunchCollisionAborted` metric if one exists (#304); otherwise calls `RunInstances` on the launch template with a tiny user-data stub. |
 | `SweeperFunction` (Lambda) | Fired hourly. Force-terminates any rebuild-tagged EC2 older than `MAX_INSTANCE_AGE_HOURS` (default 3) and emits the `StaleInstanceTerminated` metric. |
 | `LaunchTemplate` (EC2) | Pins instance type, AMI (latest AL2023 via SSM public parameter), 100 GB gp3 root, IMDSv2-only, `InstanceInitiatedShutdownBehavior=terminate`. |
 | `InstanceRole` / `InstanceProfile` (IAM) | Attached to the spawned EC2. Grants `ssm:GetParameters` on `${SsmPrefix}/*`, `kms:Decrypt` (scoped via `kms:ViaService`), and `s3:PutObject` on the log bucket. No EC2 mutation grants — shutdown is what releases the instance. |
@@ -128,6 +128,8 @@ aws ec2 terminate-instances --instance-ids i-0xxxxxxx
 |---|---|---|
 | `discogs-rebuild-launcher-errors` | The launcher Lambda errored before completing `RunInstances`. | `aws logs tail /aws/lambda/discogs-rebuild-launcher --since 1h`. Usually IAM scope drift on `iam:PassRole` or a hand-edited launch template. |
 | `discogs-rebuild-stale-instance` | The sweeper terminated a rebuild EC2 that was past its 3h budget. | Pull the log archive from S3 (the sweeper terminates *after* shutdown would have, so the bootstrap's `trap EXIT` upload should have run). Check what step the bootstrap was on when it stalled. |
+
+The launcher also emits a `LaunchCollisionAborted` metric (namespace `WXYC/DiscogsRebuild`) when its #304 precheck suppresses a launch because a rebuild is already in flight. That's the guard working as intended, not a fault, so there's no alarm on it — but a non-zero count is worth a look (usually a manual launch racing the monthly cron). Query it with `aws cloudwatch get-metric-statistics --namespace WXYC/DiscogsRebuild --metric-name LaunchCollisionAborted --statistics Sum --period 86400 --start-time <t0> --end-time <t1>`.
 
 Slack drift / pipeline-failure messages from the bootstrap itself flow through the `SLACK_MONITORING_WEBHOOK` SSM parameter — they're a different channel than CloudWatch alarms.
 

--- a/infra/ephemeral-rebuild/launcher/handler.py
+++ b/infra/ephemeral-rebuild/launcher/handler.py
@@ -4,6 +4,11 @@ Calls EC2 RunInstances with a tiny user-data stub that clones discogs-etl
 and execs scripts/rebuild-cache-bootstrap.sh. The bootstrap then takes
 care of the heavy work (deps, secrets, pipeline run, log upload, shutdown).
 
+Before launching, it prechecks for an already-running rebuild (#304): two
+rebuilds against the shared Railway cache DB deadlock on it. If a rebuild
+instance is already pending/running the launcher aborts cleanly (emitting
+the LaunchCollisionAborted metric) rather than starting a colliding one.
+
 The instance carries an InstanceProfile that grants it ssm:GetParameters on
 ${SSM_PREFIX}/* and s3:PutObject on the log bucket. The launch template
 sets InstanceInitiatedShutdownBehavior=terminate so the instance releases
@@ -35,6 +40,8 @@ from datetime import datetime, timezone
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
 
+METRIC_NAMESPACE = "WXYC/DiscogsRebuild"
+
 USER_DATA_TEMPLATE = """#!/usr/bin/env bash
 set -euxo pipefail
 exec > >(tee /var/log/cloud-init-bootstrap.log | logger -t bootstrap) 2>&1
@@ -59,20 +66,87 @@ def build_user_data(branch: str, log_bucket: str = "") -> str:
     return USER_DATA_TEMPLATE.format(branch=branch, log_bucket=log_bucket)
 
 
-def lambda_handler(event, context, ec2_client=None):
-    """Entry point. Boto3 client is injectable for unit tests."""
+def list_active_rebuild_instances(ec2_client):
+    """Return instance IDs of rebuild EC2s currently ``pending`` or ``running``.
+
+    Mirrors the sweeper's ``list_active_rebuild_instances`` state filter
+    (``tag:Project=discogs-rebuild`` + ``pending``/``running``). The two
+    Lambdas ship as separate deploy packages, so the query is intentionally
+    duplicated here rather than imported; keep the tag/state filter in sync
+    with ``sweeper/handler.py``.
+    """
+    paginator = ec2_client.get_paginator("describe_instances")
+    pages = paginator.paginate(
+        Filters=[
+            {"Name": "tag:Project", "Values": ["discogs-rebuild"]},
+            {"Name": "instance-state-name", "Values": ["running", "pending"]},
+        ],
+    )
+    return [
+        instance["InstanceId"]
+        for page in pages
+        for reservation in page.get("Reservations", [])
+        for instance in reservation.get("Instances", [])
+    ]
+
+
+def _emit_collision_metric(cloudwatch_client=None):
+    """Best-effort ``LaunchCollisionAborted`` emit — never raises.
+
+    The collision is already handled by returning without launching; a
+    CloudWatch failure (throttle, or a not-yet-propagated PutMetricData
+    grant) must not turn that clean abort into an exception, which would
+    trip LauncherErrorAlarm and trigger EventBridge async retries that
+    relaunch the instance the guard just suppressed. Losing the metric is
+    the acceptable failure here; relaunching is not.
+    """
+    try:
+        if cloudwatch_client is None:
+            import boto3
+
+            cloudwatch_client = boto3.client("cloudwatch")
+        cloudwatch_client.put_metric_data(
+            Namespace=METRIC_NAMESPACE,
+            MetricData=[{"MetricName": "LaunchCollisionAborted", "Value": 1.0, "Unit": "Count"}],
+        )
+    except Exception:
+        logger.exception("failed to emit LaunchCollisionAborted metric; aborting launch anyway")
+
+
+def lambda_handler(event, context, ec2_client=None, cloudwatch_client=None):
+    """Entry point. Boto3 clients are injectable for unit tests."""
     branch = os.environ.get("REPO_BRANCH", "main")
     launch_template_id = os.environ["LAUNCH_TEMPLATE_ID"]
     log_bucket = os.environ.get("LOG_BUCKET_NAME", "")
-
-    user_data = build_user_data(branch, log_bucket=log_bucket)
-    timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H%MZ")
-    name_tag = f"discogs-rebuild-{timestamp}"
 
     if ec2_client is None:
         import boto3
 
         ec2_client = boto3.client("ec2")
+
+    # Collision guard (#304). Two rebuilds against the shared Railway cache DB
+    # deadlock on it (2026-07-06 #298 recovery cost several hours). If a
+    # rebuild is already pending/running, abort *cleanly* — do NOT raise: a
+    # raise trips LauncherErrorAlarm and EventBridge's async retries would
+    # relaunch the very instance we're trying to suppress. Instead log, emit
+    # the LaunchCollisionAborted metric, and return. Instance state is the
+    # lease; the >3h sweeper is its TTL, so a crashed instance can't wedge
+    # future rebuilds. Checked before rendering user-data so it's a cheap
+    # fail-fast. (TOCTOU note: DescribeInstances isn't atomic, so two launches
+    # inside the pending/propagation window can still both proceed — this is a
+    # front-door check, not a lock.)
+    active = list_active_rebuild_instances(ec2_client)
+    if active:
+        logger.warning(
+            "LaunchCollisionAborted: rebuild already in flight %s; not launching a second instance",
+            active,
+        )
+        _emit_collision_metric(cloudwatch_client)
+        return {"aborted": True, "active_instances": active}
+
+    user_data = build_user_data(branch, log_bucket=log_bucket)
+    timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H%MZ")
+    name_tag = f"discogs-rebuild-{timestamp}"
 
     logger.info(
         "RunInstances LaunchTemplate=%s branch=%s name=%s", launch_template_id, branch, name_tag

--- a/infra/ephemeral-rebuild/sweeper/handler.py
+++ b/infra/ephemeral-rebuild/sweeper/handler.py
@@ -30,9 +30,16 @@ def _stale_cutoff(max_age_hours: float) -> datetime:
     return datetime.now(timezone.utc) - timedelta(hours=max_age_hours)
 
 
-def list_stale_instances(ec2_client, max_age_hours: float):
-    """Return instance IDs of running rebuild EC2s older than the cutoff."""
-    cutoff = _stale_cutoff(max_age_hours)
+def list_active_rebuild_instances(ec2_client):
+    """Return every rebuild EC2 currently ``pending`` or ``running``.
+
+    This is the same state filter the launcher's collision guard (#304)
+    applies: the launcher asks "is any rebuild in flight?", the sweeper
+    additionally applies an age cutoff (``list_stale_instances``). The
+    launcher ships as a separate deploy package and keeps a mirror of this
+    query — keep the tag/state filter in sync with ``launcher/handler.py``.
+    Each element is ``{"InstanceId": str, "LaunchTime": datetime}``.
+    """
     paginator = ec2_client.get_paginator("describe_instances")
     pages = paginator.paginate(
         Filters=[
@@ -40,14 +47,20 @@ def list_stale_instances(ec2_client, max_age_hours: float):
             {"Name": "instance-state-name", "Values": ["running", "pending"]},
         ],
     )
-    stale = []
+    active = []
     for page in pages:
         for reservation in page.get("Reservations", []):
             for instance in reservation.get("Instances", []):
-                launch_time = instance["LaunchTime"]
-                if launch_time < cutoff:
-                    stale.append({"InstanceId": instance["InstanceId"], "LaunchTime": launch_time})
-    return stale
+                active.append(
+                    {"InstanceId": instance["InstanceId"], "LaunchTime": instance["LaunchTime"]}
+                )
+    return active
+
+
+def list_stale_instances(ec2_client, max_age_hours: float):
+    """Return running rebuild EC2s older than the cutoff."""
+    cutoff = _stale_cutoff(max_age_hours)
+    return [i for i in list_active_rebuild_instances(ec2_client) if i["LaunchTime"] < cutoff]
 
 
 def lambda_handler(event, context, ec2_client=None, cloudwatch_client=None):

--- a/infra/ephemeral-rebuild/template.yaml
+++ b/infra/ephemeral-rebuild/template.yaml
@@ -211,6 +211,14 @@ Resources:
               Action: ec2:RunInstances
               Resource: '*'
             - Effect: Allow
+              Action: ec2:DescribeInstances
+              Resource: '*'
+              # DescribeInstances backs the #304 collision precheck — the
+              # launcher queries for an in-flight rebuild (Project=discogs-rebuild,
+              # pending/running) before RunInstances and aborts if one exists.
+              # Describe* has no resource-level scoping in IAM (it's '*'-only),
+              # matching the sweeper role's grant.
+            - Effect: Allow
               Action: ec2:CreateTags
               Resource: '*'
               # CreateTags is intentionally unrestricted: AWS evaluates this
@@ -222,6 +230,14 @@ Resources:
               # PassRole is the only iam:* the launcher gets, and it's
               # scoped to the single role the launch template attaches.
               Resource: !GetAtt InstanceRole.Arn
+            - Effect: Allow
+              Action: cloudwatch:PutMetricData
+              Resource: '*'
+              # Emits LaunchCollisionAborted (#304) when the precheck suppresses
+              # a colliding launch. Namespace-scoped like the sweeper's grant.
+              Condition:
+                StringEquals:
+                  cloudwatch:namespace: WXYC/DiscogsRebuild
       Events:
         Monthly:
           Type: Schedule

--- a/tests/unit/test_ephemeral_rebuild_launcher.py
+++ b/tests/unit/test_ephemeral_rebuild_launcher.py
@@ -41,10 +41,20 @@ def handler_module():
     return _load_handler()
 
 
+def _make_paginator(reservations):
+    """Build a MagicMock paginator whose paginate() yields ``reservations``."""
+    paginator = MagicMock()
+    paginator.paginate.return_value = iter([{"Reservations": reservations}])
+    return paginator
+
+
 @pytest.fixture
 def fake_ec2(handler_module):
     client = MagicMock()
     client.run_instances.return_value = {"Instances": [{"InstanceId": "i-0123456789abcdef0"}]}
+    # Precheck (#304): by default no peer rebuild instance is running, so the
+    # collision guard falls through and the launcher proceeds to RunInstances.
+    client.get_paginator.return_value = _make_paginator(reservations=[])
     return client
 
 
@@ -155,3 +165,96 @@ def test_lambda_handler_tolerates_missing_log_bucket(handler_module, fake_ec2, m
 
     user_data = fake_ec2.run_instances.call_args.kwargs["UserData"]
     assert "export REBUILD_LOG_BUCKET=" in user_data  # empty value, but key is present
+
+
+# ---------------------------------------------------------------------------
+# Collision guard (#304). Two rebuilds against the shared Railway cache DB
+# deadlock (see the 2026-07-06 #298 recovery). Before RunInstances, the
+# launcher prechecks for an already-active rebuild instance and, if one
+# exists, aborts *cleanly* — no RunInstances, no raise (a raise would trip
+# LauncherErrorAlarm and EventBridge's async retries would relaunch), just a
+# LaunchCollisionAborted metric so the guard tripping is observable.
+# ---------------------------------------------------------------------------
+
+
+def test_lambda_handler_aborts_when_active_rebuild_instance_exists(
+    handler_module, fake_ec2, monkeypatch
+):
+    monkeypatch.setenv("LAUNCH_TEMPLATE_ID", "lt-0fab0123456789ab0")
+    fake_ec2.get_paginator.return_value = _make_paginator(
+        reservations=[{"Instances": [{"InstanceId": "i-inflight"}]}]
+    )
+    cw = MagicMock()
+
+    result = handler_module.lambda_handler({}, None, ec2_client=fake_ec2, cloudwatch_client=cw)
+
+    # No second instance is started.
+    fake_ec2.run_instances.assert_not_called()
+    # The abort is observable via a metric, not an exception.
+    cw.put_metric_data.assert_called_once()
+    metric_kwargs = cw.put_metric_data.call_args.kwargs
+    assert metric_kwargs["Namespace"] == "WXYC/DiscogsRebuild"
+    assert metric_kwargs["MetricData"][0]["MetricName"] == "LaunchCollisionAborted"
+    assert metric_kwargs["MetricData"][0]["Value"] == 1.0
+    # Returns cleanly, surfacing the peer that blocked the launch.
+    assert result["aborted"] is True
+    assert result["active_instances"] == ["i-inflight"]
+
+
+def test_lambda_handler_aborts_cleanly_even_if_metric_emit_fails(
+    handler_module, fake_ec2, monkeypatch
+):
+    """A CloudWatch hiccup must not turn a clean abort into a raise — a raise
+    trips LauncherErrorAlarm and EventBridge's async retries would relaunch
+    the very instance the guard is suppressing."""
+    monkeypatch.setenv("LAUNCH_TEMPLATE_ID", "lt-0fab0123456789ab0")
+    fake_ec2.get_paginator.return_value = _make_paginator(
+        reservations=[{"Instances": [{"InstanceId": "i-inflight"}]}]
+    )
+    cw = MagicMock()
+    cw.put_metric_data.side_effect = RuntimeError("cloudwatch throttled")
+
+    result = handler_module.lambda_handler({}, None, ec2_client=fake_ec2, cloudwatch_client=cw)
+
+    fake_ec2.run_instances.assert_not_called()
+    assert result["aborted"] is True
+
+
+def test_lambda_handler_precheck_filters_project_and_running_state(
+    handler_module, fake_ec2, monkeypatch
+):
+    monkeypatch.setenv("LAUNCH_TEMPLATE_ID", "lt-0fab0123456789ab0")
+
+    handler_module.lambda_handler({}, None, ec2_client=fake_ec2, cloudwatch_client=MagicMock())
+
+    paginate = fake_ec2.get_paginator.return_value.paginate
+    paginate.assert_called_once()
+    filters = paginate.call_args.kwargs["Filters"]
+    assert {"Name": "tag:Project", "Values": ["discogs-rebuild"]} in filters
+    state_filter = next(f for f in filters if f["Name"] == "instance-state-name")
+    assert set(state_filter["Values"]) == {"running", "pending"}
+
+
+def test_lambda_handler_proceeds_when_no_active_rebuild_instance(
+    handler_module, fake_ec2, monkeypatch
+):
+    monkeypatch.setenv("LAUNCH_TEMPLATE_ID", "lt-0fab0123456789ab0")
+    cw = MagicMock()
+
+    result = handler_module.lambda_handler({}, None, ec2_client=fake_ec2, cloudwatch_client=cw)
+
+    fake_ec2.run_instances.assert_called_once()
+    cw.put_metric_data.assert_not_called()
+    assert result["instance_id"] == "i-0123456789abcdef0"
+
+
+def test_list_active_rebuild_instances_returns_ids(handler_module):
+    ec2 = MagicMock()
+    ec2.get_paginator.return_value = _make_paginator(
+        reservations=[
+            {"Instances": [{"InstanceId": "i-a"}, {"InstanceId": "i-b"}]},
+            {"Instances": [{"InstanceId": "i-c"}]},
+        ]
+    )
+
+    assert handler_module.list_active_rebuild_instances(ec2) == ["i-a", "i-b", "i-c"]

--- a/tests/unit/test_ephemeral_rebuild_sweeper.py
+++ b/tests/unit/test_ephemeral_rebuild_sweeper.py
@@ -148,6 +148,25 @@ def test_mixed_old_and_young_only_terminates_old(handler_module, monkeypatch):
     ec2.terminate_instances.assert_called_once_with(InstanceIds=["i-stale-1", "i-stale-2"])
 
 
+def test_list_active_rebuild_instances_ignores_age(handler_module):
+    """The launcher's collision guard (#304) reuses this state-filtered query
+    with no age cutoff, so a brand-new instance must still be reported."""
+    ec2 = _make_ec2(
+        reservations=[
+            {
+                "Instances": [
+                    {"InstanceId": "i-fresh", "LaunchTime": _now() - timedelta(minutes=1)},
+                    {"InstanceId": "i-old", "LaunchTime": _now() - timedelta(hours=6)},
+                ]
+            }
+        ]
+    )
+
+    active = handler_module.list_active_rebuild_instances(ec2)
+
+    assert {i["InstanceId"] for i in active} == {"i-fresh", "i-old"}
+
+
 def test_max_age_hours_env_override(handler_module, monkeypatch):
     """A 1h override should sweep instances that a 3h default leaves alone."""
     monkeypatch.setenv("MAX_INSTANCE_AGE_HOURS", "1")


### PR DESCRIPTION
## Problem

The ephemeral-rebuild launcher (`discogs-rebuild-launcher` Lambda) had no guard against more than one rebuild EC2 running at once. During the #298 recovery on 2026-07-06, a cron-dispatched and a manual instance started close together, both ran `run_pipeline.py` against the same shared Railway discogs-cache, and **deadlocked on the shared DB** — several hours lost. Nothing in the launcher checked for an already-running rebuild before `RunInstances`.

## Change

Front-door precheck in the launcher (the chosen design in #304):

- **Precheck before `RunInstances`.** Before rendering user-data, the launcher queries EC2 for rebuild workers in a non-terminal state (`tag:Project=discogs-rebuild`, `pending`/`running`). If one exists, it does not launch.
- **On collision, return + emit a metric — never raise.** A raise would trip `LauncherErrorAlarm` and trigger EventBridge's async retries (which could relaunch). Instead the guard logs the collision, emits `LaunchCollisionAborted` in the existing `WXYC/DiscogsRebuild` namespace, and returns cleanly. The metric emit is itself best-effort (wrapped) so a CloudWatch hiccup or a not-yet-propagated grant can't turn a clean abort back into a raise.
- **Shared query.** Extracted `list_active_rebuild_instances` in the sweeper (its existing state filter minus the age cutoff) so `list_stale_instances` builds on it; the launcher mirrors the same query in its own deploy package (the two Lambdas ship separately), with sync-comments on both sides.
- **IAM.** Granted the launcher role `ec2:DescribeInstances` (Describe has no resource-level scoping — matches the sweeper grant) and namespace-scoped `cloudwatch:PutMetricData`.

The existing >3h sweeper stays as the backstop: instance state *is* the lease, the sweeper *is* the TTL, so a crashed instance can't wedge future rebuilds — no hand-rolled stale-lease logic.

### Known limitation — TOCTOU

`DescribeInstances` is neither atomic nor strongly consistent, so two launches inside the pending/propagation window can both observe "no peers" and both launch. This is documented in-code as a fast-fail front-door check, not a lock; it would very likely have caught *this* incident (cron + manual, minutes apart). If the race proves real, close it with a conditional-put lease (per #304). The optional **bootstrap-side guard** for the direct-`RunInstances` / manual path is left to a separate ticket, as #304 permits.

## Acceptance criteria

- [x] A launch while a rebuild is `pending`/`running` does **not** start a second instance; it logs, emits `LaunchCollisionAborted`, and returns cleanly (no raise).
- [x] A launch after the previous instance terminated proceeds normally.
- [x] A stale lease from a crashed instance does not permanently block future rebuilds (sweeper TTL).

## Testing

- 21/21 unit tests pass (5 new: collision-abort, clean-abort-when-metric-emit-fails, precheck filter, clean-proceed, both helpers). TDD — confirmed red then green.
- `ruff check` + `ruff format --check` clean; `sam validate --lint` passes.

Closes #304