### PR TITLE
fix(#319): key master_artist dedup on artist_name so NULL-artist_id co-artists survive

### DIFF
--- a/scripts/import_csv.py
+++ b/scripts/import_csv.py
@@ -278,7 +278,15 @@ MASTER_TABLES: list[TableConfig] = [
         "db_columns": ["master_id", "artist_id", "artist_name"],
         "required": ["master_id", "artist_name"],
         "transforms": {},
-        "unique_key": ["master_id", "artist_id"],
+        # ``artist_name`` is in the dedup key because ``artist_id`` is nullable
+        # (empty cell -> NULL) and the converter serializes an artist with no
+        # Discogs id as ``"0"``: two DISTINCT co-artists on one master that both
+        # lack an id would collapse onto a single ``(master_id, NULL)`` /
+        # ``(master_id, "0")`` key and the second credit would be silently
+        # dropped. Keying on the name too keeps them apart (WXYC/discogs-etl#319;
+        # precedent ``release_artist`` #293). Safe as a static key because
+        # ``artist_name`` is always in ``csv_columns`` above.
+        "unique_key": ["master_id", "artist_id", "artist_name"],
     },
 ]
 

--- a/tests/integration/test_import.py
+++ b/tests/integration/test_import.py
@@ -1515,6 +1515,35 @@ class TestImportMasters:
         assert rows == [(100, "Stereolab"), (300, "Stereolab")]
         assert main_release_id == 1001
 
+    def test_distinct_null_artist_id_coartists_both_survive(self, tmp_path) -> None:
+        """Two DISTINCT co-credited artists on one master that BOTH lack an
+        ``artist_id`` must both survive the import. The empty ``artist_id`` cell
+        maps to NULL, so a dedup key of ``(master_id, artist_id)`` collapses
+        both credits onto a single ``(master_id, NULL)`` key and silently drops
+        the second artist. Keying on ``artist_name`` too keeps both distinct
+        (WXYC/discogs-etl#319; mirrors the ``release_artist`` fix #293). Uses the
+        real ``Duke Ellington & John Coltrane`` two-artist master."""
+        self._seed_releases([(1001, 300)])
+        self._write_master_csvs(
+            tmp_path,
+            masters=[(300, "Duke Ellington & John Coltrane", 1001, 1963)],
+            master_artists=[
+                (300, None, "Duke Ellington"),
+                (300, None, "John Coltrane"),
+            ],
+        )
+        conn = psycopg.connect(self.db_url)
+        _ic.import_masters(conn, tmp_path)
+        conn.close()
+        conn = psycopg.connect(self.db_url)
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT artist_name FROM master_artist WHERE master_id = 300 ORDER BY artist_name"
+            )
+            names = [r[0] for r in cur.fetchall()]
+        conn.close()
+        assert names == ["Duke Ellington", "John Coltrane"]
+
     def test_rerun_is_idempotent(self, tmp_path) -> None:
         """A second run neither duplicates rows nor raises a PK violation —
         the truncate-and-reload is authoritative. Guards the monthly rerun."""

--- a/tests/unit/test_import_csv.py
+++ b/tests/unit/test_import_csv.py
@@ -22,6 +22,7 @@ BASE_TABLES = _ic.BASE_TABLES
 TRACK_TABLES = _ic.TRACK_TABLES
 VIDEO_TABLES = _ic.VIDEO_TABLES
 ARTIST_TABLES = _ic.ARTIST_TABLES
+MASTER_TABLES = _ic.MASTER_TABLES
 TableConfig = _ic.TableConfig
 _import_tables_parallel = _ic._import_tables_parallel
 import_artist_details = _ic.import_artist_details
@@ -893,6 +894,115 @@ class TestImportCsvExtraDedupKey:
         ``WideTrackArtistDedup`` in discogs-xml-converter#74."""
         rta_config = next(t for t in TRACK_TABLES if t["table"] == "release_track_artist")
         assert rta_config.get("optional_unique_key") == ["extra"]
+
+
+class TestImportCsvMasterArtistDedupKey:
+    """WXYC/discogs-etl#319: the loader must keep two DISTINCT co-credited
+    artists on one master even when both lack an ``artist_id``.
+
+    ``master_artist.artist_id`` is nullable (the Discogs artist id can be
+    absent) and ``import_csv`` maps an empty cell to ``None``, so two different
+    co-artists sharing a NULL/empty ``artist_id`` collapse onto one
+    ``(master_id, NULL)`` dedup key — first-wins — and the second credit is
+    silently dropped. In the converter's actual output the missing id is
+    serialized as ``"0"`` rather than an empty cell (``MasterArtist.id`` is a
+    non-nullable ``u64`` that defaults to 0), which collapses just the same on
+    the shared ``(master_id, "0")`` key. Adding ``artist_name`` to the key keeps
+    both distinct. Mirrors the ``release_artist`` precedent #293.
+    """
+
+    def test_master_artist_keeps_distinct_null_artist_id_coartists(self, tmp_path) -> None:
+        """Two co-artists on one master with an EMPTY ``artist_id`` and
+        different names both survive. Driven from the real ``MASTER_TABLES``
+        config so the widened static key is what makes this pass. RED on the
+        current ``(master_id, artist_id)`` key (collapses to 1), GREEN after
+        adding ``artist_name``."""
+        ma_config = next(t for t in MASTER_TABLES if t["table"] == "master_artist")
+
+        csv_path = tmp_path / "master_artist.csv"
+        csv_path.write_text(
+            "master_id,artist_id,artist_name\n300,,Duke Ellington\n300,,John Coltrane\n"
+        )
+
+        conn, captured = _recording_conn()
+        count = import_csv(
+            conn,
+            csv_path,
+            table="master_artist",
+            csv_columns=ma_config["csv_columns"],
+            db_columns=ma_config["db_columns"],
+            required_columns=ma_config["required"],
+            transforms=ma_config["transforms"],
+            unique_key=ma_config["unique_key"],
+        )
+
+        assert count == 2
+        assert captured["rows"][0] == ("300", None, "Duke Ellington")
+        assert captured["rows"][1] == ("300", None, "John Coltrane")
+
+    def test_master_artist_keeps_distinct_zero_artist_id_coartists(self, tmp_path) -> None:
+        """The converter's real vector: an artist lacking a Discogs id is
+        emitted with ``artist_id="0"`` (non-nullable ``u64`` default), so two
+        distinct co-artists share ``(master_id, "0")``. Both must survive.
+        RED on the current key (collapses to 1), GREEN after adding
+        ``artist_name``."""
+        ma_config = next(t for t in MASTER_TABLES if t["table"] == "master_artist")
+
+        csv_path = tmp_path / "master_artist.csv"
+        csv_path.write_text(
+            "master_id,artist_id,artist_name\n300,0,Duke Ellington\n300,0,John Coltrane\n"
+        )
+
+        conn, captured = _recording_conn()
+        count = import_csv(
+            conn,
+            csv_path,
+            table="master_artist",
+            csv_columns=ma_config["csv_columns"],
+            db_columns=ma_config["db_columns"],
+            required_columns=ma_config["required"],
+            transforms=ma_config["transforms"],
+            unique_key=ma_config["unique_key"],
+        )
+
+        assert count == 2
+        assert captured["rows"][0] == ("300", "0", "Duke Ellington")
+        assert captured["rows"][1] == ("300", "0", "John Coltrane")
+
+    def test_master_artist_genuine_duplicate_still_collapses(self, tmp_path) -> None:
+        """Over-widening guard: two rows identical on ``(master_id, artist_id,
+        artist_name)`` still collapse to one, keeping the first — the widened
+        key must not stop deduplicating true duplicate credits."""
+        ma_config = next(t for t in MASTER_TABLES if t["table"] == "master_artist")
+
+        csv_path = tmp_path / "master_artist.csv"
+        csv_path.write_text(
+            "master_id,artist_id,artist_name\n300,,Duke Ellington\n300,,Duke Ellington\n"
+        )
+
+        conn, captured = _recording_conn()
+        count = import_csv(
+            conn,
+            csv_path,
+            table="master_artist",
+            csv_columns=ma_config["csv_columns"],
+            db_columns=ma_config["db_columns"],
+            required_columns=ma_config["required"],
+            transforms=ma_config["transforms"],
+            unique_key=ma_config["unique_key"],
+        )
+
+        assert count == 1
+        assert captured["rows"][0] == ("300", None, "Duke Ellington")
+
+    def test_master_artist_config_unique_key_includes_artist_name(self) -> None:
+        """Config pin: ``master_artist`` dedups on ``artist_name`` so a future
+        edit that drops it from the static key trips this test rather than
+        silently reintroducing the NULL-``artist_id`` collapse (#319).
+        ``artist_name`` is a hard ``csv_columns`` entry, so the static key is
+        safe."""
+        ma_config = next(t for t in MASTER_TABLES if t["table"] == "master_artist")
+        assert ma_config["unique_key"] == ["master_id", "artist_id", "artist_name"]
 
 
 class TestImportCsvMissingColumns:


### PR DESCRIPTION
## Problem

`scripts/import_csv.py` de-dupes `master_artist` rows in Python on `unique_key: ["master_id", "artist_id"]`. `artist_id` is nullable — an empty CSV cell is mapped to `None` before the dedup key is built — so two *distinct* co-credited artists on the same master that both lack an `artist_id` collapse onto a single `(master_id, NULL)` key. First-wins, and the second co-artist's row is silently dropped. `master_artist` has no DB unique constraint, so no error is raised. This was inert until #317/#318 (masters never loaded before); the one-time prod import (2026-07-19) logged `skipped 181 duplicates` on `master_artist`, an unknown fraction of which may be legitimate distinct co-credits collapsed on a shared/empty `artist_id`.

## Fix

Widen the `master_artist` dedup key to `["master_id", "artist_id", "artist_name"]`, mirroring the `release_artist` precedent (#293), which keys on the name (`["release_id", "artist_name", "extra"]`) for exactly this reason. Adding `artist_name` to the key is strictly safe: it can only *prevent* the collapse of distinct rows, never collapse legitimately-distinct ones. A genuine duplicate (identical on all three columns) still collapses. An explanatory comment above the key records the rationale (#319, precedent #293).

## Converter finding (Step 1)

I inspected the upstream converter (`discogs-xml-converter` `src/master_writer.rs` + `src/master_parser.rs`). The converter does **not** emit an empty/missing `artist_id` cell for `master_artist` rows: `MasterArtist.id` is a non-nullable `u64` with `#[derive(Default)]` (default `0`), the parser assigns `current_artist.id = current_text.trim().parse().unwrap_or(0)` (so a missing/empty/unparseable `<id>` becomes `0`), and the writer serializes it via `artist.id.to_string()` — which produces `"0"`, never an empty string.

So the exact "empty/NULL `artist_id`" cell is **not observed in practice** from this converter. The real-world collapse vector is a shared `artist_id="0"`: two distinct co-artists that both lack a Discogs id are both serialized with `"0"` and collapse on `(master_id, "0")`. The fix covers both the `"0"` case (the actual converter output) and the hypothetical empty/NULL case (defensive, matching the #293 precedent). Both are tested.

## Tests (TDD)

Written failing-first, then made green:

- Integration (`TestImportMasters.test_distinct_null_artist_id_coartists_both_survive`): imports a master with two `master_artist` rows carrying different names and an empty `artist_id`; asserts both survive in the DB. RED (1 row) on the old key, GREEN after.
- Unit (`TestImportCsvMasterArtistDedupKey`): distinct co-artists with empty `artist_id` both survive; distinct co-artists with `artist_id="0"` (the converter's real output) both survive; a genuine full duplicate still collapses to one (over-widening guard); and a config-pin on the widened `unique_key`.

Existing masters tests (`TestImportMasters`, `test_import_csv.py` masters cases) stay green. One unrelated pre-existing failure (`TestImportArtworkPreservation::test_rebuild_preserves_artwork_when_dump_missing_image`) fails identically on the base branch — a `now()`/DST date-boundary artifact, untouched here.

Closes #319

## Related

- WXYC/discogs-etl#320 — stale dedup/master_id contract (sibling follow-up)
- WXYC/discogs-etl#321 — automation.md FIFO caveat (sibling follow-up)
- WXYC/discogs-etl#317 — masters phase (origin of this finding)
- WXYC/discogs-etl#318 — masters phase PR (where the `/code-review max` pass surfaced this)
