### PR TITLE
fix(#320): infer dedup completion from post-swap FK, not the persistent master_id column

### DIFF
--- a/schema/create_database.sql
+++ b/schema/create_database.sql
@@ -273,8 +273,12 @@ CREATE INDEX IF NOT EXISTS idx_artist_name_variation_artist_id ON artist_name_va
 CREATE INDEX IF NOT EXISTS idx_artist_member_artist_id ON artist_member(artist_id);
 CREATE INDEX IF NOT EXISTS idx_artist_url_artist_id ON artist_url(artist_id);
 
--- Partial index on master_id for dedup performance.
--- Transient: dropped automatically by dedup copy-swap (which excludes master_id).
+-- Partial index on master_id: speeds the dedup partition scan.
+-- The INDEX is transient — the copy-swap rebuilds `release` via CTAS (CREATE
+-- TABLE new_release AS SELECT ...), which carries no indexes, and
+-- add_base_constraints_and_indexes does not recreate it, so it is gone
+-- post-swap. The master_id COLUMN itself persists (it is in DEDUP_TABLES; see
+-- L64 and scripts/dedup_releases.py) — the swap does not exclude it.
 CREATE INDEX IF NOT EXISTS idx_release_master_id ON release(master_id) WHERE master_id IS NOT NULL;
 
 -- Master indexes

--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -766,7 +766,7 @@ def convert_and_filter(
 def _infer_pipeline_state(db_url: str, csv_dir: str) -> PipelineState:
     """Infer pipeline state from database structure.
 
-    Inspects table existence, row counts, column presence, and index names
+    Inspects table existence, row counts, index names, and constraint names
     to determine which pipeline steps have already completed. Steps that
     cannot be inferred (prune, vacuum) are left as pending since they are
     safe to re-run.
@@ -804,14 +804,29 @@ def _infer_pipeline_state(db_url: str, csv_dir: str) -> PipelineState:
                 return state
             state.mark_completed("create_indexes")
 
-            # dedup: master_id column gone?
+            # dedup: post-swap FK constraint present?
+            #
+            # The dedup copy-swap does NOT drop release.master_id — the column is
+            # in DEDUP_TABLES (scripts/dedup_releases.py) and is load-bearing for the
+            # #317 masters phase (import_masters / --masters-only do
+            # SELECT DISTINCT master_id FROM release), so it MUST persist. The old
+            # "master_id column gone?" signal was a stale pre-#129 contract that never
+            # fires now, wrongly forcing a resume to re-run dedup.
+            #
+            # The durable post-swap artifact is the NAMED FK fk_release_artist_release,
+            # which add_base_constraints_and_indexes adds only after the swap
+            # (scripts/dedup_releases.py). Before dedup the base schema's inline FK on
+            # release_artist is auto-named release_artist_release_id_fkey (a different
+            # name) and is dropped by the swap's DROP TABLE ... CASCADE, so this
+            # constraint name is absent pre-dedup and present post-dedup.
             cur.execute(
                 "SELECT EXISTS ("
-                "  SELECT 1 FROM information_schema.columns"
-                "  WHERE table_name = 'release' AND column_name = 'master_id'"
+                "  SELECT 1 FROM information_schema.table_constraints"
+                "  WHERE constraint_name = 'fk_release_artist_release'"
+                "    AND constraint_type = 'FOREIGN KEY'"
                 ")"
             )
-            if cur.fetchone()[0]:
+            if not cur.fetchone()[0]:
                 return state
             state.mark_completed("dedup")
 

--- a/tests/integration/test_dedup.py
+++ b/tests/integration/test_dedup.py
@@ -25,6 +25,12 @@ assert _dspec is not None and _dspec.loader is not None
 _dd = importlib.util.module_from_spec(_dspec)
 _dspec.loader.exec_module(_dd)
 
+_RUN_PIPELINE_PATH = Path(__file__).parent.parent.parent / "scripts" / "run_pipeline.py"
+_rpspec = importlib.util.spec_from_file_location("run_pipeline", _RUN_PIPELINE_PATH)
+assert _rpspec is not None and _rpspec.loader is not None
+_rp = importlib.util.module_from_spec(_rpspec)
+_rpspec.loader.exec_module(_rp)
+
 import_csv_func = _ic.import_csv
 import_artwork = _ic.import_artwork
 create_track_count_table = _ic.create_track_count_table
@@ -40,6 +46,7 @@ load_library_labels = _dd.load_library_labels
 load_label_hierarchy = _dd.load_label_hierarchy
 create_label_match_table = _dd.create_label_match_table
 DEDUP_TABLES = _dd.DEDUP_TABLES
+_infer_pipeline_state = _rp._infer_pipeline_state
 
 pytestmark = pytest.mark.pg
 
@@ -267,8 +274,10 @@ class TestDedup:
     def test_master_id_column_persists_when_no_dedup(self) -> None:
         """master_id persists when no duplicates found (copy-swap not triggered).
 
-        With format-aware dedup, each (master_id, format) group in fixtures has one member,
-        so no copy-swap occurs and master_id stays in the schema.
+        With format-aware dedup, each (master_id, format) group in these fixtures has one
+        member, so no copy-swap occurs — the base schema is untouched and master_id is
+        trivially present. (master_id also persists *through* a real copy-swap, since it
+        is in DEDUP_TABLES; see TestDedupCopySwapPreservesMasterId.)
         """
         conn = self._connect()
         with conn.cursor() as cur:
@@ -307,7 +316,7 @@ class TestDedup:
         assert expected.issubset(fk_tables)
 
     def test_format_column_persists_after_dedup(self) -> None:
-        """format column exists after dedup copy-swap (unlike master_id which is dropped)."""
+        """format column exists after dedup copy-swap (it is in DEDUP_TABLES, like master_id)."""
         conn = self._connect()
         with conn.cursor() as cur:
             cur.execute(
@@ -1319,3 +1328,24 @@ class TestDedupCopySwapPreservesMasterId:
                 "WXYC/discogs-etl#239 / WXYC/library-metadata-lookup#423"
             )
         conn.close()
+
+    def test_infer_pipeline_state_marks_dedup_complete_post_swap(self, tmp_path) -> None:
+        """Resume without a state file infers ``dedup`` complete after a real copy-swap.
+
+        Regression for WXYC/discogs-etl#320. ``_infer_pipeline_state`` used to key
+        the dedup-completion signal on ``release.master_id`` being *absent* — a stale
+        contract from before #129/#317, when the copy-swap dropped the column. Now that
+        ``master_id`` persists post-swap (it is in ``DEDUP_TABLES`` and load-bearing for
+        the #317 masters phase / ``--masters-only``), that signal never fires and dedup
+        is wrongly inferred as pending. The durable post-swap artifact this class already
+        produces is the named FK ``fk_release_artist_release`` (added only by
+        ``add_base_constraints_and_indexes``; the pre-dedup schema's inline FK is
+        auto-named ``release_artist_release_id_fkey`` and is dropped by the swap's
+        ``DROP TABLE ... CASCADE``).
+        """
+        state = _infer_pipeline_state(self.db_url, str(tmp_path))
+        assert state.is_completed("dedup"), (
+            "dedup not inferred complete after a real copy-swap — the master_id column "
+            "persists post-swap (WXYC/discogs-etl#320), so the completion signal must key "
+            "off the post-swap fk_release_artist_release constraint, not master_id absence"
+        )


### PR DESCRIPTION
## Problem

`release.master_id` now **persists** through the dedup copy-swap — it is in `DEDUP_TABLES` (`scripts/dedup_releases.py`) and became load-bearing in [#317](https://github.com/WXYC/discogs-etl/issues/317)/[#318](https://github.com/WXYC/discogs-etl/pull/318): `import_masters` and the `--masters-only` prod path run `SELECT DISTINCT master_id FROM release`. But several artifacts still encoded the obsolete contract that dedup *drops* `master_id`.

The latent bug: `_infer_pipeline_state` (the `--resume`-without-a-state-file recovery path) keyed the dedup-completion signal on *"is the `release.master_id` column gone?"*. Since the column never disappears now, that check always returns early, so `dedup` is inferred as **not** complete and dedup / tracks / index steps re-run needlessly.

## Fix

- **A — `scripts/run_pipeline.py` `_infer_pipeline_state`:** replace the `master_id`-gone signal with a durable post-swap artifact — the named FK `fk_release_artist_release`, which `add_base_constraints_and_indexes` adds only after the swap. It is absent pre-dedup (the base schema's inline FK on `release_artist` is auto-named `release_artist_release_id_fkey` and is dropped by the swap's `DROP TABLE ... CASCADE`) and present post-dedup. Verified absent-before / present-after against a real PG copy-swap.
- **B — `schema/create_database.sql:277`:** rewrite the stale comment. The partial index `idx_release_master_id` is transient because the copy-swap rebuilds `release` via CTAS (which carries no indexes) and `add_base_constraints_and_indexes` does not recreate it — **not** because `master_id` is "excluded". The `master_id` **column** persists post-swap.
- **C — `tests/integration/test_dedup.py`:** correct two stale docstrings that claimed `master_id` is dropped by the copy-swap.

## Tests

New regression test `TestDedupCopySwapPreservesMasterId::test_infer_pipeline_state_marks_dedup_complete_post_swap` builds a real post-copy-swap DB state and asserts `_infer_pipeline_state` marks `dedup` complete (fails against the old `master_id`-gone signal, passes with the FK signal). The class's existing `test_master_id_column_persists_after_copy_swap` guards the #317 contract.

## Behavior unchanged

Dedup pipeline behavior is **not** touched — `DEDUP_TABLES` is unchanged, so `release.master_id` continues to persist through the copy-swap. This is a stale-contract fix (inference signal + comments/docstrings) only. `_infer_pipeline_state` affects only the `--resume`-without-state-file path; the happy path (with a state file) is unaffected.

Closes #320

## Related

- WXYC/discogs-etl#317
- WXYC/discogs-etl#318
- WXYC/discogs-etl#319
- WXYC/discogs-etl#321