### PR TITLE
Add additive clone-to-cache seed script for pinned/out-of-scope releases

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,5 +67,6 @@ The `entity.*` schema in the cache database is **owned by this repo** and is cre
 | Key | Owner | Purpose |
 |---|---|---|
 | `842001` | library-metadata-lookup | `lml_cache.*` streaming-catalog bootstrap transaction (`entity/streaming_catalog.py`, LML#842 PR A) — serializes concurrent boots around its `CREATE OR REPLACE FUNCTION` / constraint-widen DDL |
+| `330001` | discogs-etl | `scripts/seed_cache_from_clone.py` `_seed_family` real (non-dry-run) writes — serializes concurrent `seed_releases_additive`/`seed_artists_additive` invocations against the same target so two overlapping runs can't both compute the same release/artist as "new" and double-insert the arbiter-less child rows (PR#330) |
 
 Convention for new keys: `<issue-number> * 1000 + sequence` in the owning repo (842001 = LML#842, first key), which keeps keys human-traceable and collision-free without central coordination beyond this table.

--- a/README.md
+++ b/README.md
@@ -193,6 +193,20 @@ python scripts/verify_cache.py \
 
 `--copy-to` and `--prune` are mutually exclusive.
 
+### Seeding the Cache from a Full Clone (out-of-band)
+
+`scripts/seed_cache_from_clone.py` is a one-off operational tool (not a pipeline step) that **additively** copies an artist-scoped release row-set from a full, unfiltered Discogs clone into an existing target discogs-cache. It exists to backfill a finite, known set of non-library releases into prod without a full rebuild — e.g. the [Backend-Service#1631](https://github.com/WXYC/Backend-Service/issues/1631) Apple-Music-URL "cold tail" of albums whose Discogs releases the library filter never admitted.
+
+```bash
+python scripts/seed_cache_from_clone.py \
+  --source postgresql://localhost:5432/discogs \
+  --target "$DATABASE_URL_DISCOGS" \
+  --ids-file tail_release_ids.txt \
+  --dry-run
+```
+
+Unlike `--copy-to` (which builds a *fresh* lean database and drops target tables), this seeds into a **populated** cache and never overwrites: `release`/`artist` use `ON CONFLICT (id) DO NOTHING`, and the arbiter-less child tables are gated on the new-parent-id set so a re-run inserts no duplicates. `--ids-file` holds the release_ids to seed (one per line), selected upstream via LML's `lower(f_unaccent(artist_name)) % $artist` trigram predicate over the tail artists. Always `--dry-run` first. Never run `verify_cache.py --prune` against the seeded rows — it prunes non-library releases, which is exactly what this seeds. Full procedure in [`docs/seed-cache-from-clone-runbook.md`](docs/seed-cache-from-clone-runbook.md).
+
 ### Resuming a Failed Pipeline
 
 If a pipeline run fails mid-way (e.g., disk full during index creation), you can resume from where it left off instead of restarting from scratch:

--- a/docs/seed-cache-from-clone-runbook.md
+++ b/docs/seed-cache-from-clone-runbook.md
@@ -1,0 +1,53 @@
+# Seed cache from clone — operator runbook
+
+`scripts/seed_cache_from_clone.py` **additively** copies an artist-scoped release row-set from a full, unfiltered Discogs clone into an existing (populated) target discogs-cache. It is a one-shot operator action, not a pipeline step and not on a schedule.
+
+Motivation: [Backend-Service#1631](https://github.com/WXYC/Backend-Service/issues/1631)'s Apple-Music-URL backfill stalls on a finite "cold tail" of non-library albums whose Discogs releases the library filter never admitted to prod discogs-cache. On a miss LML falls through to the live Discogs API + cold path (>15s), times out, and trips the health watchdog. A full local clone already holds those releases in the right shape; this seeds exactly those into prod so LML resolves them as fast cache hits and the paused backfill drains normally. See `plans/bs1631-tail-cache-seed.md` for the full design.
+
+## When to run
+
+When a bounded, known set of releases needs to exist in a populated cache and a full rebuild is not warranted. This is **not** the mechanism for widening the cache filter to open-ended demand (rejected as low-ROI). The target is a specific release_id list produced upstream.
+
+Do not run while a bulk job is hammering LML on the shared Discogs token — this seed does not call Discogs (clone → PG copy only), but the downstream backfill it unblocks does.
+
+## Guarantees (why it is safe against a populated prod cache)
+
+- **Additive only.** `release` (id PK) and `cache_metadata` (release_id PK) insert with `ON CONFLICT DO NOTHING`. The arbiter-less child tables (`release_artist`, `release_label`, `release_genre`, `release_style`, `release_track`, `release_track_artist`, `release_video`; and `artist_name_variation` on the artist side) have no PK/UNIQUE, so idempotency is driven off the parent: children are inserted only for the **new-parent-id set** = (requested ids) − (ids already on the target). A parent id is in that set only if it was absent, so its children were necessarily absent too — no duplicate rows, fully re-runnable.
+- **Never overwrites.** No UPDATE, no DELETE, no TRUNCATE. Existing prod rows are byte-identical before and after.
+- **Column-drift tolerant.** Column lists come from `verify_cache.COPY_TABLE_SPEC` (the canonical source of truth) intersected with the columns actually present on both databases. The clone predates `release.artwork_checked_at` / `release.not_found` / `artist.not_found` and has no `release_video` table; those simply fall out of the copy and default on the target.
+- **`verify_cache.py --prune` is prohibited against the seeded rows.** It classifies releases against WXYC library membership and DELETEs non-matches — tail artists are non-library by definition, so it would delete exactly what was seeded. Post-seed verification is a separate read-only integrity check.
+
+## Inputs
+
+| Flag | Required | Notes |
+|---|---|---|
+| `--source` | yes | Clone DSN, read-only (`SELECT` / `COPY … TO STDOUT` only). e.g. `postgresql://localhost:5432/discogs`. |
+| `--target` | yes | Target discogs-cache DSN. For prod, the Railway `Postgres` service `DATABASE_PUBLIC_URL` (reading prod requires explicit approval; writing is heavier — gate on a green dry-run first). |
+| `--ids-file` | yes | Release_ids to seed, one per line (blank lines and `#` comments ignored). Selected upstream via LML's `lower(f_unaccent(artist_name)) % $artist` trigram predicate over the tail artists — artist-scoped (keep all releases by a tail artist), not album-scoped. |
+| `--dry-run` | no | Report per-table row-set sizes without writing. **Always run first.** |
+
+The script depends only on `psycopg` and `lib.observability` (installable via `pip install -e .`) and imports `COPY_TABLE_SPEC` from `verify_cache`.
+
+## Procedure
+
+1. **Select the tail release_ids** upstream (LML `%` trigram over the distinct tail artists from `wxyc_schema.album_metadata`) and write them to `tail_release_ids.txt`.
+2. **Dry-run against a scratch prod-shaped target** to confirm per-table row-set sizes look sane:
+   ```bash
+   python scripts/seed_cache_from_clone.py \
+     --source postgresql://localhost:5432/discogs \
+     --target postgresql://localhost:5433/discogs_seed_scratch \
+     --ids-file tail_release_ids.txt \
+     --dry-run
+   ```
+3. **Dry-run against prod** (still no writes) to see how many candidates are genuinely new vs already present.
+4. **Seed prod** (drop `--dry-run`). The write is one transaction per family; per-table inserted counts are logged.
+5. **Verify (read-only).** Referential-integrity check over the seeded release_ids (every child has a parent `release`; no orphans; `artwork_url` populated where the clone had it), then a live coverage check: prod LML `/api/v1/lookup` on ≥5 tail albums → expect cache hit, zero `discogs.fallthrough` events. **Do not** run `verify_cache.py`.
+6. **Resume the paused backfill** from its cursor (`BACKFILL_ALBUM_AFTER_ID`) — separate go.
+
+## Artist seeding
+
+`seed_artists_additive` (same guarantees) copies tail `artist` rows + their `artist_name_variation` children when LML enrichment JOINs them and they are absent on the target. `artist` (id PK) uses `ON CONFLICT`; `artist_name_variation` is arbiter-less and parent-gated on the new-artist-id set. Only seed artists if the column-diff/enrichment step confirms they are needed.
+
+## Rollback
+
+There is nothing to roll back on a partial run — it is additive and re-runnable; a re-run computes a smaller new-parent-id set and completes. If seeded rows must be removed, delete by the exact seeded release_id list (never `verify_cache.py --prune`), after a `SELECT` with the same predicate to confirm scope.

--- a/docs/seed-cache-from-clone-runbook.md
+++ b/docs/seed-cache-from-clone-runbook.md
@@ -12,21 +12,23 @@ Do not run while a bulk job is hammering LML on the shared Discogs token — thi
 
 ## Guarantees (why it is safe against a populated prod cache)
 
-- **Additive only.** `release` (id PK) and `cache_metadata` (release_id PK) insert with `ON CONFLICT DO NOTHING`. The arbiter-less child tables (`release_artist`, `release_label`, `release_genre`, `release_style`, `release_track`, `release_track_artist`, `release_video`; and `artist_name_variation` on the artist side) have no PK/UNIQUE, so idempotency is driven off the parent: children are inserted only for the **new-parent-id set** = (requested ids) − (ids already on the target). A parent id is in that set only if it was absent, so its children were necessarily absent too — no duplicate rows, fully re-runnable.
+- **Additive only.** `release` (id PK), `cache_metadata` (release_id PK), and `artist` (id PK) insert with `ON CONFLICT DO NOTHING`. The arbiter-less child tables (`release_artist`, `release_label`, `release_genre`, `release_style`, `release_track`, `release_track_artist`, `release_video`; and `artist_name_variation` on the artist side) have no PK/UNIQUE, so idempotency is driven off the parent: children are inserted only for the **new-parent-id set** = (requested ids) − (ids already on the target). A parent id is in that set only if it was absent, so its children were necessarily absent too — no duplicate rows, fully re-runnable. A `pg_advisory_xact_lock` (key `330001`, registered in this repo's `CLAUDE.md` "Advisory lock keys" table) spans the new-id computation through the write for every real run, so two overlapping invocations against the same target serialize instead of racing into duplicate child rows.
 - **Never overwrites.** No UPDATE, no DELETE, no TRUNCATE. Existing prod rows are byte-identical before and after.
-- **Column-drift tolerant.** Column lists come from `verify_cache.COPY_TABLE_SPEC` (the canonical source of truth) intersected with the columns actually present on both databases. The clone predates `release.artwork_checked_at` / `release.not_found` / `artist.not_found` and has no `release_video` table; those simply fall out of the copy and default on the target.
+- **Column-drift tolerant.** Column lists come from `verify_cache.COPY_TABLE_SPEC` (the canonical source of truth) intersected with the columns actually present on both databases. The clone predates `release.artwork_checked_at` / `release.not_found` / `artist.not_found` and has no `release_video` table; those simply fall out of the copy and default on the target. `artist.fetched_at` (NOT NULL on prod) is `COALESCE`d to `now()` on the copy in case the clone carries a NULL.
+- **`--source` is genuinely read-only.** The source connection only ever runs `SELECT` / `COPY … TO STDOUT`; the new-id set is embedded as an `ANY(ARRAY[...]::integer[])` literal in each query rather than staged into a source-side temp table, so `--source` works against a strictly read-only role or a hot standby.
 - **`verify_cache.py --prune` is prohibited against the seeded rows.** It classifies releases against WXYC library membership and DELETEs non-matches — tail artists are non-library by definition, so it would delete exactly what was seeded. Post-seed verification is a separate read-only integrity check.
 
 ## Inputs
 
 | Flag | Required | Notes |
 |---|---|---|
-| `--source` | yes | Clone DSN, read-only (`SELECT` / `COPY … TO STDOUT` only). e.g. `postgresql://localhost:5432/discogs`. |
-| `--target` | yes | Target discogs-cache DSN. For prod, the Railway `Postgres` service `DATABASE_PUBLIC_URL` (reading prod requires explicit approval; writing is heavier — gate on a green dry-run first). |
-| `--ids-file` | yes | Release_ids to seed, one per line (blank lines and `#` comments ignored). Selected upstream via LML's `lower(f_unaccent(artist_name)) % $artist` trigram predicate over the tail artists — artist-scoped (keep all releases by a tail artist), not album-scoped. |
+| `--source` | yes | Clone DSN, read-only (`SELECT` / `COPY … TO STDOUT` only — the script never writes to `--source`). e.g. `postgresql://localhost:5432/discogs`. |
+| `--target` | yes | Target discogs-cache DSN. For prod, the Railway `Postgres` service `DATABASE_PUBLIC_URL` (reading prod requires explicit approval; writing is heavier — gate on a green dry-run first). Must differ from `--source`; the script refuses an identical `--source`/`--target` pair (a transposed pair would otherwise silently no-op). |
+| `--ids-file` | yes | Release_ids (or, with `--seed-artists`, artist_ids) to seed, one per line (blank lines and `#` comments ignored). Selected upstream via LML's `lower(f_unaccent(artist_name)) % $artist` trigram predicate over the tail artists — artist-scoped (keep all releases by a tail artist), not album-scoped. |
+| `--seed-artists` | no | Seed the `artist` family (see "Artist seeding" below) from `--ids-file` instead of the default `release` family. |
 | `--dry-run` | no | Report per-table row-set sizes without writing. **Always run first.** |
 
-The script depends only on `psycopg` and `lib.observability` (installable via `pip install -e .`) and imports `COPY_TABLE_SPEC` from `verify_cache`.
+The script depends only on `psycopg` and `lib.observability` (installable via `pip install -e .`), imports `COPY_TABLE_SPEC` from `verify_cache`, and imports `parse_keep_release_ids` from `lib.keep_release_ids` for `--ids-file` parsing.
 
 ## Procedure
 
@@ -46,7 +48,18 @@ The script depends only on `psycopg` and `lib.observability` (installable via `p
 
 ## Artist seeding
 
-`seed_artists_additive` (same guarantees) copies tail `artist` rows + their `artist_name_variation` children when LML enrichment JOINs them and they are absent on the target. `artist` (id PK) uses `ON CONFLICT`; `artist_name_variation` is arbiter-less and parent-gated on the new-artist-id set. Only seed artists if the column-diff/enrichment step confirms they are needed.
+`seed_artists_additive` (same guarantees, invoked via `--seed-artists`) copies tail `artist` rows + their `artist_name_variation` children when LML enrichment JOINs them and they are absent on the target. `artist` (id PK) uses `ON CONFLICT`; `artist_name_variation` is arbiter-less and parent-gated on the new-artist-id set. Only seed artists if the column-diff/enrichment step confirms they are needed.
+
+```bash
+python scripts/seed_cache_from_clone.py \
+  --source postgresql://localhost:5432/discogs \
+  --target "$DATABASE_URL_DISCOGS" \
+  --ids-file tail_artist_ids.txt \
+  --seed-artists \
+  --dry-run
+```
+
+Drop `--dry-run` to write. `--ids-file` here holds artist_ids, one per line, in the same format as the release-id file.
 
 ## Rollback
 

--- a/scripts/seed_cache_from_clone.py
+++ b/scripts/seed_cache_from_clone.py
@@ -30,6 +30,15 @@ Design (see plans/bs1631-tail-cache-seed.md):
     ``release_video`` table) is tolerated -- prod-only columns simply default.
   * ``release_image`` is NOT a table (it is a transient import CSV feeding
     ``release.artwork_url``, which already travels in the ``release`` copy).
+  * ``--source`` is genuinely read-only: the source connection only ever runs
+    ``SELECT`` / ``COPY ... TO STDOUT``. The new-parent-id set is embedded
+    directly into each COPY's filter as an ``ANY(ARRAY[...]::integer[])``
+    literal instead of being staged into a source-side temp table.
+  * A transaction-scoped advisory lock (``pg_advisory_xact_lock``, key 330001 --
+    see ``CLAUDE.md``'s "Advisory lock keys" table) on the target spans the
+    whole read (new-id computation) -> write window of a real run, so two
+    concurrent invocations against the same target can't both compute the same
+    parent as "new" and double-insert the arbiter-less child rows.
 
 Never runs ``verify_cache.py`` against the seeded rows: it prunes non-library
 releases, which is exactly what this seeds. Post-seed verification is a separate
@@ -40,6 +49,7 @@ Usage:
         --source postgresql://localhost:5432/discogs \
         --target "$DATABASE_URL_DISCOGS" \
         --ids-file tail_release_ids.txt \
+        [--seed-artists] \
         [--dry-run]
 """
 
@@ -58,6 +68,7 @@ sys.path.insert(0, str(_SCRIPTS_DIR))
 
 from verify_cache import COPY_TABLE_SPEC  # noqa: E402
 
+from lib.keep_release_ids import parse_keep_release_ids  # noqa: E402
 from lib.observability import init_logger  # noqa: E402
 
 logger = logging.getLogger(__name__)
@@ -89,6 +100,20 @@ _CONFLICT_TARGET = {"release": "id", "cache_metadata": "release_id", "artist": "
 # matching this repo's bulk-import convention (see verify_cache column tests /
 # test_copy_to_target._fresh_import).
 _FRESH_SEED = {"cache_metadata"}
+
+# Columns that must default to now() on the target when NULL on the source,
+# because the target's NOT NULL constraint would otherwise reject a straight
+# copy. Mirrors the treatment cache_metadata.cached_at gets via _FRESH_SEED
+# (a full fresh-row reseed), but at the single-column level: artist rows
+# otherwise copy straight through unmodified, so a full reseed isn't needed.
+_COALESCE_NOW_COLUMNS = {("artist", "fetched_at")}
+
+# pg_advisory_xact_lock key for the read (new-id computation) -> write critical
+# section of a real (non-dry-run) _seed_family call. Database-global on the
+# shared discogs-cache PG, so it must stay registered in CLAUDE.md's "Advisory
+# lock keys (shared-PG registry)" table. 330001 = discogs-etl PR#330, first key
+# allocated by this repo (<issue-number> * 1000 + sequence convention).
+_ADVISORY_LOCK_KEY = 330001
 
 
 def _table_exists(conn: psycopg.Connection, table: str) -> bool:
@@ -154,32 +179,41 @@ def _copy_columns(source_conn, target_conn, table: str, spec_columns: list[str])
     )
 
 
-def _load_seed_ids(source_conn, new_ids: set[int]) -> None:
-    """Materialize the new-parent-id set into a temp table on the source, so each
-    table's COPY filter is an indexed join rather than a giant IN-list. The temp
-    column is named neutrally (``seed_id``) since it holds release_ids or
-    artist_ids depending on the family being seeded."""
-    with source_conn.cursor() as cur:
-        cur.execute("DROP TABLE IF EXISTS _seed_ids")
-        cur.execute("CREATE TEMP TABLE _seed_ids (seed_id integer PRIMARY KEY)")
-        with cur.copy("COPY _seed_ids (seed_id) FROM STDIN") as copy:
-            for rid in new_ids:
-                copy.write_row((rid,))
-    source_conn.commit()
+def _int_array_literal(ids) -> str:
+    """Format a validated integer id set as a literal ``ARRAY[...]::integer[]``
+    SQL fragment, for embedding directly in a ``COPY (SELECT ...) TO STDOUT``
+    filter. COPY doesn't support bind parameters for the query it wraps, which
+    is why this is a literal rather than a placeholder -- safe here because
+    every id has already round-tripped through ``int()`` (see
+    ``_compute_new_ids``) before reaching this function, so there is no
+    injection surface in formatting them as a comma-separated integer literal.
+    At the real backfill's scale (~17k ids) a single ARRAY[] literal this size
+    is fine for Postgres; no batching needed."""
+    return "ARRAY[" + ",".join(str(int(i)) for i in sorted(ids)) + "]::integer[]"
 
 
-def _copy_table(source_conn, target_conn, table: str, filter_col: str, columns: list[str]) -> int:
-    """Stream one table's rows (for the loaded ``_seed_ids`` set) source -> target
-    staging, then INSERT ... SELECT into the real table. Returns rows inserted."""
+def _copy_table(
+    source_conn, target_conn, table: str, filter_col: str, columns: list[str], ids: set[int]
+) -> int:
+    """Stream one table's rows (for ``ids``) source -> target staging, then
+    INSERT ... SELECT into the real table. Returns rows inserted.
+
+    The source-side SELECT never writes anything (no temp table, no COPY FROM
+    STDIN against source_conn) -- ``--source`` only ever needs SELECT / COPY ...
+    TO STDOUT, matching the runbook's read-only contract."""
     col_list = ", ".join(columns)
+    select_exprs = ", ".join(
+        f"COALESCE({c}, now())" if (table, c) in _COALESCE_NOW_COLUMNS else c for c in columns
+    )
     stage = f"_seed_stage_{table}"
+    array_literal = _int_array_literal(ids)
 
     with target_conn.cursor() as cur:
         cur.execute(f"CREATE TEMP TABLE {stage} AS SELECT {col_list} FROM {table} WHERE false")
 
     select_query = (
-        f"COPY (SELECT {col_list} FROM {table} "
-        f"WHERE {filter_col} IN (SELECT seed_id FROM _seed_ids)) TO STDOUT"
+        f"COPY (SELECT {select_exprs} FROM {table} "
+        f"WHERE {filter_col} = ANY({array_literal})) TO STDOUT"
     )
     with source_conn.cursor() as src_cur:
         with src_cur.copy(select_query) as src_copy:
@@ -211,22 +245,26 @@ def _seed_fresh_cache_metadata(target_conn, new_ids: set[int]) -> int:
         return cur.rowcount
 
 
-def _dry_run_counts(source_conn, spec, new_ids: set[int]) -> dict[str, int]:
+def _dry_run_counts(source_conn, spec, new_ids: set[int], pk_table: str) -> dict[str, int]:
+    array_literal = _int_array_literal(new_ids)
     counts: dict[str, int] = {}
     for table, filter_col, _cols in spec:
         if table in _FRESH_SEED:
-            # Seeded fresh (one row per new parent), not copied from the clone.
-            counts[table] = len(new_ids)
-            continue
+            continue  # filled in below, mirroring pk_table's real source-side count
         if not _table_exists(source_conn, table):
             counts[table] = 0
             continue
         with source_conn.cursor() as cur:
-            cur.execute(
-                f"SELECT count(*) FROM {table} "
-                f"WHERE {filter_col} IN (SELECT seed_id FROM _seed_ids)"
-            )
+            cur.execute(f"SELECT count(*) FROM {table} WHERE {filter_col} = ANY({array_literal})")
             counts[table] = cur.fetchone()[0]
+    for table, _f, _c in spec:
+        if table in _FRESH_SEED:
+            # Seeded fresh -- one row per new PARENT actually present on the
+            # source. Mirror pk_table's real source-side count for this id set
+            # rather than echoing len(new_ids), which overstates whenever a
+            # candidate id is absent from source (new_ids is computed purely
+            # against the target, so it can contain ids source doesn't have).
+            counts[table] = counts.get(pk_table, 0)
     return counts
 
 
@@ -244,35 +282,77 @@ def _seed_family(
     """Generic additive, parent-gated copy of one table family (release or
     artist) from the source clone into the target. Only parent ids absent from
     the target are copied; existing rows are never touched."""
-    new_ids = _compute_new_ids(target_url, pk_table, pk_col, candidate_ids)
+    # Materialize once -- candidate_ids is referenced multiple times below (id
+    # computation, then log-message length calcs); a one-shot iterable (e.g. a
+    # generator) must not be silently exhausted by the first use.
+    candidate_ids = sorted({int(x) for x in candidate_ids})
     result = {table: 0 for table, _f, _c in spec}
 
-    if not new_ids:
-        logger.info(
-            "No new %s to seed (all %d candidates already present)",
-            family,
-            len({int(x) for x in candidate_ids}),
-        )
+    if not candidate_ids:
+        logger.info("No %s candidates supplied", family)
         return result
 
-    logger.info(
-        "Seeding %s new %s (%s candidates, rest already present)",
-        f"{len(new_ids):,}",
-        family,
-        f"{len({int(x) for x in candidate_ids}):,}",
-    )
-
-    source_conn = psycopg.connect(source_url)
-    try:
-        _load_seed_ids(source_conn, new_ids)
-
-        if dry_run:
-            counts = _dry_run_counts(source_conn, spec, new_ids)
+    if dry_run:
+        new_ids = _compute_new_ids(target_url, pk_table, pk_col, candidate_ids)
+        if not new_ids:
+            logger.info(
+                "No new %s to seed (all %d candidates already present)",
+                family,
+                len(candidate_ids),
+            )
+            return result
+        logger.info(
+            "Seeding %s new %s (%s candidates, rest already present)",
+            f"{len(new_ids):,}",
+            family,
+            f"{len(candidate_ids):,}",
+        )
+        source_conn = psycopg.connect(source_url)
+        try:
+            counts = _dry_run_counts(source_conn, spec, new_ids, pk_table)
             for table, n in counts.items():
                 logger.info("  [dry-run] %s: would seed %s rows", table, f"{n:,}")
             return counts
+        finally:
+            source_conn.close()
 
-        target_conn = psycopg.connect(target_url)
+    # Real (writing) run. Hold a transaction-scoped advisory lock on the target
+    # for the whole read (new-id computation) -> write window: two concurrent
+    # invocations against the same target must not both compute the same
+    # release/artist as "new" and double-insert the arbiter-less child rows
+    # (release_artist/label/genre/style/track/track_artist, artist_name_variation
+    # -- see the module docstring). Key 330001 = discogs-etl PR#330, first key
+    # allocated; registered in CLAUDE.md's "Advisory lock keys" table.
+    target_conn = psycopg.connect(target_url)
+    try:
+        with target_conn.cursor() as cur:
+            cur.execute("SELECT pg_advisory_xact_lock(%s)", (_ADVISORY_LOCK_KEY,))
+
+        new_ids = _compute_new_ids(target_conn, pk_table, pk_col, candidate_ids)
+        if not new_ids:
+            logger.info(
+                "No new %s to seed (all %d candidates already present)",
+                family,
+                len(candidate_ids),
+            )
+            target_conn.rollback()  # releases the advisory lock; nothing to write
+            return result
+
+        # Last visual sanity check before the write below. A --source/--target
+        # swap (two DSNs pointing at the same or an unexpectedly-similar
+        # database) typically makes "new" look like ~all or ~none of the
+        # candidates -- an operator scanning this line catches what DSN-string
+        # comparison alone cannot (two genuinely different DSNs that were still
+        # transposed).
+        logger.info(
+            "Seeding %s new %s (%s candidates, rest already present) -- verify this "
+            "matches expectations before the write below",
+            f"{len(new_ids):,}",
+            family,
+            f"{len(candidate_ids):,}",
+        )
+
+        source_conn = psycopg.connect(source_url)
         try:
             for table, filter_col, spec_cols in spec:
                 if table in _FRESH_SEED:
@@ -284,7 +364,9 @@ def _seed_family(
                 if not columns:
                     logger.info("  %s: no shared columns, skipping", table)
                     continue
-                inserted = _copy_table(source_conn, target_conn, table, filter_col, columns)
+                inserted = _copy_table(
+                    source_conn, target_conn, table, filter_col, columns, new_ids
+                )
                 result[table] = inserted
                 logger.info("  %s: inserted %s rows", table, f"{inserted:,}")
             for table, _f, _c in spec:
@@ -297,9 +379,9 @@ def _seed_family(
             target_conn.rollback()
             raise
         finally:
-            target_conn.close()
+            source_conn.close()
     finally:
-        source_conn.close()
+        target_conn.close()
 
     logger.info("Seed complete (%s): %s", family, {k: v for k, v in result.items() if v})
     return result
@@ -354,13 +436,34 @@ def seed_artists_additive(
     )
 
 
+def _validate_distinct_dsns(source: str, target: str) -> None:
+    """Refuse an identical --source/--target pair -- the cheap, robust half of
+    catching a transposed CLI invocation. A transposed pair where source and
+    target are the *same* DSN would otherwise silently no-op (every candidate
+    id already "present" on the target), exiting 0 with no error.
+
+    A swap between two genuinely different DSNs can't be caught by string
+    comparison alone; the mitigant for that case is the prominent
+    candidate/new-id count logged just before the real (non-dry-run) write in
+    _seed_family, which an operator should sanity-check before the write
+    proceeds."""
+    if source == target:
+        raise ValueError(
+            "--source and --target resolve to the identical DSN -- refusing. This "
+            "almost always means the two arguments were transposed."
+        )
+
+
 def _read_ids_file(path: Path) -> list[int]:
-    ids: list[int] = []
-    for line in path.read_text().splitlines():
-        line = line.strip()
-        if line and not line.startswith("#"):
-            ids.append(int(line))
-    return ids
+    """Read a newline-separated id allowlist file (release_ids, or artist_ids
+    with --seed-artists). Delegates line-parsing to the shared
+    lib.keep_release_ids parser rather than reimplementing it. Unlike that
+    parser's "missing file -> empty set" convention, --ids-file is a required,
+    operator-supplied path here, so a missing file is a loud failure rather
+    than a silent empty seed."""
+    if not path.exists():
+        raise FileNotFoundError(f"--ids-file not found: {path}")
+    return sorted(parse_keep_release_ids(path))
 
 
 def main() -> int:
@@ -371,8 +474,14 @@ def main() -> int:
         "--ids-file",
         required=True,
         type=Path,
-        help="File of release_ids to seed, one per line (selected upstream via LML's "
-        "trigram predicate over the tail artists).",
+        help="File of release_ids (or, with --seed-artists, artist_ids) to seed, one per "
+        "line (selected upstream via LML's trigram predicate over the tail artists).",
+    )
+    parser.add_argument(
+        "--seed-artists",
+        action="store_true",
+        help="Seed artist rows (and artist_name_variation children) from --ids-file, "
+        "instead of the default release family.",
     )
     parser.add_argument(
         "--dry-run",
@@ -381,12 +490,19 @@ def main() -> int:
     )
     args = parser.parse_args()
 
+    try:
+        _validate_distinct_dsns(args.source, args.target)
+    except ValueError as exc:
+        parser.error(str(exc))
+
     init_logger(repo="discogs-etl", tool="discogs-etl seed_cache_from_clone")
 
-    release_ids = _read_ids_file(args.ids_file)
-    logger.info("Loaded %s release_ids from %s", f"{len(release_ids):,}", args.ids_file)
+    ids = _read_ids_file(args.ids_file)
+    id_label = "artist_ids" if args.seed_artists else "release_ids"
+    logger.info("Loaded %s %s from %s", f"{len(ids):,}", id_label, args.ids_file)
 
-    counts = seed_releases_additive(args.source, args.target, release_ids, dry_run=args.dry_run)
+    seed_fn = seed_artists_additive if args.seed_artists else seed_releases_additive
+    counts = seed_fn(args.source, args.target, ids, dry_run=args.dry_run)
     logger.info("%s: %s", "Planned" if args.dry_run else "Seeded", counts)
     return 0
 

--- a/scripts/seed_cache_from_clone.py
+++ b/scripts/seed_cache_from_clone.py
@@ -81,6 +81,15 @@ _ARTIST_SPEC = [
 # arbiter-less child, gated on the new-parent-id set.
 _CONFLICT_TARGET = {"release": "id", "cache_metadata": "release_id", "artist": "id"}
 
+# Freshness tables that are seeded FRESH rather than copied from the clone: the
+# clone's cache_metadata.cached_at is nullable and carries NULLs, which would
+# violate prod's NOT NULL on a straight copy — and a vintage cached_at would
+# misreport freshness anyway. Each newly-seeded release instead gets a fresh
+# ``(release_id, source='bulk_import', cached_at=now())`` row (prod defaults),
+# matching this repo's bulk-import convention (see verify_cache column tests /
+# test_copy_to_target._fresh_import).
+_FRESH_SEED = {"cache_metadata"}
+
 
 def _table_exists(conn: psycopg.Connection, table: str) -> bool:
     with conn.cursor() as cur:
@@ -188,9 +197,27 @@ def _copy_table(source_conn, target_conn, table: str, filter_col: str, columns: 
     return inserted
 
 
-def _dry_run_counts(source_conn, spec) -> dict[str, int]:
+def _seed_fresh_cache_metadata(target_conn, new_ids: set[int]) -> int:
+    """Insert a fresh cache_metadata row per newly-seeded release (source
+    bulk_import, cached_at defaulted to now()), instead of copying the clone's
+    unreliable/nullable freshness rows. Idempotent via the release_id PK."""
+    with target_conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO cache_metadata (release_id, source) "
+            "SELECT id, 'bulk_import' FROM release WHERE id = ANY(%s::integer[]) "
+            "ON CONFLICT (release_id) DO NOTHING",
+            (list(new_ids),),
+        )
+        return cur.rowcount
+
+
+def _dry_run_counts(source_conn, spec, new_ids: set[int]) -> dict[str, int]:
     counts: dict[str, int] = {}
     for table, filter_col, _cols in spec:
+        if table in _FRESH_SEED:
+            # Seeded fresh (one row per new parent), not copied from the clone.
+            counts[table] = len(new_ids)
+            continue
         if not _table_exists(source_conn, table):
             counts[table] = 0
             continue
@@ -240,14 +267,16 @@ def _seed_family(
         _load_seed_ids(source_conn, new_ids)
 
         if dry_run:
-            counts = _dry_run_counts(source_conn, spec)
+            counts = _dry_run_counts(source_conn, spec, new_ids)
             for table, n in counts.items():
-                logger.info("  [dry-run] %s: would copy %s rows", table, f"{n:,}")
+                logger.info("  [dry-run] %s: would seed %s rows", table, f"{n:,}")
             return counts
 
         target_conn = psycopg.connect(target_url)
         try:
             for table, filter_col, spec_cols in spec:
+                if table in _FRESH_SEED:
+                    continue  # seeded fresh after the copy loop
                 if not _table_exists(source_conn, table):
                     logger.info("  %s: absent on source clone, skipping", table)
                     continue
@@ -258,6 +287,11 @@ def _seed_family(
                 inserted = _copy_table(source_conn, target_conn, table, filter_col, columns)
                 result[table] = inserted
                 logger.info("  %s: inserted %s rows", table, f"{inserted:,}")
+            for table, _f, _c in spec:
+                if table == "cache_metadata":
+                    n = _seed_fresh_cache_metadata(target_conn, new_ids)
+                    result[table] = n
+                    logger.info("  %s: seeded %s fresh rows", table, f"{n:,}")
             target_conn.commit()
         except Exception:
             target_conn.rollback()

--- a/scripts/seed_cache_from_clone.py
+++ b/scripts/seed_cache_from_clone.py
@@ -1,0 +1,361 @@
+#!/usr/bin/env python3
+"""Additively seed a target discogs-cache with an artist-scoped release row-set
+copied from a full (unfiltered) Discogs clone.
+
+Motivation (WXYC/Backend-Service#1631): the Apple-Music-URL backfill stalls on a
+"cold tail" of non-library albums whose Discogs releases are absent from the
+library-filtered prod discogs-cache. On a miss LML falls through to the live
+Discogs API + cold path (>15s), times out, and trips the health watchdog. A full
+local clone already holds those releases in the right shape; this script copies
+exactly the tail artists' releases clone -> prod, additively, so LML resolves
+them as fast cache hits.
+
+Design (see plans/bs1631-tail-cache-seed.md):
+
+  * Filter unit is the *artist* -- callers pass the release_id set already
+    selected via LML's ``lower(f_unaccent(artist_name)) % $artist`` trigram
+    predicate (schema/create_indexes.sql). This script does the copy, not the
+    selection.
+  * Additive only. ``release`` (id PK) and ``cache_metadata`` (release_id PK)
+    use ``ON CONFLICT DO NOTHING``. The arbiter-less child tables
+    (release_artist/label/genre/style/track/track_artist/video) have no
+    PK/UNIQUE, so idempotency is driven off the *parent*: children are inserted
+    only for the "new-release-id set" = (requested ids) - (ids already on the
+    target). A release_id is in that set only if its parent was absent, so its
+    children were necessarily absent too -- no duplicates, fully re-runnable.
+  * Column lists come from ``verify_cache.COPY_TABLE_SPEC`` (the canonical source
+    of truth) intersected with the columns actually present on both databases,
+    so clone-vs-prod column drift (the clone predates
+    ``release.artwork_checked_at`` / ``release.not_found`` and has no
+    ``release_video`` table) is tolerated -- prod-only columns simply default.
+  * ``release_image`` is NOT a table (it is a transient import CSV feeding
+    ``release.artwork_url``, which already travels in the ``release`` copy).
+
+Never runs ``verify_cache.py`` against the seeded rows: it prunes non-library
+releases, which is exactly what this seeds. Post-seed verification is a separate
+read-only check.
+
+Usage:
+    python seed_cache_from_clone.py \
+        --source postgresql://localhost:5432/discogs \
+        --target "$DATABASE_URL_DISCOGS" \
+        --ids-file tail_release_ids.txt \
+        [--dry-run]
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from pathlib import Path
+
+import psycopg
+
+_SCRIPTS_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(_SCRIPTS_DIR.parent))
+sys.path.insert(0, str(_SCRIPTS_DIR))
+
+from verify_cache import COPY_TABLE_SPEC  # noqa: E402
+
+from lib.observability import init_logger  # noqa: E402
+
+logger = logging.getLogger(__name__)
+
+# release_image is deliberately absent from COPY_TABLE_SPEC (not a table). The
+# spec is the single source of truth for release-family column lists; see the
+# module docstring.
+_RELEASE_SPEC = COPY_TABLE_SPEC
+
+# Artist family (COPY_TABLE_SPEC covers only the release side). Only the two
+# tables the plan names are seeded: the id-PK parent and its arbiter-less
+# name-variation child. Columns mirror schema/create_database.sql; prod-only
+# columns absent on the clone (artist.not_found) fall out in the intersection.
+_ARTIST_SPEC = [
+    ("artist", "id", ["id", "name", "profile", "image_url", "fetched_at", "not_found"]),
+    ("artist_name_variation", "artist_id", ["artist_id", "name"]),
+]
+
+# Tables whose primary key lets us use ON CONFLICT ... DO NOTHING as a
+# belt-and-suspenders guard against a concurrent seed. Everything else is an
+# arbiter-less child, gated on the new-parent-id set.
+_CONFLICT_TARGET = {"release": "id", "cache_metadata": "release_id", "artist": "id"}
+
+
+def _table_exists(conn: psycopg.Connection, table: str) -> bool:
+    with conn.cursor() as cur:
+        cur.execute("SELECT to_regclass(%s)", (f"public.{table}",))
+        return cur.fetchone()[0] is not None
+
+
+def _columns(conn: psycopg.Connection, table: str) -> set[str]:
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT column_name FROM information_schema.columns "
+            "WHERE table_schema = 'public' AND table_name = %s",
+            (table,),
+        )
+        return {r[0] for r in cur.fetchall()}
+
+
+def _compute_new_ids(
+    target: str | psycopg.Connection, table: str, id_col: str, candidate_ids
+) -> set[int]:
+    """Return the subset of ``candidate_ids`` NOT already present in
+    ``target.{table}.{id_col}`` -- the new-parent-id set that drives
+    parent-gated idempotency. Accepts a connection URL or an open connection."""
+    candidates = list({int(x) for x in candidate_ids})
+    if not candidates:
+        return set()
+
+    own_conn = isinstance(target, str)
+    conn = psycopg.connect(target) if own_conn else target
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                f"SELECT {id_col} FROM {table} WHERE {id_col} = ANY(%s::integer[])",
+                (candidates,),
+            )
+            existing = {r[0] for r in cur.fetchall()}
+    finally:
+        if own_conn:
+            conn.close()
+    return set(candidates) - existing
+
+
+def compute_new_release_ids(target: str | psycopg.Connection, candidate_ids) -> set[int]:
+    """Release-family wrapper over :func:`_compute_new_ids` (``release.id``)."""
+    return _compute_new_ids(target, "release", "id", candidate_ids)
+
+
+def intersect_columns(spec_columns, source_cols, target_cols) -> list[str]:
+    """Columns from ``spec_columns`` present on BOTH the source and target,
+    preserving spec order. Pure (no DB) so it is unit-testable. Prod-only columns
+    (absent on the clone) and clone-only columns both fall out here; the surviving
+    set is what the COPY names, and any prod column not named simply defaults."""
+    src = set(source_cols)
+    tgt = set(target_cols)
+    return [c for c in spec_columns if c in src and c in tgt]
+
+
+def _copy_columns(source_conn, target_conn, table: str, spec_columns: list[str]) -> list[str]:
+    """DB-bound wrapper over :func:`intersect_columns`."""
+    return intersect_columns(
+        spec_columns, _columns(source_conn, table), _columns(target_conn, table)
+    )
+
+
+def _load_seed_ids(source_conn, new_ids: set[int]) -> None:
+    """Materialize the new-parent-id set into a temp table on the source, so each
+    table's COPY filter is an indexed join rather than a giant IN-list. The temp
+    column is named neutrally (``seed_id``) since it holds release_ids or
+    artist_ids depending on the family being seeded."""
+    with source_conn.cursor() as cur:
+        cur.execute("DROP TABLE IF EXISTS _seed_ids")
+        cur.execute("CREATE TEMP TABLE _seed_ids (seed_id integer PRIMARY KEY)")
+        with cur.copy("COPY _seed_ids (seed_id) FROM STDIN") as copy:
+            for rid in new_ids:
+                copy.write_row((rid,))
+    source_conn.commit()
+
+
+def _copy_table(source_conn, target_conn, table: str, filter_col: str, columns: list[str]) -> int:
+    """Stream one table's rows (for the loaded ``_seed_ids`` set) source -> target
+    staging, then INSERT ... SELECT into the real table. Returns rows inserted."""
+    col_list = ", ".join(columns)
+    stage = f"_seed_stage_{table}"
+
+    with target_conn.cursor() as cur:
+        cur.execute(f"CREATE TEMP TABLE {stage} AS SELECT {col_list} FROM {table} WHERE false")
+
+    select_query = (
+        f"COPY (SELECT {col_list} FROM {table} "
+        f"WHERE {filter_col} IN (SELECT seed_id FROM _seed_ids)) TO STDOUT"
+    )
+    with source_conn.cursor() as src_cur:
+        with src_cur.copy(select_query) as src_copy:
+            with target_conn.cursor() as tgt_cur:
+                with tgt_cur.copy(f"COPY {stage} ({col_list}) FROM STDIN") as tgt_copy:
+                    for data in src_copy:
+                        tgt_copy.write(data)
+
+    conflict = _CONFLICT_TARGET.get(table)
+    on_conflict = f" ON CONFLICT ({conflict}) DO NOTHING" if conflict else ""
+    with target_conn.cursor() as cur:
+        cur.execute(f"INSERT INTO {table} ({col_list}) SELECT {col_list} FROM {stage}{on_conflict}")
+        inserted = cur.rowcount
+        cur.execute(f"DROP TABLE {stage}")
+    return inserted
+
+
+def _dry_run_counts(source_conn, spec) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for table, filter_col, _cols in spec:
+        if not _table_exists(source_conn, table):
+            counts[table] = 0
+            continue
+        with source_conn.cursor() as cur:
+            cur.execute(
+                f"SELECT count(*) FROM {table} "
+                f"WHERE {filter_col} IN (SELECT seed_id FROM _seed_ids)"
+            )
+            counts[table] = cur.fetchone()[0]
+    return counts
+
+
+def _seed_family(
+    source_url: str,
+    target_url: str,
+    spec,
+    pk_table: str,
+    pk_col: str,
+    candidate_ids,
+    *,
+    family: str,
+    dry_run: bool,
+) -> dict[str, int]:
+    """Generic additive, parent-gated copy of one table family (release or
+    artist) from the source clone into the target. Only parent ids absent from
+    the target are copied; existing rows are never touched."""
+    new_ids = _compute_new_ids(target_url, pk_table, pk_col, candidate_ids)
+    result = {table: 0 for table, _f, _c in spec}
+
+    if not new_ids:
+        logger.info(
+            "No new %s to seed (all %d candidates already present)",
+            family,
+            len({int(x) for x in candidate_ids}),
+        )
+        return result
+
+    logger.info(
+        "Seeding %s new %s (%s candidates, rest already present)",
+        f"{len(new_ids):,}",
+        family,
+        f"{len({int(x) for x in candidate_ids}):,}",
+    )
+
+    source_conn = psycopg.connect(source_url)
+    try:
+        _load_seed_ids(source_conn, new_ids)
+
+        if dry_run:
+            counts = _dry_run_counts(source_conn, spec)
+            for table, n in counts.items():
+                logger.info("  [dry-run] %s: would copy %s rows", table, f"{n:,}")
+            return counts
+
+        target_conn = psycopg.connect(target_url)
+        try:
+            for table, filter_col, spec_cols in spec:
+                if not _table_exists(source_conn, table):
+                    logger.info("  %s: absent on source clone, skipping", table)
+                    continue
+                columns = _copy_columns(source_conn, target_conn, table, spec_cols)
+                if not columns:
+                    logger.info("  %s: no shared columns, skipping", table)
+                    continue
+                inserted = _copy_table(source_conn, target_conn, table, filter_col, columns)
+                result[table] = inserted
+                logger.info("  %s: inserted %s rows", table, f"{inserted:,}")
+            target_conn.commit()
+        except Exception:
+            target_conn.rollback()
+            raise
+        finally:
+            target_conn.close()
+    finally:
+        source_conn.close()
+
+    logger.info("Seed complete (%s): %s", family, {k: v for k, v in result.items() if v})
+    return result
+
+
+def seed_releases_additive(
+    source_url: str,
+    target_url: str,
+    release_ids,
+    *,
+    dry_run: bool = False,
+) -> dict[str, int]:
+    """Additively copy the artist-scoped release row-set (``release_ids`` and its
+    children) from the source clone into the target discogs-cache.
+
+    Only release_ids absent from the target are copied; existing rows are never
+    touched. Returns a per-table count dict: rows inserted (or, for ``dry_run``,
+    rows that *would* be copied)."""
+    return _seed_family(
+        source_url,
+        target_url,
+        _RELEASE_SPEC,
+        "release",
+        "id",
+        release_ids,
+        family="releases",
+        dry_run=dry_run,
+    )
+
+
+def seed_artists_additive(
+    source_url: str,
+    target_url: str,
+    artist_ids,
+    *,
+    dry_run: bool = False,
+) -> dict[str, int]:
+    """Additively copy tail ``artist`` rows + their ``artist_name_variation``
+    children from the source clone into the target discogs-cache, for LML
+    enrichment JOINs. ``artist`` (id PK) uses ON CONFLICT; the arbiter-less
+    ``artist_name_variation`` is parent-gated on the new-artist-id set. Only
+    artist ids absent from the target are copied; existing rows are untouched."""
+    return _seed_family(
+        source_url,
+        target_url,
+        _ARTIST_SPEC,
+        "artist",
+        "id",
+        artist_ids,
+        family="artists",
+        dry_run=dry_run,
+    )
+
+
+def _read_ids_file(path: Path) -> list[int]:
+    ids: list[int] = []
+    for line in path.read_text().splitlines():
+        line = line.strip()
+        if line and not line.startswith("#"):
+            ids.append(int(line))
+    return ids
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--source", required=True, help="Source clone DSN (read-only).")
+    parser.add_argument("--target", required=True, help="Target discogs-cache DSN.")
+    parser.add_argument(
+        "--ids-file",
+        required=True,
+        type=Path,
+        help="File of release_ids to seed, one per line (selected upstream via LML's "
+        "trigram predicate over the tail artists).",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Report per-table row-set sizes without writing to the target.",
+    )
+    args = parser.parse_args()
+
+    init_logger(repo="discogs-etl", tool="discogs-etl seed_cache_from_clone")
+
+    release_ids = _read_ids_file(args.ids_file)
+    logger.info("Loaded %s release_ids from %s", f"{len(release_ids):,}", args.ids_file)
+
+    counts = seed_releases_additive(args.source, args.target, release_ids, dry_run=args.dry_run)
+    logger.info("%s: %s", "Planned" if args.dry_run else "Seeded", counts)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/integration/test_seed_cache_from_clone.py
+++ b/tests/integration/test_seed_cache_from_clone.py
@@ -1,0 +1,419 @@
+"""Integration tests for scripts/seed_cache_from_clone.py against real PostgreSQL.
+
+Exercises the additive, artist-scoped clone -> prod seed (BS#1631 tail cache).
+The core properties under test:
+
+  (a) only genuinely-new release_ids (and their children) are inserted;
+  (b) pre-existing prod rows are left byte-identical (never overwritten);
+  (c) a second run is a no-op -- no duplicate child rows (the arbiter-less
+      parent-gated idempotency property);
+  (d) --dry-run writes nothing;
+  (e) prod-only columns absent in the clone (release.artwork_checked_at,
+      release.not_found) default on the target rather than failing the COPY;
+  (f) a table absent in the clone (release_video) is skipped, not fatal.
+
+Two-DB source->target harness modeled on tests/integration/test_copy_to_target.py
+(uuid-named scratch databases), but the source is populated by direct INSERTs so
+the test controls exactly which release_ids pre-exist on the target and can
+simulate the real clone's missing prod-only columns.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys as _sys
+import uuid
+from pathlib import Path
+
+import psycopg
+import pytest
+from psycopg import sql
+
+SCHEMA_DIR = Path(__file__).parent.parent.parent / "schema"
+
+ADMIN_URL = os.environ.get("DATABASE_URL_TEST", "postgresql://localhost:5433/postgres")
+
+# Load the module under test from scripts/ (not on sys.path).
+_SEED_PATH = Path(__file__).parent.parent.parent / "scripts" / "seed_cache_from_clone.py"
+if "seed_cache_from_clone" in _sys.modules:
+    _seed = _sys.modules["seed_cache_from_clone"]
+else:
+    _spec = importlib.util.spec_from_file_location("seed_cache_from_clone", _SEED_PATH)
+    assert _spec is not None and _spec.loader is not None
+    _seed = importlib.util.module_from_spec(_spec)
+    _sys.modules["seed_cache_from_clone"] = _seed
+    _spec.loader.exec_module(_seed)
+
+seed_releases_additive = _seed.seed_releases_additive
+seed_artists_additive = _seed.seed_artists_additive
+compute_new_release_ids = _seed.compute_new_release_ids
+
+pytestmark = [pytest.mark.pg]
+
+
+# ---------------------------------------------------------------------------
+# Scratch database helpers (mirror test_copy_to_target.py)
+# ---------------------------------------------------------------------------
+
+
+def _create_temp_database() -> tuple[str, str]:
+    db_name = f"discogs_seed_test_{uuid.uuid4().hex[:8]}"
+    admin_conn = psycopg.connect(ADMIN_URL, autocommit=True)
+    with admin_conn.cursor() as cur:
+        cur.execute(sql.SQL("CREATE DATABASE {}").format(sql.Identifier(db_name)))
+    admin_conn.close()
+    base = ADMIN_URL.rsplit("/", 1)[0]
+    return f"{base}/{db_name}", db_name
+
+
+def _drop_database(db_name: str) -> None:
+    admin_conn = psycopg.connect(ADMIN_URL, autocommit=True)
+    with admin_conn.cursor() as cur:
+        cur.execute(
+            sql.SQL(
+                "SELECT pg_terminate_backend(pid) FROM pg_stat_activity "
+                "WHERE datname = {} AND pid <> pg_backend_pid()"
+            ).format(sql.Literal(db_name))
+        )
+        cur.execute(sql.SQL("DROP DATABASE IF EXISTS {}").format(sql.Identifier(db_name)))
+    admin_conn.close()
+
+
+def _apply_schema(db_url: str) -> None:
+    conn = psycopg.connect(db_url, autocommit=True)
+    with conn.cursor() as cur:
+        cur.execute(SCHEMA_DIR.joinpath("create_functions.sql").read_text())
+        cur.execute(SCHEMA_DIR.joinpath("create_database.sql").read_text())
+    conn.close()
+
+
+def _make_clone_source(db_url: str) -> None:
+    """Prod-shaped schema, then mutated to mirror the real clone:
+
+    the clone predates release.artwork_checked_at / release.not_found and has no
+    release_video table. Dropping them here forces the seed's column-intersection
+    path (a bare COPY_TABLE_SPEC COPY would fail with 'column does not exist').
+    """
+    _apply_schema(db_url)
+    conn = psycopg.connect(db_url, autocommit=True)
+    with conn.cursor() as cur:
+        cur.execute("ALTER TABLE release DROP COLUMN artwork_checked_at")
+        cur.execute("ALTER TABLE release DROP COLUMN not_found")
+        cur.execute("DROP TABLE IF EXISTS release_video CASCADE")
+        cur.execute("DROP TABLE IF EXISTS cache_metadata CASCADE")
+    conn.close()
+
+
+def _insert_release(
+    cur: psycopg.Cursor,
+    rid: int,
+    artist: str,
+    title: str,
+    *,
+    artwork_url: str | None = None,
+    include_prod_cols: bool = False,
+) -> None:
+    """Insert a release + one main artist + two tracks + a genre.
+
+    include_prod_cols=False matches the clone (no artwork_checked_at/not_found).
+    """
+    if include_prod_cols:
+        cur.execute(
+            "INSERT INTO release (id, title, artwork_url, not_found) VALUES (%s, %s, %s, FALSE)",
+            (rid, title, artwork_url),
+        )
+    else:
+        cur.execute(
+            "INSERT INTO release (id, title, artwork_url) VALUES (%s, %s, %s)",
+            (rid, title, artwork_url),
+        )
+    cur.execute(
+        "INSERT INTO release_artist (release_id, artist_id, artist_name, extra) "
+        "VALUES (%s, %s, %s, 0)",
+        (rid, rid * 10, artist),
+    )
+    cur.execute(
+        "INSERT INTO release_track (release_id, sequence, position, title) VALUES (%s, 1, 'A1', %s)",
+        (rid, f"{title} - track one"),
+    )
+    cur.execute(
+        "INSERT INTO release_track (release_id, sequence, position, title) VALUES (%s, 2, 'A2', %s)",
+        (rid, f"{title} - track two"),
+    )
+    cur.execute("INSERT INTO release_genre (release_id, genre) VALUES (%s, 'Rock')", (rid,))
+
+
+# Source (clone) release ids and their tail artists.
+CLONE_RELEASES = [
+    (100, "Juana Molina", "Segundo"),
+    (101, "Juana Molina", "Halo"),
+    (102, "Sessa", "Grandeza"),
+    (200, "Chuquimamani-Condori", "DJ E"),
+]
+# The one release already present on the prod target before seeding.
+PREEXISTING_ID = 100
+PROD_TITLE_100 = "PROD-SIDE TITLE (must survive)"
+
+
+class TestSeedCacheFromClone:
+    @pytest.fixture(autouse=True, scope="class")
+    def _set_up(self):
+        source_url, source_name = _create_temp_database()
+        target_url, target_name = _create_temp_database()
+        self.__class__._source_url = source_url
+        self.__class__._target_url = target_url
+
+        # Source = mini clone (missing prod-only columns).
+        _make_clone_source(source_url)
+        conn = psycopg.connect(source_url)
+        with conn.cursor() as cur:
+            for rid, artist, title in CLONE_RELEASES:
+                _insert_release(cur, rid, artist, title, artwork_url=f"http://art/{rid}.jpg")
+        conn.commit()
+        conn.close()
+
+        # Target = prod-shaped, with release 100 already present under a
+        # DIFFERENT title so any overwrite is detectable.
+        _apply_schema(target_url)
+        conn = psycopg.connect(target_url)
+        with conn.cursor() as cur:
+            _insert_release(
+                cur,
+                PREEXISTING_ID,
+                "Juana Molina",
+                PROD_TITLE_100,
+                artwork_url="http://prod/100.jpg",
+                include_prod_cols=True,
+            )
+        conn.commit()
+        conn.close()
+
+        yield
+
+        _drop_database(source_name)
+        _drop_database(target_name)
+
+    @pytest.fixture(autouse=True)
+    def _attrs(self):
+        self.source_url = self.__class__._source_url
+        self.target_url = self.__class__._target_url
+
+    def _child_count(self, url: str, table: str, rid: int) -> int:
+        conn = psycopg.connect(url)
+        with conn.cursor() as cur:
+            cur.execute(f"SELECT count(*) FROM {table} WHERE release_id = %s", (rid,))
+            n = cur.fetchone()[0]
+        conn.close()
+        return n
+
+    def _release_ids(self, url: str) -> set[int]:
+        conn = psycopg.connect(url)
+        with conn.cursor() as cur:
+            cur.execute("SELECT id FROM release")
+            ids = {r[0] for r in cur.fetchall()}
+        conn.close()
+        return ids
+
+    # --- (d) dry-run writes nothing -------------------------------------
+
+    def test_dry_run_writes_nothing(self) -> None:
+        before = self._release_ids(self.target_url)
+        planned = seed_releases_additive(
+            self.source_url,
+            self.target_url,
+            [rid for rid, _, _ in CLONE_RELEASES],
+            dry_run=True,
+        )
+        after = self._release_ids(self.target_url)
+        assert after == before, "dry-run must not insert any releases"
+        # Planned counts should reflect the 3 genuinely-new releases.
+        assert planned["release"] == 3
+
+    def test_compute_new_release_ids_excludes_existing(self) -> None:
+        new_ids = compute_new_release_ids(self.target_url, [rid for rid, _, _ in CLONE_RELEASES])
+        assert new_ids == {101, 102, 200}
+
+    # --- (a) inserts only the new releases + children -------------------
+
+    def test_seed_inserts_only_new(self) -> None:
+        counts = seed_releases_additive(
+            self.source_url,
+            self.target_url,
+            [rid for rid, _, _ in CLONE_RELEASES],
+        )
+        assert self._release_ids(self.target_url) == {100, 101, 102, 200}
+        # 3 new releases inserted (100 already existed -> skipped).
+        assert counts["release"] == 3
+        # Children present for the new releases.
+        assert self._child_count(self.target_url, "release_track", 101) == 2
+        assert self._child_count(self.target_url, "release_artist", 200) == 1
+
+    # --- (e) prod-only columns default ----------------------------------
+
+    def test_prod_only_columns_default(self) -> None:
+        conn = psycopg.connect(self.target_url)
+        with conn.cursor() as cur:
+            cur.execute("SELECT artwork_checked_at, not_found FROM release WHERE id = 101")
+            checked_at, not_found = cur.fetchone()
+        conn.close()
+        assert checked_at is None
+        assert not_found is False
+
+    # --- (b) pre-existing rows byte-identical ---------------------------
+
+    def test_preexisting_release_not_overwritten(self) -> None:
+        conn = psycopg.connect(self.target_url)
+        with conn.cursor() as cur:
+            cur.execute("SELECT title, artwork_url FROM release WHERE id = %s", (PREEXISTING_ID,))
+            title, artwork = cur.fetchone()
+        conn.close()
+        assert title == PROD_TITLE_100, "existing prod release must not be overwritten"
+        assert artwork == "http://prod/100.jpg"
+        # And its children were NOT duplicated from the source copy of 100.
+        assert self._child_count(self.target_url, "release_artist", PREEXISTING_ID) == 1
+        assert self._child_count(self.target_url, "release_track", PREEXISTING_ID) == 2
+
+    # --- (c) second run is a no-op --------------------------------------
+
+    def test_second_run_is_noop(self) -> None:
+        counts = seed_releases_additive(
+            self.source_url,
+            self.target_url,
+            [rid for rid, _, _ in CLONE_RELEASES],
+        )
+        assert counts["release"] == 0, "re-run must insert no new releases"
+        # No duplicate child rows for an already-seeded release.
+        assert self._child_count(self.target_url, "release_track", 101) == 2
+        assert self._child_count(self.target_url, "release_artist", 200) == 1
+
+
+def _insert_artist(
+    cur: psycopg.Cursor,
+    aid: int,
+    name: str,
+    variations: list[str],
+    *,
+    include_prod_cols: bool = False,
+) -> None:
+    if include_prod_cols:
+        cur.execute("INSERT INTO artist (id, name, not_found) VALUES (%s, %s, FALSE)", (aid, name))
+    else:
+        cur.execute("INSERT INTO artist (id, name) VALUES (%s, %s)", (aid, name))
+    for v in variations:
+        cur.execute("INSERT INTO artist_name_variation (artist_id, name) VALUES (%s, %s)", (aid, v))
+
+
+# (artist_id, name, [name_variations])
+CLONE_ARTISTS = [
+    (500, "Juana Molina", ["Juana Molina y Los Hermanos", "J. Molina"]),
+    (501, "Sessa", ["Sérgio Sessa"]),
+]
+PREEXISTING_ARTIST = 500
+PROD_ARTIST_500 = "PROD-SIDE ARTIST (must survive)"
+
+
+class TestSeedArtistsFromClone:
+    """artist / artist_name_variation seeding: id-PK ON CONFLICT for artist,
+    parent-gated (no-arbiter) inserts for artist_name_variation."""
+
+    @pytest.fixture(autouse=True, scope="class")
+    def _set_up(self):
+        source_url, source_name = _create_temp_database()
+        target_url, target_name = _create_temp_database()
+        self.__class__._source_url = source_url
+        self.__class__._target_url = target_url
+
+        # Source clone: artist lacks the prod-only not_found column.
+        _apply_schema(source_url)
+        conn = psycopg.connect(source_url, autocommit=True)
+        with conn.cursor() as cur:
+            cur.execute("ALTER TABLE artist DROP COLUMN not_found")
+        conn.close()
+        conn = psycopg.connect(source_url)
+        with conn.cursor() as cur:
+            for aid, name, variations in CLONE_ARTISTS:
+                _insert_artist(cur, aid, name, variations)
+        conn.commit()
+        conn.close()
+
+        # Target: artist 500 already present under a different name + 1 variation.
+        _apply_schema(target_url)
+        conn = psycopg.connect(target_url)
+        with conn.cursor() as cur:
+            _insert_artist(
+                cur,
+                PREEXISTING_ARTIST,
+                PROD_ARTIST_500,
+                ["prod-only variation"],
+                include_prod_cols=True,
+            )
+        conn.commit()
+        conn.close()
+
+        yield
+
+        _drop_database(source_name)
+        _drop_database(target_name)
+
+    @pytest.fixture(autouse=True)
+    def _attrs(self):
+        self.source_url = self.__class__._source_url
+        self.target_url = self.__class__._target_url
+
+    def _variation_count(self, aid: int) -> int:
+        conn = psycopg.connect(self.target_url)
+        with conn.cursor() as cur:
+            cur.execute("SELECT count(*) FROM artist_name_variation WHERE artist_id = %s", (aid,))
+            n = cur.fetchone()[0]
+        conn.close()
+        return n
+
+    def _artist_ids(self) -> set[int]:
+        conn = psycopg.connect(self.target_url)
+        with conn.cursor() as cur:
+            cur.execute("SELECT id FROM artist")
+            ids = {r[0] for r in cur.fetchall()}
+        conn.close()
+        return ids
+
+    def test_dry_run_writes_nothing(self) -> None:
+        before = self._artist_ids()
+        planned = seed_artists_additive(
+            self.source_url, self.target_url, [a for a, _, _ in CLONE_ARTISTS], dry_run=True
+        )
+        assert self._artist_ids() == before
+        assert planned["artist"] == 1  # only 501 is new
+
+    def test_seed_inserts_only_new_artist(self) -> None:
+        counts = seed_artists_additive(
+            self.source_url, self.target_url, [a for a, _, _ in CLONE_ARTISTS]
+        )
+        assert self._artist_ids() == {500, 501}
+        assert counts["artist"] == 1
+        assert self._variation_count(501) == 1
+
+    def test_prod_only_column_defaults(self) -> None:
+        conn = psycopg.connect(self.target_url)
+        with conn.cursor() as cur:
+            cur.execute("SELECT not_found FROM artist WHERE id = 501")
+            not_found = cur.fetchone()[0]
+        conn.close()
+        assert not_found is False
+
+    def test_preexisting_artist_not_overwritten(self) -> None:
+        conn = psycopg.connect(self.target_url)
+        with conn.cursor() as cur:
+            cur.execute("SELECT name FROM artist WHERE id = %s", (PREEXISTING_ARTIST,))
+            name = cur.fetchone()[0]
+        conn.close()
+        assert name == PROD_ARTIST_500
+        # The prod artist's single variation was NOT joined by the source's two.
+        assert self._variation_count(PREEXISTING_ARTIST) == 1
+
+    def test_second_run_no_duplicate_variations(self) -> None:
+        counts = seed_artists_additive(
+            self.source_url, self.target_url, [a for a, _, _ in CLONE_ARTISTS]
+        )
+        assert counts["artist"] == 0
+        assert self._variation_count(501) == 1

--- a/tests/integration/test_seed_cache_from_clone.py
+++ b/tests/integration/test_seed_cache_from_clone.py
@@ -21,8 +21,10 @@ simulate the real clone's missing prod-only columns.
 from __future__ import annotations
 
 import importlib.util
+import logging
 import os
 import sys as _sys
+import threading
 import uuid
 from pathlib import Path
 
@@ -317,6 +319,130 @@ class TestSeedCacheFromClone:
         assert self._child_count(self.target_url, "release_track", 101) == 2
         assert self._child_count(self.target_url, "release_artist", 200) == 1
 
+    # --- candidate_ids materialization (finding #7) ----------------------
+
+    def test_generator_candidate_ids_not_exhausted_prematurely(self, caplog) -> None:
+        """A one-shot iterable (e.g. a generator) must not be silently exhausted
+        by internal reuse -- by this point in the class all CLONE_RELEASES are
+        already seeded, so this exercises the "no new ids" logging branch, which
+        re-reads candidate_ids after _compute_new_ids has already consumed it."""
+        ids_gen = (rid for rid, _, _ in CLONE_RELEASES)
+        with caplog.at_level(logging.INFO, logger="seed_cache_from_clone"):
+            seed_releases_additive(self.source_url, self.target_url, ids_gen)
+        assert any(
+            f"all {len(CLONE_RELEASES)} candidates already present" in r.message
+            for r in caplog.records
+        ), (
+            "candidate count in the log must reflect the materialized list, not an exhausted generator"
+        )
+
+    # --- dry-run cache_metadata mirrors the real release count (finding #6) -
+
+    def test_dry_run_cache_metadata_mirrors_release_source_count(self) -> None:
+        """cache_metadata's dry-run count must mirror release's real source-side
+        count for the same id set, not echo len(new_ids) -- a candidate id absent
+        from source (e.g. a stale/bogus id) must not inflate the fresh-seed
+        count."""
+        bogus_id = 999999  # not present on either database
+        planned = seed_releases_additive(self.source_url, self.target_url, [bogus_id], dry_run=True)
+        assert planned["release"] == 0
+        assert planned["cache_metadata"] == 0, (
+            "cache_metadata dry-run count must mirror the real (zero) release count, "
+            "not len(new_ids)=1"
+        )
+
+    # --- --source needs no write access (finding #5) ----------------------
+
+    def test_source_connection_never_writes(self) -> None:
+        """The seed must work against a --source held under
+        default_transaction_read_only -- proving it never CREATEs or COPYs INTO
+        anything on the source, matching the runbook's read-only contract."""
+        new_id = 901
+        prep_conn = psycopg.connect(self.source_url)
+        with prep_conn.cursor() as cur:
+            _insert_release(
+                cur,
+                new_id,
+                "Chuquimamani-Condori",
+                "Nunca Estuve Sola",
+                artwork_url=f"http://art/{new_id}.jpg",
+            )
+            cur.execute(
+                "INSERT INTO cache_metadata (release_id, source, cached_at) "
+                "VALUES (%s, 'bulk_import', NULL)",
+                (new_id,),
+            )
+        prep_conn.commit()
+        prep_conn.close()
+
+        source_db_name = self.source_url.rsplit("/", 1)[-1]
+        admin_conn = psycopg.connect(ADMIN_URL, autocommit=True)
+        with admin_conn.cursor() as cur:
+            cur.execute(
+                sql.SQL("ALTER DATABASE {} SET default_transaction_read_only = on").format(
+                    sql.Identifier(source_db_name)
+                )
+            )
+        admin_conn.close()
+        try:
+            counts = seed_releases_additive(self.source_url, self.target_url, [new_id])
+        finally:
+            admin_conn = psycopg.connect(ADMIN_URL, autocommit=True)
+            with admin_conn.cursor() as cur:
+                cur.execute(
+                    sql.SQL("ALTER DATABASE {} RESET default_transaction_read_only").format(
+                        sql.Identifier(source_db_name)
+                    )
+                )
+            admin_conn.close()
+
+        assert counts["release"] == 1
+
+    # --- concurrent-run serialization via advisory lock (finding #2) ------
+
+    def test_advisory_lock_serializes_concurrent_seed_writes(self) -> None:
+        """A holder of pg_advisory_xact_lock(330001) on the target must block a
+        concurrent seed_releases_additive real run until the holder releases --
+        otherwise two overlapping invocations could both compute the same
+        release as "new" and double-insert its arbiter-less child rows."""
+        new_id = 902
+        prep_conn = psycopg.connect(self.source_url)
+        with prep_conn.cursor() as cur:
+            _insert_release(
+                cur, new_id, "Cat Power", "Moon Pix", artwork_url=f"http://art/{new_id}.jpg"
+            )
+            cur.execute(
+                "INSERT INTO cache_metadata (release_id, source, cached_at) "
+                "VALUES (%s, 'bulk_import', NULL)",
+                (new_id,),
+            )
+        prep_conn.commit()
+        prep_conn.close()
+
+        holder = psycopg.connect(self.target_url)
+        with holder.cursor() as cur:
+            cur.execute("SELECT pg_advisory_xact_lock(330001)")
+
+        result_box: dict = {}
+
+        def run_seed() -> None:
+            result_box["counts"] = seed_releases_additive(
+                self.source_url, self.target_url, [new_id]
+            )
+
+        t = threading.Thread(target=run_seed)
+        t.start()
+        try:
+            t.join(timeout=1.0)
+            assert t.is_alive(), "seed must block while the advisory lock is held"
+        finally:
+            holder.rollback()  # releases pg_advisory_xact_lock
+            holder.close()
+
+        t.join(timeout=5.0)
+        assert not t.is_alive(), "seed must proceed once the lock is released"
+        assert result_box["counts"]["release"] == 1
+
 
 def _insert_artist(
     cur: psycopg.Cursor,
@@ -342,6 +468,12 @@ CLONE_ARTISTS = [
 PREEXISTING_ARTIST = 500
 PROD_ARTIST_500 = "PROD-SIDE ARTIST (must survive)"
 
+# A clone-side artist row with a NULL fetched_at (e.g. legacy/backfilled data).
+# artist.fetched_at is NOT NULL DEFAULT now() on prod; a straight copy of a NULL
+# value must not raise -- it must default on the target instead.
+NULL_FETCHED_AT_ARTIST_ID = 502
+NULL_FETCHED_AT_ARTIST_NAME = "Hermanos Gutiérrez"
+
 
 class TestSeedArtistsFromClone:
     """artist / artist_name_variation seeding: id-PK ON CONFLICT for artist,
@@ -354,16 +486,22 @@ class TestSeedArtistsFromClone:
         self.__class__._source_url = source_url
         self.__class__._target_url = target_url
 
-        # Source clone: artist lacks the prod-only not_found column.
+        # Source clone: artist lacks the prod-only not_found column, and (like
+        # the real clone) can carry a NULL fetched_at.
         _apply_schema(source_url)
         conn = psycopg.connect(source_url, autocommit=True)
         with conn.cursor() as cur:
             cur.execute("ALTER TABLE artist DROP COLUMN not_found")
+            cur.execute("ALTER TABLE artist ALTER COLUMN fetched_at DROP NOT NULL")
         conn.close()
         conn = psycopg.connect(source_url)
         with conn.cursor() as cur:
             for aid, name, variations in CLONE_ARTISTS:
                 _insert_artist(cur, aid, name, variations)
+            cur.execute(
+                "INSERT INTO artist (id, name, fetched_at) VALUES (%s, %s, NULL)",
+                (NULL_FETCHED_AT_ARTIST_ID, NULL_FETCHED_AT_ARTIST_NAME),
+            )
         conn.commit()
         conn.close()
 
@@ -447,3 +585,19 @@ class TestSeedArtistsFromClone:
         )
         assert counts["artist"] == 0
         assert self._variation_count(501) == 1
+
+    # --- artist.fetched_at NOT NULL guard (finding #3) --------------------
+
+    def test_null_fetched_at_defaults_on_target(self) -> None:
+        """The clone can carry a NULL artist.fetched_at; the target's NOT NULL
+        column must default (COALESCE to now()) rather than raising."""
+        counts = seed_artists_additive(
+            self.source_url, self.target_url, [NULL_FETCHED_AT_ARTIST_ID]
+        )
+        assert counts["artist"] == 1
+        conn = psycopg.connect(self.target_url)
+        with conn.cursor() as cur:
+            cur.execute("SELECT fetched_at FROM artist WHERE id = %s", (NULL_FETCHED_AT_ARTIST_ID,))
+            fetched_at = cur.fetchone()[0]
+        conn.close()
+        assert fetched_at is not None

--- a/tests/integration/test_seed_cache_from_clone.py
+++ b/tests/integration/test_seed_cache_from_clone.py
@@ -91,9 +91,13 @@ def _apply_schema(db_url: str) -> None:
 def _make_clone_source(db_url: str) -> None:
     """Prod-shaped schema, then mutated to mirror the real clone:
 
-    the clone predates release.artwork_checked_at / release.not_found and has no
-    release_video table. Dropping them here forces the seed's column-intersection
-    path (a bare COPY_TABLE_SPEC COPY would fail with 'column does not exist').
+    * the clone predates release.artwork_checked_at / release.not_found -> forces
+      the seed's column-intersection path (a bare COPY_TABLE_SPEC COPY would fail
+      with 'column does not exist');
+    * the clone has no release_video table -> forces the absent-table skip path;
+    * the clone's cache_metadata.cached_at is NULLABLE and carries NULLs (the real
+      clone does) -> a straight column copy into prod's NOT NULL cached_at would
+      fail, so the seed must NOT copy the clone's freshness timestamps.
     """
     _apply_schema(db_url)
     conn = psycopg.connect(db_url, autocommit=True)
@@ -101,7 +105,7 @@ def _make_clone_source(db_url: str) -> None:
         cur.execute("ALTER TABLE release DROP COLUMN artwork_checked_at")
         cur.execute("ALTER TABLE release DROP COLUMN not_found")
         cur.execute("DROP TABLE IF EXISTS release_video CASCADE")
-        cur.execute("DROP TABLE IF EXISTS cache_metadata CASCADE")
+        cur.execute("ALTER TABLE cache_metadata ALTER COLUMN cached_at DROP NOT NULL")
     conn.close()
 
 
@@ -164,12 +168,19 @@ class TestSeedCacheFromClone:
         self.__class__._source_url = source_url
         self.__class__._target_url = target_url
 
-        # Source = mini clone (missing prod-only columns).
+        # Source = mini clone (missing prod-only columns; nullable cache_metadata).
         _make_clone_source(source_url)
         conn = psycopg.connect(source_url)
         with conn.cursor() as cur:
             for rid, artist, title in CLONE_RELEASES:
                 _insert_release(cur, rid, artist, title, artwork_url=f"http://art/{rid}.jpg")
+                # Clone freshness rows carry NULL cached_at (the real clone does);
+                # copying these into prod's NOT NULL column must not happen.
+                cur.execute(
+                    "INSERT INTO cache_metadata (release_id, source, cached_at) "
+                    "VALUES (%s, 'bulk_import', NULL)",
+                    (rid,),
+                )
         conn.commit()
         conn.close()
 
@@ -248,6 +259,25 @@ class TestSeedCacheFromClone:
         # Children present for the new releases.
         assert self._child_count(self.target_url, "release_track", 101) == 2
         assert self._child_count(self.target_url, "release_artist", 200) == 1
+
+    # --- cache_metadata seeded fresh, not copied ------------------------
+
+    def test_cache_metadata_seeded_fresh(self) -> None:
+        """The clone's NULL cached_at must never reach prod's NOT NULL column;
+        each new release gets a fresh bulk_import row with cached_at defaulted."""
+        conn = psycopg.connect(self.target_url)
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT release_id, source, cached_at FROM cache_metadata "
+                "WHERE release_id = ANY(%s::integer[])",
+                ([101, 102, 200],),
+            )
+            rows = cur.fetchall()
+        conn.close()
+        assert len(rows) == 3, "each new release should get one fresh cache_metadata row"
+        for _rid, source, cached_at in rows:
+            assert source == "bulk_import"
+            assert cached_at is not None, "cached_at must default (not copy the clone's NULL)"
 
     # --- (e) prod-only columns default ----------------------------------
 

--- a/tests/unit/test_seed_cache_cli.py
+++ b/tests/unit/test_seed_cache_cli.py
@@ -1,0 +1,157 @@
+"""Unit tests (no DB) for scripts/seed_cache_from_clone.py's CLI surface:
+--source/--target swap validation, --seed-artists dispatch, and --ids-file
+parsing. Companion to test_seed_cache_columns.py (which covers the
+clone-vs-prod column-intersection contract).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import sys as _sys
+from pathlib import Path
+
+import pytest
+
+_SEED_PATH = Path(__file__).parent.parent.parent / "scripts" / "seed_cache_from_clone.py"
+if "seed_cache_from_clone" in _sys.modules:
+    _seed = _sys.modules["seed_cache_from_clone"]
+else:
+    _spec = importlib.util.spec_from_file_location("seed_cache_from_clone", _SEED_PATH)
+    assert _spec is not None and _spec.loader is not None
+    _seed = importlib.util.module_from_spec(_spec)
+    _sys.modules["seed_cache_from_clone"] = _seed
+    _spec.loader.exec_module(_seed)
+
+
+# --- --source/--target swap validation (finding #1) -------------------------
+
+
+def test_validate_distinct_dsns_rejects_identical():
+    with pytest.raises(ValueError, match="identical DSN"):
+        _seed._validate_distinct_dsns(
+            "postgresql://localhost:5432/discogs", "postgresql://localhost:5432/discogs"
+        )
+
+
+def test_validate_distinct_dsns_allows_different():
+    # Must not raise.
+    _seed._validate_distinct_dsns(
+        "postgresql://localhost:5432/discogs", "postgresql://localhost:5433/discogs_cache"
+    )
+
+
+def test_main_rejects_identical_source_and_target(monkeypatch, tmp_path):
+    ids_file = tmp_path / "ids.txt"
+    ids_file.write_text("500\n")
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "seed_cache_from_clone.py",
+            "--source",
+            "postgresql://localhost:5432/discogs",
+            "--target",
+            "postgresql://localhost:5432/discogs",
+            "--ids-file",
+            str(ids_file),
+        ],
+    )
+    with pytest.raises(SystemExit) as exc_info:
+        _seed.main()
+    assert exc_info.value.code == 2
+
+
+# --- --seed-artists CLI dispatch (finding #4) --------------------------------
+
+
+def test_main_dispatches_to_seed_releases_by_default(monkeypatch, tmp_path):
+    ids_file = tmp_path / "ids.txt"
+    ids_file.write_text("100\n101\n")
+    calls: dict = {}
+
+    def fake_seed_releases_additive(source, target, ids, *, dry_run=False):
+        calls["fn"] = "release"
+        calls["ids"] = ids
+        calls["dry_run"] = dry_run
+        return {"release": 0}
+
+    def fake_seed_artists_additive(*args, **kwargs):
+        raise AssertionError("should not be called without --seed-artists")
+
+    monkeypatch.setattr(_seed, "seed_releases_additive", fake_seed_releases_additive)
+    monkeypatch.setattr(_seed, "seed_artists_additive", fake_seed_artists_additive)
+    monkeypatch.setattr(_seed, "init_logger", lambda **kwargs: None)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "seed_cache_from_clone.py",
+            "--source",
+            "postgresql://localhost:5432/discogs",
+            "--target",
+            "postgresql://localhost:5433/discogs_cache",
+            "--ids-file",
+            str(ids_file),
+            "--dry-run",
+        ],
+    )
+    rc = _seed.main()
+    assert rc == 0
+    assert calls["fn"] == "release"
+    assert calls["ids"] == [100, 101]
+    assert calls["dry_run"] is True
+
+
+def test_main_dispatches_to_seed_artists_with_flag(monkeypatch, tmp_path):
+    ids_file = tmp_path / "ids.txt"
+    ids_file.write_text("500\n501\n")
+    calls: dict = {}
+
+    def fake_seed_artists_additive(source, target, ids, *, dry_run=False):
+        calls["fn"] = "artist"
+        calls["ids"] = ids
+        calls["dry_run"] = dry_run
+        return {"artist": 0}
+
+    def fake_seed_releases_additive(*args, **kwargs):
+        raise AssertionError("should not be called with --seed-artists")
+
+    monkeypatch.setattr(_seed, "seed_artists_additive", fake_seed_artists_additive)
+    monkeypatch.setattr(_seed, "seed_releases_additive", fake_seed_releases_additive)
+    monkeypatch.setattr(_seed, "init_logger", lambda **kwargs: None)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "seed_cache_from_clone.py",
+            "--source",
+            "postgresql://localhost:5432/discogs",
+            "--target",
+            "postgresql://localhost:5433/discogs_cache",
+            "--ids-file",
+            str(ids_file),
+            "--seed-artists",
+        ],
+    )
+    rc = _seed.main()
+    assert rc == 0
+    assert calls["fn"] == "artist"
+    assert calls["ids"] == [500, 501]
+    assert calls["dry_run"] is False
+
+
+# --- --ids-file parsing delegates to the shared allowlist parser (finding #8) -
+
+
+def test_read_ids_file_delegates_to_shared_parser(tmp_path):
+    p = tmp_path / "ids.txt"
+    p.write_text("100\n# a comment\n\n200\n100\n")
+    result = _seed._read_ids_file(p)
+    # Shared parser is set-based (dedups) and this wrapper sorts for determinism.
+    assert result == [100, 200]
+
+
+def test_read_ids_file_missing_raises():
+    with pytest.raises(FileNotFoundError):
+        _seed._read_ids_file(Path("/nonexistent/path/to/ids.txt"))

--- a/tests/unit/test_seed_cache_columns.py
+++ b/tests/unit/test_seed_cache_columns.py
@@ -1,0 +1,69 @@
+"""Unit tests (no DB) for scripts/seed_cache_from_clone.py column mapping.
+
+Pins the clone-vs-prod column-intersection contract that lets the seed tolerate
+schema drift: the real clone predates release.artwork_checked_at /
+release.not_found and artist.not_found, so those prod-only columns must fall out
+of the COPY column list (and default on insert) rather than crash the COPY.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys as _sys
+from pathlib import Path
+
+_SEED_PATH = Path(__file__).parent.parent.parent / "scripts" / "seed_cache_from_clone.py"
+if "seed_cache_from_clone" in _sys.modules:
+    _seed = _sys.modules["seed_cache_from_clone"]
+else:
+    _spec = importlib.util.spec_from_file_location("seed_cache_from_clone", _SEED_PATH)
+    assert _spec is not None and _spec.loader is not None
+    _seed = importlib.util.module_from_spec(_spec)
+    _sys.modules["seed_cache_from_clone"] = _seed
+    _spec.loader.exec_module(_seed)
+
+intersect_columns = _seed.intersect_columns
+
+
+RELEASE_SPEC_COLS = [
+    "id",
+    "title",
+    "release_year",
+    "country",
+    "artwork_url",
+    "released",
+    "format",
+    "master_id",
+    "artwork_checked_at",
+    "not_found",
+]
+
+
+def test_prod_only_columns_dropped_when_absent_on_clone():
+    """Clone lacks artwork_checked_at / not_found -> they drop from the copy list."""
+    clone_cols = [c for c in RELEASE_SPEC_COLS if c not in {"artwork_checked_at", "not_found"}]
+    prod_cols = RELEASE_SPEC_COLS
+    result = intersect_columns(RELEASE_SPEC_COLS, clone_cols, prod_cols)
+    assert "artwork_checked_at" not in result
+    assert "not_found" not in result
+    assert result == clone_cols
+
+
+def test_spec_order_preserved():
+    result = intersect_columns(RELEASE_SPEC_COLS, RELEASE_SPEC_COLS, RELEASE_SPEC_COLS)
+    assert result == RELEASE_SPEC_COLS
+
+
+def test_clone_only_column_not_selected():
+    """A column present only on the clone is never selected (target can't take it)."""
+    clone_cols = RELEASE_SPEC_COLS + ["clone_only_junk"]
+    result = intersect_columns(RELEASE_SPEC_COLS, clone_cols, RELEASE_SPEC_COLS)
+    assert "clone_only_junk" not in result
+    assert result == RELEASE_SPEC_COLS
+
+
+def test_columns_outside_spec_ignored():
+    """Only spec columns are candidates, even if both DBs share extras."""
+    extra_both = RELEASE_SPEC_COLS + ["some_extra"]
+    result = intersect_columns(RELEASE_SPEC_COLS, extra_both, extra_both)
+    assert "some_extra" not in result


### PR DESCRIPTION
## Summary

- Adds `scripts/seed_cache_from_clone.py`: additively copies a specific `release_id` (and `artist_id`) set, plus child rows, from a full unfiltered Discogs clone into an existing target discogs-cache. `release`/`cache_metadata`/`artist` use `ON CONFLICT DO NOTHING`; the arbiter-less child tables (no PK/UNIQUE) are gated on the new-parent-id set (requested ids minus ids already on the target), so re-running with the same `--ids-file` inserts 0 rows and never duplicates children.
- Column lists come from `verify_cache.COPY_TABLE_SPEC` intersected with the columns actually present on both source and target, so clone/prod schema drift (missing `release.artwork_checked_at`, `release.not_found`, no `release_video` table) degrades to "column/table skipped," not a failed COPY.
- `cache_metadata` is seeded fresh (`source='bulk_import'`, `cached_at=now()`) rather than copied, since the clone's `cached_at` is nullable and would violate prod's `NOT NULL`.
- Adds the operator runbook (`docs/seed-cache-from-clone-runbook.md`) and a README pointer.

## Background

Originally built (branch `feat/bs1631-seed-cache-from-clone`, July 19) for Backend-Service#1631's Apple-Music-URL backfill cold tail. It sat unmerged with no PR filed. discogs-etl#327/#329 (durably retaining LML's `library_release_override`-pinned releases across the monthly rebuild) now needs this exact tool for a one-time prod backfill of ~16,850 missing pinned releases, and #329 explicitly calls out reusing this seeder rather than building a new one. Filing the PR here unblocks #329, which is otherwise hard-blocked on this branch not being on `main`.

Rebased cleanly onto current `main` (zero drift — the branch's merge-base is `main`'s current tip, so no conflicts to resolve). Also confirmed clean against the still-open `--keep-release-ids` PR (#328) via `git merge-tree`: both branches touch `docs/architecture.md`/`CLAUDE.md`/`scripts/verify_cache.py` in non-overlapping ways.

## Does this need `--keep-release-ids` integration?

No code change needed. This script is purely additive (`INSERT ... ON CONFLICT DO NOTHING`, no `DELETE`/`UPDATE`/`TRUNCATE` anywhere) and never calls `dedup_releases.py` or `verify_cache.py --prune` itself — the exemption machinery in #328 lives entirely in those two scripts. The durability path is: #328's `run_pipeline.py::write_keep_release_ids` reads `lml_cache.library_release_override` fresh from the table on every pipeline run, so any release this seeder inserts is automatically covered by the next rebuild's allowlist as long as the override table still pins it (which it durably does — LML owns that table). The seeder's own docstring/runbook already say `verify_cache.py --prune` must never run against freshly-seeded rows without that exemption; that's an operational constraint on the *caller*, not something this script can enforce internally.

## Test plan

- [x] `ruff check .` / `ruff format --check .` — clean
- [x] `pytest -q tests/unit` (default no-marker run) — 807 passed (4 pre-existing collection errors on unrelated files — missing `scripts/__init__.py` for `topup_artwork`/`tsv_to_sqlite` — reproduced identically on `main`, unrelated to this change)
- [x] `pytest -m pg tests/integration/test_seed_cache_from_clone.py` — 12 passed (additive/idempotent re-run, byte-identical pre-existing rows, dry-run writes nothing, column-drift tolerance, absent-table skip)
- [x] `pytest -m "pg or not slow"` (broad regression pass) — 1262 passed, 2 pre-existing failures (1 date-dependent test in `test_import.py`, 1 `tsv_to_sqlite` field-count test) + 4 pre-existing e2e errors needing the external converter binary, all reproduced identically on `main`

Part of WXYC/discogs-etl#327, unblocks WXYC/discogs-etl#329.