### PR TITLE
feat(#334): add cross_reference_names to the daily library.db sync

### DIFF
--- a/scripts/sync-library.sh
+++ b/scripts/sync-library.sh
@@ -119,11 +119,20 @@ DB_PATH=$(mktemp -d)/library.db
 MYSQL_HOST="${DB_HOST:-$LIBRARY_DB_HOST}"
 MYSQL_PORT="${DB_PORT:-3306}"
 
+# The 11th SELECT column is CROSS_REFERENCE_NAMES: a correlated subquery over
+# LIBRARY_CODE_CROSS_REFERENCE that pipe-joins (" | ") the PRESENTATION_NAMEs
+# of any LIBRARY_CODEs cataloger-cross-referenced to this row's own code, in
+# either FK direction (CROSS_REFERENCING_ARTIST_ID / CROSS_REFERENCED_LIBRARY_
+# CODE_ID both -> LIBRARY_CODE.ID), excluding the row's own name. This is the
+# same alias link wxyc-catalog's TubafrenzySource.fetch_cross_referenced_artists
+# reads for the XML-converter artist filter -- here it rides along on every
+# library.db row instead of only feeding that allowlist. See
+# WXYC/discogs-etl#334.
 ETL_OUTPUT=$(mktemp)
 CSV_FILE=$(mktemp)
 if ! MYSQL_PWD="$LIBRARY_DB_PASSWORD" mysql -h "$MYSQL_HOST" -P "$MYSQL_PORT" -u "$LIBRARY_DB_USER" \
     --default-character-set=utf8 -B -N "$LIBRARY_DB_NAME" \
-    -e "SELECT r.ID, r.TITLE, lc.PRESENTATION_NAME, lc.CALL_LETTERS, lc.CALL_NUMBERS, r.CALL_NUMBERS, g.REFERENCE_NAME, f.REFERENCE_NAME, r.ALTERNATE_ARTIST_NAME, r.ALBUM_ARTIST FROM LIBRARY_RELEASE r JOIN LIBRARY_CODE lc ON r.LIBRARY_CODE_ID = lc.ID JOIN FORMAT f ON r.FORMAT_ID = f.ID JOIN GENRE g ON lc.GENRE_ID = g.ID" \
+    -e "SELECT r.ID, r.TITLE, lc.PRESENTATION_NAME, lc.CALL_LETTERS, lc.CALL_NUMBERS, r.CALL_NUMBERS, g.REFERENCE_NAME, f.REFERENCE_NAME, r.ALTERNATE_ARTIST_NAME, r.ALBUM_ARTIST, (SELECT GROUP_CONCAT(DISTINCT xlc.PRESENTATION_NAME SEPARATOR ' | ') FROM LIBRARY_CODE_CROSS_REFERENCE xcr, LIBRARY_CODE xlc WHERE xlc.ID = CASE WHEN xcr.CROSS_REFERENCING_ARTIST_ID = lc.ID THEN xcr.CROSS_REFERENCED_LIBRARY_CODE_ID WHEN xcr.CROSS_REFERENCED_LIBRARY_CODE_ID = lc.ID THEN xcr.CROSS_REFERENCING_ARTIST_ID ELSE NULL END AND (xcr.CROSS_REFERENCING_ARTIST_ID = lc.ID OR xcr.CROSS_REFERENCED_LIBRARY_CODE_ID = lc.ID) AND xlc.ID != lc.ID) FROM LIBRARY_RELEASE r JOIN LIBRARY_CODE lc ON r.LIBRARY_CODE_ID = lc.ID JOIN FORMAT f ON r.FORMAT_ID = f.ID JOIN GENRE g ON lc.GENRE_ID = g.ID" \
     > "$CSV_FILE" 2> "$ETL_OUTPUT"; then
     ERROR_DETAILS=$(cat "$ETL_OUTPUT" | tail -1 | sed 's/"/\\"/g')
     cat "$ETL_OUTPUT" >> "$LOG_FILE"

--- a/scripts/tsv_to_sqlite.py
+++ b/scripts/tsv_to_sqlite.py
@@ -6,7 +6,7 @@ database containing:
 
 - A ``library`` table with id, title, artist, call_letters,
   artist_call_number, release_call_number, genre, format,
-  alternate_artist_name, album_artist, cross_reference_names, and label
+  alternate_artist_name, album_artist, label, and cross_reference_names
   columns (label is always NULL since the MySQL query doesn't include it).
 - An FTS5 virtual table (``library_fts``) for full-text search on title,
   artist, alternate_artist_name, and album_artist.

--- a/scripts/tsv_to_sqlite.py
+++ b/scripts/tsv_to_sqlite.py
@@ -1,19 +1,25 @@
 """Convert a MySQL TSV dump to a SQLite database with FTS5 index.
 
-Reads a tab-separated file (as produced by ``mysql -B -N``) with 10 columns
+Reads a tab-separated file (as produced by ``mysql -B -N``) with 11 columns
 corresponding to the WXYC library catalog schema and creates a SQLite
 database containing:
 
 - A ``library`` table with id, title, artist, call_letters,
   artist_call_number, release_call_number, genre, format,
-  alternate_artist_name, album_artist, and label columns (label is always
-  NULL since the MySQL query doesn't include it).
+  alternate_artist_name, album_artist, cross_reference_names, and label
+  columns (label is always NULL since the MySQL query doesn't include it).
 - An FTS5 virtual table (``library_fts``) for full-text search on title,
   artist, alternate_artist_name, and album_artist.
 - Indexes on artist, title, alternate_artist_name, and album_artist.
 
+``cross_reference_names`` holds the pipe-joined (``" | "``) PRESENTATION_NAMEs
+of any WXYC ``LIBRARY_CODE``s cataloger-cross-referenced to this row's own
+code (e.g. a release filed under a band name carries its member's personal
+name), sourced from ``LIBRARY_CODE_CROSS_REFERENCE`` via the correlated
+subquery in ``sync-library.sh``. See WXYC/discogs-etl#334.
+
 MySQL ``\\N`` values are converted to SQL NULL. Rows that do not contain
-exactly 10 tab-separated fields are skipped with a warning on stderr.
+exactly 11 tab-separated fields are skipped with a warning on stderr.
 """
 
 from __future__ import annotations
@@ -42,7 +48,7 @@ def tsv_to_sqlite(tsv_path: str, db_path: str) -> int:
         id INTEGER PRIMARY KEY, title TEXT, artist TEXT, call_letters TEXT,
         artist_call_number INTEGER, release_call_number INTEGER,
         genre TEXT, format TEXT, alternate_artist_name TEXT,
-        album_artist TEXT, label TEXT
+        album_artist TEXT, label TEXT, cross_reference_names TEXT
     )""")
     # FTS5 tokenizer extends unicode61 with the Symbol category and U+200D ZWJ so
     # bare-emoji rows (waving-hand, musical-note) and ZWJ graphemes (family,
@@ -70,7 +76,7 @@ def tsv_to_sqlite(tsv_path: str, db_path: str) -> int:
     with open(tsv_path, encoding="utf-8") as f:
         for line in f:
             fields = line.rstrip("\n").split("\t")
-            if len(fields) != 10:
+            if len(fields) != 11:
                 print(
                     f"WARNING: skipping malformed row with {len(fields)} fields",
                     file=sys.stderr,
@@ -81,7 +87,8 @@ def tsv_to_sqlite(tsv_path: str, db_path: str) -> int:
             cur.execute(
                 "INSERT INTO library (id, title, artist, call_letters,"
                 " artist_call_number, release_call_number, genre, format,"
-                " alternate_artist_name, album_artist) VALUES (?,?,?,?,?,?,?,?,?,?)",
+                " alternate_artist_name, album_artist, cross_reference_names)"
+                " VALUES (?,?,?,?,?,?,?,?,?,?,?)",
                 row,
             )
             count += 1

--- a/tests/integration/test_tsv_to_sqlite.py
+++ b/tests/integration/test_tsv_to_sqlite.py
@@ -23,22 +23,23 @@ class TestTsvToSqliteIntegration:
         """TSV mimicking real MySQL -B -N output imports correctly and FTS search works."""
         # Realistic MySQL batch-mode output with mix of NULLs, Unicode, and varied genres
         lines = [
-            "10001\tAluminum Tunes\tStereolab\tST\t1234\t1\tRock\tCD\t\\N\t\\N",
-            "10002\tDOGA\tJuana Molina\tMO\t5678\t2\tRock\tLP\t\\N\t\\N",
-            "10003\tConfield\tAutechre\tAU\t9012\t3\tElectronic\tCD\t\\N\t\\N",
-            "10004\tMoon Pix\tCat Power\tCA\t3456\t1\tRock\tLP\tCharlyn Marie Marshall\t\\N",
-            "10005\tPequena Vertigem de Amor\tSessa\tSE\t7890\t1\tLatin\tLP\t\\N\t\\N",
-            "10006\tDuke Ellington & John Coltrane\tDuke Ellington\tEL\t2345\t1\tJazz\tLP\tEdward Kennedy Ellington\t\\N",
-            "10007\tOn Your Own Love Again\tJessica Pratt\tPR\t6789\t1\tRock\tLP\t\\N\t\\N",
-            "10008\tEdits\tChuquimamani-Condori\tCH\t\\N\t\\N\tElectronic\tCD\t\\N\t\\N",
-            "10009\tDJ-Kicks\tVarious Artists\tZ-\t\\N\t1\tElectronic\tCD\t\\N\tKruder & Dorfmeister",
+            "10001\tAluminum Tunes\tStereolab\tST\t1234\t1\tRock\tCD\t\\N\t\\N\t\\N",
+            "10002\tDOGA\tJuana Molina\tMO\t5678\t2\tRock\tLP\t\\N\t\\N\t\\N",
+            "10003\tConfield\tAutechre\tAU\t9012\t3\tElectronic\tCD\t\\N\t\\N\t\\N",
+            "10004\tMoon Pix\tCat Power\tCA\t3456\t1\tRock\tLP\tCharlyn Marie Marshall\t\\N\t\\N",
+            "10005\tPequena Vertigem de Amor\tSessa\tSE\t7890\t1\tLatin\tLP\t\\N\t\\N\t\\N",
+            "10006\tDuke Ellington & John Coltrane\tDuke Ellington\tEL\t2345\t1\tJazz\tLP\tEdward Kennedy Ellington\t\\N\t\\N",
+            "10007\tOn Your Own Love Again\tJessica Pratt\tPR\t6789\t1\tRock\tLP\t\\N\t\\N\t\\N",
+            "10008\tEdits\tChuquimamani-Condori\tCH\t\\N\t\\N\tElectronic\tCD\t\\N\t\\N\t\\N",
+            "10009\tDJ-Kicks\tVarious Artists\tZ-\t\\N\t1\tElectronic\tCD\t\\N\tKruder & Dorfmeister\t\\N",
+            '57833\t"In The Blink of an Eye" 7-inch\tBurning Star Core\tBU\t110\t6\tRock\tvinyl - 7"\tC.S. Yeh\t\\N\tC. Spencer Yeh',
         ]
         tsv_file = tmp_path / "mysql_output.tsv"
         tsv_file.write_text("\n".join(lines) + "\n", encoding="utf-8")
         db_path = tmp_path / "library.db"
 
         count = tsv_to_sqlite(str(tsv_file), str(db_path))
-        assert count == 9
+        assert count == 10
 
         conn = sqlite3.connect(str(db_path))
 
@@ -86,6 +87,17 @@ class TestTsvToSqliteIntegration:
         assert row[0] is None
         assert row[1] is None
 
+        # cross_reference_names round-trips for a cataloger-linked alias row
+        # (WXYC/discogs-etl#334) and stays NULL for rows without one.
+        row = conn.execute(
+            "SELECT artist, alternate_artist_name, cross_reference_names "
+            "FROM library WHERE id = 57833"
+        ).fetchone()
+        assert row == ("Burning Star Core", "C.S. Yeh", "C. Spencer Yeh")
+
+        row = conn.execute("SELECT cross_reference_names FROM library WHERE id = 10001").fetchone()
+        assert row[0] is None
+
         conn.close()
 
     def test_schema_matches_wxyc_catalog(self, tmp_path: Path) -> None:
@@ -112,6 +124,7 @@ class TestTsvToSqliteIntegration:
             (8, "alternate_artist_name", "TEXT", 0, None, 0),
             (9, "album_artist", "TEXT", 0, None, 0),
             (10, "label", "TEXT", 0, None, 0),
+            (11, "cross_reference_names", "TEXT", 0, None, 0),
         ]
 
         assert columns == expected_columns

--- a/tests/unit/test_charset_torture_sqlite_build.py
+++ b/tests/unit/test_charset_torture_sqlite_build.py
@@ -35,8 +35,9 @@ def test_tsv_to_sqlite_roundtrip(
     tsv_path = tmp_path / "library.tsv"
     db_path = tmp_path / "library.db"
 
-    # Schema (10 columns): id, title, artist, call_letters, artist_call_number,
-    # release_call_number, genre, format, alternate_artist_name, album_artist
+    # Schema (11 columns): id, title, artist, call_letters, artist_call_number,
+    # release_call_number, genre, format, alternate_artist_name, album_artist,
+    # cross_reference_names
     fields = [
         "1",
         entry["input"],  # title
@@ -48,6 +49,7 @@ def test_tsv_to_sqlite_roundtrip(
         "CD",
         "\\N",  # alternate_artist_name
         "\\N",  # album_artist
+        "\\N",  # cross_reference_names
     ]
     tsv_path.write_text("\t".join(fields) + "\n", encoding="utf-8")
 

--- a/tests/unit/test_tsv_to_sqlite.py
+++ b/tests/unit/test_tsv_to_sqlite.py
@@ -1,8 +1,8 @@
 """Unit tests for scripts/tsv_to_sqlite.py.
 
-Each TSV row has 10 tab-separated fields matching the MySQL SELECT output:
+Each TSV row has 11 tab-separated fields matching the MySQL SELECT output:
 id, title, artist, call_letters, artist_call_number, release_call_number,
-genre, format, alternate_artist_name, album_artist.
+genre, format, alternate_artist_name, album_artist, cross_reference_names.
 """
 
 from __future__ import annotations
@@ -37,9 +37,45 @@ class TestTsvToSqlite:
         """3-row TSV produces a library table with 3 rows and correct data."""
         tsv = _make_tsv(
             [
-                ["1", "Aluminum Tunes", "Stereolab", "ST", "100", "1", "Rock", "CD", "\\N", "\\N"],
-                ["2", "DOGA", "Juana Molina", "MO", "200", "2", "Rock", "LP", "\\N", "\\N"],
-                ["3", "Confield", "Autechre", "AU", "300", "3", "Electronic", "CD", "\\N", "\\N"],
+                [
+                    "1",
+                    "Aluminum Tunes",
+                    "Stereolab",
+                    "ST",
+                    "100",
+                    "1",
+                    "Rock",
+                    "CD",
+                    "\\N",
+                    "\\N",
+                    "\\N",
+                ],
+                [
+                    "2",
+                    "DOGA",
+                    "Juana Molina",
+                    "MO",
+                    "200",
+                    "2",
+                    "Rock",
+                    "LP",
+                    "\\N",
+                    "\\N",
+                    "\\N",
+                ],
+                [
+                    "3",
+                    "Confield",
+                    "Autechre",
+                    "AU",
+                    "300",
+                    "3",
+                    "Electronic",
+                    "CD",
+                    "\\N",
+                    "\\N",
+                    "\\N",
+                ],
             ]
         )
         tsv_file = tmp_path / "input.tsv"
@@ -72,6 +108,7 @@ class TestTsvToSqlite:
                     "CD",
                     "\\N",
                     "\\N",
+                    "\\N",
                 ],
             ]
         )
@@ -90,12 +127,12 @@ class TestTsvToSqlite:
         assert row[0] is None
         assert row[1] is None
 
-    def test_ten_column_validation(self, tmp_path: Path) -> None:
-        """Rows with != 10 fields are skipped; valid rows are still imported."""
+    def test_eleven_column_validation(self, tmp_path: Path) -> None:
+        """Rows with != 11 fields are skipped; valid rows are still imported."""
         tsv = (
-            "1\tAluminum Tunes\tStereolab\tST\t100\t1\tRock\tCD\t\\N\t\\N\n"
+            "1\tAluminum Tunes\tStereolab\tST\t100\t1\tRock\tCD\t\\N\t\\N\t\\N\n"
             "bad\trow\twith\ttoo\tfew\n"
-            "2\tDOGA\tJuana Molina\tMO\t200\t2\tRock\tLP\t\\N\t\\N\n"
+            "2\tDOGA\tJuana Molina\tMO\t200\t2\tRock\tLP\t\\N\t\\N\t\\N\n"
             "3\textra\tfields\there\t1\t2\t3\t4\t5\t6\t7\t8\n"
         )
         tsv_file = tmp_path / "input.tsv"
@@ -115,9 +152,45 @@ class TestTsvToSqlite:
         """After import, FTS MATCH queries work against artist and title."""
         tsv = _make_tsv(
             [
-                ["1", "Aluminum Tunes", "Stereolab", "ST", "100", "1", "Rock", "CD", "\\N", "\\N"],
-                ["2", "DOGA", "Juana Molina", "MO", "200", "2", "Rock", "LP", "\\N", "\\N"],
-                ["3", "Confield", "Autechre", "AU", "300", "3", "Electronic", "CD", "\\N", "\\N"],
+                [
+                    "1",
+                    "Aluminum Tunes",
+                    "Stereolab",
+                    "ST",
+                    "100",
+                    "1",
+                    "Rock",
+                    "CD",
+                    "\\N",
+                    "\\N",
+                    "\\N",
+                ],
+                [
+                    "2",
+                    "DOGA",
+                    "Juana Molina",
+                    "MO",
+                    "200",
+                    "2",
+                    "Rock",
+                    "LP",
+                    "\\N",
+                    "\\N",
+                    "\\N",
+                ],
+                [
+                    "3",
+                    "Confield",
+                    "Autechre",
+                    "AU",
+                    "300",
+                    "3",
+                    "Electronic",
+                    "CD",
+                    "\\N",
+                    "\\N",
+                    "\\N",
+                ],
             ]
         )
         tsv_file = tmp_path / "input.tsv"
@@ -146,7 +219,19 @@ class TestTsvToSqlite:
         """idx_artist, idx_title, and idx_alternate_artist indexes exist."""
         tsv = _make_tsv(
             [
-                ["1", "Aluminum Tunes", "Stereolab", "ST", "100", "1", "Rock", "CD", "\\N", "\\N"],
+                [
+                    "1",
+                    "Aluminum Tunes",
+                    "Stereolab",
+                    "ST",
+                    "100",
+                    "1",
+                    "Rock",
+                    "CD",
+                    "\\N",
+                    "\\N",
+                    "\\N",
+                ],
             ]
         )
         tsv_file = tmp_path / "input.tsv"
@@ -196,7 +281,19 @@ class TestTsvToSqlite:
         """Unicode characters (accents, non-Latin scripts) round-trip correctly."""
         tsv = _make_tsv(
             [
-                ["1", "DOGA", "Juana Molina", "MO", "200", "2", "Rock", "LP", "\\N", "\\N"],
+                [
+                    "1",
+                    "DOGA",
+                    "Juana Molina",
+                    "MO",
+                    "200",
+                    "2",
+                    "Rock",
+                    "LP",
+                    "\\N",
+                    "\\N",
+                    "\\N",
+                ],
                 [
                     "2",
                     "Pequena Vertigem de Amor",
@@ -206,6 +303,7 @@ class TestTsvToSqlite:
                     "1",
                     "Latin",
                     "LP",
+                    "\\N",
                     "\\N",
                     "\\N",
                 ],
@@ -219,6 +317,7 @@ class TestTsvToSqlite:
                     "Rock",
                     "CD",
                     "Sigur R\u00f3s",
+                    "\\N",
                     "\\N",
                 ],
             ]
@@ -243,9 +342,45 @@ class TestTsvToSqlite:
         """Return value matches the number of rows inserted."""
         tsv = _make_tsv(
             [
-                ["1", "Aluminum Tunes", "Stereolab", "ST", "100", "1", "Rock", "CD", "\\N", "\\N"],
-                ["2", "DOGA", "Juana Molina", "MO", "200", "2", "Rock", "LP", "\\N", "\\N"],
-                ["3", "Confield", "Autechre", "AU", "300", "3", "Electronic", "CD", "\\N", "\\N"],
+                [
+                    "1",
+                    "Aluminum Tunes",
+                    "Stereolab",
+                    "ST",
+                    "100",
+                    "1",
+                    "Rock",
+                    "CD",
+                    "\\N",
+                    "\\N",
+                    "\\N",
+                ],
+                [
+                    "2",
+                    "DOGA",
+                    "Juana Molina",
+                    "MO",
+                    "200",
+                    "2",
+                    "Rock",
+                    "LP",
+                    "\\N",
+                    "\\N",
+                    "\\N",
+                ],
+                [
+                    "3",
+                    "Confield",
+                    "Autechre",
+                    "AU",
+                    "300",
+                    "3",
+                    "Electronic",
+                    "CD",
+                    "\\N",
+                    "\\N",
+                    "\\N",
+                ],
                 [
                     "4",
                     "Pequena Vertigem de Amor",
@@ -255,6 +390,7 @@ class TestTsvToSqlite:
                     "1",
                     "Latin",
                     "LP",
+                    "\\N",
                     "\\N",
                     "\\N",
                 ],
@@ -285,8 +421,32 @@ class TestTsvToSqlite:
         """Running as a subprocess produces a valid SQLite database."""
         tsv = _make_tsv(
             [
-                ["1", "Aluminum Tunes", "Stereolab", "ST", "100", "1", "Rock", "CD", "\\N", "\\N"],
-                ["2", "DOGA", "Juana Molina", "MO", "200", "2", "Rock", "LP", "\\N", "\\N"],
+                [
+                    "1",
+                    "Aluminum Tunes",
+                    "Stereolab",
+                    "ST",
+                    "100",
+                    "1",
+                    "Rock",
+                    "CD",
+                    "\\N",
+                    "\\N",
+                    "\\N",
+                ],
+                [
+                    "2",
+                    "DOGA",
+                    "Juana Molina",
+                    "MO",
+                    "200",
+                    "2",
+                    "Rock",
+                    "LP",
+                    "\\N",
+                    "\\N",
+                    "\\N",
+                ],
             ]
         )
         tsv_file = tmp_path / "input.tsv"
@@ -325,8 +485,8 @@ class TestTsvToSqlite:
         zwj_family = f"\U0001f468{zwj}\U0001f469{zwj}\U0001f467{zwj}\U0001f466"
         tsv = _make_tsv(
             [
-                ["1", "Hello", "\U0001f44b", "EM", "100", "1", "Rock", "CD", "\\N", "\\N"],
-                ["2", "Family", zwj_family, "FA", "200", "2", "Rock", "CD", "\\N", "\\N"],
+                ["1", "Hello", "\U0001f44b", "EM", "100", "1", "Rock", "CD", "\\N", "\\N", "\\N"],
+                ["2", "Family", zwj_family, "FA", "200", "2", "Rock", "CD", "\\N", "\\N", "\\N"],
             ]
         )
         tsv_file = tmp_path / "input.tsv"
@@ -350,12 +510,85 @@ class TestTsvToSqlite:
         finally:
             conn.close()
 
+    def test_cross_reference_names_column(self, tmp_path: Path) -> None:
+        """The 11th TSV field populates cross_reference_names (WXYC/discogs-etl#334).
+
+        Mirrors library.db row 57833: filed under the band name "Burning Star
+        Core" with alternate_artist_name "C.S. Yeh". The WXYC catalog's
+        LIBRARY_CODE_CROSS_REFERENCE table also links it to the personal name
+        "C. Spencer Yeh", which the daily sync now carries through as a
+        pipe-joined cross_reference_names value so LML can match a typed
+        "C. Spencer Yeh" lookup against this row.
+        """
+        tsv = _make_tsv(
+            [
+                [
+                    "57833",
+                    '"In The Blink of an Eye" 7-inch',
+                    "Burning Star Core",
+                    "BU",
+                    "110",
+                    "6",
+                    "Rock",
+                    'vinyl - 7"',
+                    "C.S. Yeh",
+                    "\\N",
+                    "C. Spencer Yeh",
+                ],
+            ]
+        )
+        tsv_file = tmp_path / "input.tsv"
+        tsv_file.write_text(tsv, encoding="utf-8")
+        db_path = tmp_path / "library.db"
+
+        tsv_to_sqlite(str(tsv_file), str(db_path))
+
+        conn = sqlite3.connect(str(db_path))
+        row = conn.execute(
+            "SELECT artist, alternate_artist_name, cross_reference_names "
+            "FROM library WHERE id = 57833"
+        ).fetchone()
+        conn.close()
+
+        assert row == ("Burning Star Core", "C.S. Yeh", "C. Spencer Yeh")
+
+    def test_cross_reference_names_null_when_absent(self, tmp_path: Path) -> None:
+        """A row with no cross-reference (11th field is \\N) stores SQL NULL."""
+        tsv = _make_tsv(
+            [
+                [
+                    "1",
+                    "Aluminum Tunes",
+                    "Stereolab",
+                    "ST",
+                    "100",
+                    "1",
+                    "Rock",
+                    "CD",
+                    "\\N",
+                    "\\N",
+                    "\\N",
+                ],
+            ]
+        )
+        tsv_file = tmp_path / "input.tsv"
+        tsv_file.write_text(tsv, encoding="utf-8")
+        db_path = tmp_path / "library.db"
+
+        tsv_to_sqlite(str(tsv_file), str(db_path))
+
+        conn = sqlite3.connect(str(db_path))
+        row = conn.execute("SELECT cross_reference_names FROM library WHERE id = 1").fetchone()
+        conn.close()
+
+        assert row[0] is None
+
     def test_tab_in_field_value(self, tmp_path: Path) -> None:
         r"""MySQL escapes literal tabs in fields as \t; they should be unescaped."""
         # MySQL -B -N escapes real tabs inside data as the two-char sequence \t.
         # Our code splits on real tabs (\t), so literal \t in the data arrives as
         # the two characters backslash-t, which are preserved as-is in the field.
-        tsv = "1\tAluminum\\tTunes\tStereolab\tST\t100\t1\tRock\tCD\t\\N\t\\N\n"
+        tsv = "1\tAluminum\\tTunes\tStereolab\tST\t100\t1\tRock\tCD\t\\N\t\\N\t\\N\n"
         tsv_file = tmp_path / "input.tsv"
         tsv_file.write_text(tsv, encoding="utf-8")
         db_path = tmp_path / "library.db"
@@ -373,7 +606,7 @@ class TestTsvToSqlite:
         r"""MySQL escapes literal newlines in fields as \n; they should be preserved."""
         # Similar to tabs: MySQL -B outputs literal \n (two chars) for embedded newlines.
         # Since we split on real newlines, the two-char sequence stays intact.
-        tsv = "1\tNotes\\nMore notes\tAutechre\tAU\t300\t3\tElectronic\tCD\t\\N\t\\N\n"
+        tsv = "1\tNotes\\nMore notes\tAutechre\tAU\t300\t3\tElectronic\tCD\t\\N\t\\N\t\\N\n"
         tsv_file = tmp_path / "input.tsv"
         tsv_file.write_text(tsv, encoding="utf-8")
         db_path = tmp_path / "library.db"


### PR DESCRIPTION
## Summary

Adds a new additive `cross_reference_names` column to library.db, populated from tubafrenzy's `LIBRARY_CODE_CROSS_REFERENCE` table, so a release filed under a band name or abbreviated alias also carries the cataloger-recorded personal name a DJ might type.

- `scripts/sync-library.sh`: extends the daily MySQL query with a correlated subquery over `LIBRARY_CODE_CROSS_REFERENCE` that pipe-joins (`" | "`) the `PRESENTATION_NAME`s of any `LIBRARY_CODE`s cross-referenced to a release's own code, in either FK direction (`CROSS_REFERENCING_ARTIST_ID` / `CROSS_REFERENCED_LIBRARY_CODE_ID`, both -> `LIBRARY_CODE.ID`), excluding the row's own name.
- `scripts/tsv_to_sqlite.py`: adds the `cross_reference_names` column to the SQLite DDL and column mapping; the TSV parser now expects 11 tab-separated fields instead of 10.

Worked example: library.db row 57833 is `artist="Burning Star Core"`, `alternate_artist_name="C.S. Yeh"` -- neither prefix-matches a DJ typing "C. Spencer Yeh" (the artist's personal name). WXYC's `LIBRARY_CODE_CROSS_REFERENCE` table already links the two `LIBRARY_CODE`s; this PR carries that link into library.db.

## Phase 0 coverage (staging MySQL clone, ~2026-04-22 snapshot -- see PR discussion for a caveat)

Brought up the `WXYC/staging` MySQL container (already-downloaded dump, no fresh prod snapshot taken) and queried directly:

- `LIBRARY_CODE_CROSS_REFERENCE` row count: **119**
- Distinct `LIBRARY_CODE`s touched (either FK side): **196**
- `LIBRARY_RELEASE` rows that would gain a non-null `cross_reference_names`: **945** of 64,689 total (~1.5%)
- Confirmed both `LIBRARY_CODE` rows exist and release 57833 matches the ticket's description exactly (`artist="Burning Star Core"`, `alternate_artist_name="C.S. Yeh"`) -- **but this snapshot has no `LIBRARY_CODE_CROSS_REFERENCE` row linking "Burning Star Core" (7716) to "C. Spencer Yeh" (21708)**. The snapshot is also missing the `LIBRARY_RELEASE.ALBUM_ARTIST` column that the live `sync-library.sh` query already selects, confirming it's stale relative to current production schema. The correlated subquery itself was verified correct against real (if stale) cross-reference pairs in this snapshot (e.g. "Clouddead" <-> "Odd Nosdam", "Return to Forever" <-> "Chick Corea (Return to Forever)" / "Elf Power" / "Masters of the Hemisphere").

**Flag for human verification**: whether the Burning Star Core <-> C. Spencer Yeh cross-reference exists in current production tubafrenzy is unconfirmed -- the staging snapshot used here predates it or it was never catalogued. The code change is correct regardless (additive, verified against real rows of the same shape); this only affects how much of the catalog benefits on day one.

## Test plan

- [x] `tests/unit/test_tsv_to_sqlite.py` + `tests/integration/test_tsv_to_sqlite.py`: new tests for the 11-field schema, `cross_reference_names` round-trip (including the row-57833 fixture), and NULL handling; all pre-existing 10-field fixtures updated to 11 fields (`ruff format`-ed)
- [x] `tests/unit/test_charset_torture_sqlite_build.py`: fixture updated to 11 fields
- [x] Full suite: `945 passed, 8 skipped, 405 deselected, 1 xfailed`
- [x] `ruff check .` / `ruff format --check .` clean

## Related

Refs #334. Paired with WXYC/wxyc-catalog#34 (inline export path) and WXYC/library-metadata-lookup#978 (consumer). Data-column PRs (this one + wxyc-catalog) land before the LML consumer PR.

Per #334's constraints: does **not** run the production library sync, `POST /admin/upload-library-db`, or any prod library.db regeneration -- that stays a separate HITL step.
