### PR TITLE
feat(#217): instrument verify_cache prune classification (Phase 0)

### DIFF
--- a/docs/automation.md
+++ b/docs/automation.md
@@ -31,6 +31,12 @@ After the pipeline succeeds, the workflow runs `scripts/check_cache_drift.py` ag
 | `SENTRY_DSN` | Sentry DSN for error reporting (optional; JSON logging still works without it) |
 | `SLACK_MONITORING_WEBHOOK` | Slack incoming webhook for failure + drift alerts. **Required for production-grade alerting**: when this secret is unset the `Notify Slack on failure` step *itself* fails (with an `::error::` annotation explaining the missing-secret state) instead of silently skipping, so a workflow-level failure can't fall silent the way the 2026-05-05 runs did (#219). The dispatcher's GitHub failure-notification email is the sole signal in that degraded state. |
 
+**Optional instrumentation env:**
+
+| Env var | Description |
+|---------|-------------|
+| `PRUNE_AUDIT_DUMP_DIR` | Opt-in for the prune-coverage audit ([discogs-etl#217](https://github.com/WXYC/discogs-etl/issues/217) Phase 0). **Default unset — leave it unset for normal rebuilds.** When set, `run_pipeline.py` appends `--dump-classification $PRUNE_AUDIT_DUMP_DIR/prune-audit-<UTC-date>` to the `verify_cache.py` prune step. That step then writes the prune classification (keep/prune/review id sets, the pruned releases' raw artist/title, the applied pinned-override ids, and a second no-ANV classification pass for the #305 uplift diff) to that directory, and runs one extra classification pass. It is read-only with respect to cache **data** — only local artifact files are written. Set this (to a path that survives the run, e.g. under the EC2 work dir) only on the deliberate audit rebuild that Phase 1 of #217 calls for. |
+
 **Upstream dependency**: a successful `sync-library.yml` run must have uploaded `library.db` to the `streaming-data-v1` release on `WXYC/library-metadata-lookup` before this workflow fires, or the `Download library.db from LML release artifact` step fails with `release asset not found`. The default `${{ github.token }}` has read scope on the public LML repo; no extra PAT required.
 
 **Interpreting a failed run** (#219):

--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -33,6 +33,7 @@ import subprocess
 import sys
 import tempfile
 import time
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import NamedTuple
 
@@ -717,6 +718,28 @@ def write_keep_release_ids(db_url: str, output_path: Path) -> int:
     return len(ids)
 
 
+def prune_audit_dump_args() -> list[str]:
+    """Extra ``verify_cache.py`` args to capture the prune classification, or [].
+
+    Opt-in instrumentation for the discogs-etl#217 coverage audit. When the
+    ``PRUNE_AUDIT_DUMP_DIR`` environment variable is set, the prune step also
+    dumps its keep/prune/review id sets (plus a second, no-ANV classification
+    pass for the #305 uplift diff) under
+    ``$PRUNE_AUDIT_DUMP_DIR/prune-audit-<UTC-date>``. Default off: a normal
+    monthly rebuild leaves the env unset and ``verify_cache.py`` runs unchanged
+    with no extra classification pass.
+
+    The UTC date stamp (matching the rebuild's UTC scheduling) keeps a re-run on
+    a later day from clobbering an earlier capture. The dump is read-only with
+    respect to cache data — it only writes local artifact files.
+    """
+    base = os.environ.get("PRUNE_AUDIT_DUMP_DIR")
+    if not base:
+        return []
+    date = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    return ["--dump-classification", str(Path(base) / f"prune-audit-{date}")]
+
+
 def check_reload_invariant(
     db_url: str,
     *,
@@ -1262,6 +1285,7 @@ def _run_database_build_post_import(
                 db_url,
                 "--keep-release-ids",
                 str(keep_release_ids_path),
+                *prune_audit_dump_args(),
             ],
         )
     else:
@@ -1518,6 +1542,7 @@ def _run_database_build(
                 db_url,
                 "--keep-release-ids",
                 str(keep_release_ids_path),
+                *prune_audit_dump_args(),
             ],
         )
         if state:
@@ -1534,6 +1559,7 @@ def _run_database_build(
                 db_url,
                 "--keep-release-ids",
                 str(keep_release_ids_path),
+                *prune_audit_dump_args(),
             ],
         )
         if state:

--- a/scripts/verify_cache.py
+++ b/scripts/verify_cache.py
@@ -42,6 +42,7 @@ import sqlite3
 import sys
 import time
 import unicodedata
+from collections.abc import Sequence
 from concurrent.futures import ProcessPoolExecutor, as_completed
 from dataclasses import dataclass
 from pathlib import Path
@@ -376,7 +377,7 @@ class LibraryIndex:
         )
 
     @classmethod
-    def from_sqlite(cls, db_path: Path) -> LibraryIndex:
+    def from_sqlite(cls, db_path: Path, use_alternate: bool = True) -> LibraryIndex:
         """Build index from the library SQLite database.
 
         Prefers the widest column set available, degrading gracefully:
@@ -388,13 +389,28 @@ class LibraryIndex:
 
         Args:
             db_path: Path to library.db
+            use_alternate: When ``True`` (default), select ``alternate_artist_name``
+                and index it as an extra exact key (post-#305 behavior). When
+                ``False``, skip that column entirely so ``has_alternate`` stays
+                False and the alias is never indexed — reproducing pre-#305
+                matching. The prune audit (discogs-etl#217 Phase 0) builds a
+                second index with ``use_alternate=False`` to measure the #305
+                recall uplift as a file diff.
         """
-        logger.info(f"Building LibraryIndex from {db_path}")
+        logger.info(f"Building LibraryIndex from {db_path} (use_alternate={use_alternate})")
         conn = sqlite3.connect(str(db_path))
         cur = conn.cursor()
-        try:
-            cur.execute("SELECT artist, title, format, alternate_artist_name FROM library")
-        except sqlite3.OperationalError:
+        if use_alternate:
+            try:
+                cur.execute("SELECT artist, title, format, alternate_artist_name FROM library")
+            except sqlite3.OperationalError:
+                try:
+                    cur.execute("SELECT artist, title, format FROM library")
+                except sqlite3.OperationalError:
+                    cur.execute("SELECT artist, title FROM library")
+        else:
+            # Pre-#305 reproduction: never select the alias column, so
+            # from_rows sees at most 3-tuples and has_alternate is False.
             try:
                 cur.execute("SELECT artist, title, format FROM library")
             except sqlite3.OperationalError:
@@ -720,6 +736,139 @@ def apply_release_overrides(report: ClassificationReport, override_ids: set[int]
     report.keep_ids |= override_ids
     report.prune_ids -= override_ids
     report.review_ids -= override_ids
+
+
+def _write_release_ids(path: Path, ids: set[int]) -> None:
+    """Write *ids* to *path*, sorted, one release_id per line."""
+    with open(path, "w", encoding="utf-8") as f:
+        for release_id in sorted(ids):
+            f.write(f"{release_id}\n")
+
+
+def _partition_report(report: ClassificationReport) -> tuple[set[int], set[int], set[int]]:
+    """Resolve a report's keep/prune/review to a true partition by release_id.
+
+    ``classify_all_releases`` classifies each release once per primary-artist
+    group, so a release credited to several ``extra=0`` artists can land in more
+    than one bucket — e.g. KEEP via an in-library artist and PRUNE via a junk
+    co-credit. Resolve those collisions with the production precedence
+    ``KEEP > REVIEW > PRUNE`` (the prune copy-swap rebuilds from
+    ``keep_ids ∪ review_ids``, so any keep/review membership means the release is
+    retained). The returned prune set is therefore exactly what the rebuild
+    removes — the coverage gap the audit measures — not the raw per-group prunes.
+
+    Returns ``(keep, review, prune)`` as disjoint sets covering every classified
+    release_id.
+    """
+    keep = set(report.keep_ids)
+    review = report.review_ids - keep
+    prune = report.prune_ids - keep - report.review_ids
+    return keep, review, prune
+
+
+def dump_classification(
+    out_dir: Path,
+    report: ClassificationReport,
+    report_no_anv: ClassificationReport,
+    override_ids: set[int],
+    releases: Sequence[tuple[int, str, str, str | None]],
+) -> None:
+    """Persist the prune classification for the coverage audit (discogs-etl#217).
+
+    The keep/prune/review id sets exist only in memory during a rebuild and are
+    otherwise reported as counts only; in ``--prune`` mode the pre-prune
+    population is deleted immediately after classification, so it cannot be
+    recovered post-hoc. This writes everything Phase 2 of the audit needs, all
+    from state already in memory (no extra query):
+
+    - ``keep_ids.txt`` / ``prune_ids.txt`` / ``review_ids.txt`` — sorted,
+      newline-delimited ``release_id``s, resolved to a true partition by
+      ``_partition_report`` (KEEP > REVIEW > PRUNE). Post-override: they reflect
+      the ``apply_release_overrides`` pass, so pinned releases have already moved
+      into ``keep_ids``. ``prune_ids.txt`` is exactly the set the rebuild
+      removes, so it never lists a release that is retained via another credit.
+    - ``override_ids.txt`` — the pinned ids that were exempted, so the
+      pinned/non-pinned split needs no live join later.
+    - ``prune_ids_no_anv.txt`` — the (partitioned) prune set from a second
+      classification pass built *without* ``alternate_artist_name`` indexing
+      (pre-#305), with the SAME pinned-override exemption applied. Because both
+      sides are post-override, the #305 recall uplift is a clean file diff
+      (``prune_ids_no_anv − prune_ids``) with no pin contamination. Note the
+      uplift this measures is *marginal over pins*: a release that ANV rescues
+      but that is also pinned is retained either way, so it is intentionally
+      excluded — the diff counts releases ANV saves that a pin did not already
+      save, not the total ANV alias-match count.
+    - ``prune_releases.jsonl`` — one ``{"id", "artist", "title", "format"}``
+      object per pruned id, so the false-negative sample can read raw
+      artist/title without a DB round-trip. A release fans out to several rows in
+      ``releases`` (the ``extra=0`` join); the row with the lexicographically
+      smallest artist is kept so the output is deterministic across runs.
+    - ``counts.json`` — headline counts plus a ``dedup_note`` slot left null for
+      Phase 2 to fill with the post-prune dedup delta. ``total_release_rows`` is
+      the fan-out row count (a multi-artist release counts once per credit), so
+      it is ``>=`` the number of distinct ids in the partitioned sets.
+
+    Every write is a local file; the cache database is untouched.
+    """
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    keep_ids, review_ids, prune_ids = _partition_report(report)
+    _, _, prune_ids_no_anv = _partition_report(report_no_anv)
+
+    _write_release_ids(out_dir / "keep_ids.txt", keep_ids)
+    _write_release_ids(out_dir / "prune_ids.txt", prune_ids)
+    _write_release_ids(out_dir / "review_ids.txt", review_ids)
+    _write_release_ids(out_dir / "override_ids.txt", override_ids)
+    _write_release_ids(out_dir / "prune_ids_no_anv.txt", prune_ids_no_anv)
+
+    # One (artist, title, format) per release_id. A release with multiple primary
+    # artists fans out to several rows in ``releases`` (the extra=0 join in
+    # load_discogs_releases, ordered only by r.id); keep the row with the
+    # smallest artist name so the dump is reproducible regardless of row order.
+    release_by_id: dict[int, tuple[str | None, str | None, str | None]] = {}
+    for release in releases:
+        rid = release[0]
+        artist = release[1]
+        existing = release_by_id.get(rid)
+        if existing is None or (artist or "") < (existing[0] or ""):
+            fmt = release[3] if len(release) > 3 else None
+            release_by_id[rid] = (artist, release[2], fmt)
+
+    with open(out_dir / "prune_releases.jsonl", "w", encoding="utf-8") as f:
+        for rid in sorted(prune_ids):
+            artist, title, fmt = release_by_id.get(rid, (None, None, None))
+            f.write(
+                json.dumps(
+                    {"id": rid, "artist": artist, "title": title, "format": fmt},
+                    ensure_ascii=False,
+                )
+                + "\n"
+            )
+
+    counts = {
+        "keep": len(keep_ids),
+        "prune": len(prune_ids),
+        "review": len(review_ids),
+        "override_applied": len(override_ids),
+        "total_release_rows": report.total_releases,
+        # Filled by Phase 2: (keep + review) − final `release` count, the
+        # dedup_releases.py collapse that happens after the prune.
+        "dedup_note": None,
+    }
+    with open(out_dir / "counts.json", "w", encoding="utf-8") as f:
+        json.dump(counts, f, indent=2)
+        f.write("\n")
+
+    logger.info(
+        "Wrote prune-audit classification to %s "
+        "(keep=%d prune=%d review=%d override=%d prune_no_anv=%d)",
+        out_dir,
+        len(keep_ids),
+        len(prune_ids),
+        len(review_ids),
+        len(override_ids),
+        len(prune_ids_no_anv),
+    )
 
 
 def save_artist_mappings(path: Path, mappings: dict) -> None:
@@ -1712,6 +1861,19 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "pinned overrides from lml_cache.library_release_override). "
         "Omit for today's behavior.",
     )
+    parser.add_argument(
+        "--dump-classification",
+        type=Path,
+        default=None,
+        metavar="DIR",
+        help="Write the prune classification to DIR for the coverage audit "
+        "(discogs-etl#217 Phase 0): keep/prune/review id sets, the pruned "
+        "releases' raw artist/title, the applied override ids, and a second "
+        "prune set computed without alternate_artist_name indexing (pre-#305) "
+        "for the #305-uplift diff. Read-only with respect to cache data (only "
+        "writes local files); adds one extra classification pass. Omit for "
+        "normal rebuilds.",
+    )
     return parser.parse_args(argv)
 
 
@@ -2194,6 +2356,36 @@ async def async_main():
         if override_ids:
             logger.info(f"Applying {len(override_ids):,} pinned release_id override(s)")
         apply_release_overrides(report, override_ids)
+
+        # Step 5b (audit only): dump the prune classification for discogs-etl#217
+        # Phase 0. Runs a second classification pass with alternate_artist_name
+        # indexing disabled (pre-#305) so the #305 recall uplift is recoverable
+        # as a pure file diff in Phase 2. Guarded by --dump-classification, so it
+        # never runs on a normal rebuild. Read-only w.r.t. cache data.
+        if args.dump_classification is not None:
+            logger.info(
+                "Prune-audit mode: running a second no-ANV classification pass "
+                "for the #305 uplift diff (discogs-etl#217)"
+            )
+            index_no_anv = LibraryIndex.from_sqlite(args.library_db, use_alternate=False)
+            matcher_no_anv = MultiIndexMatcher(
+                index_no_anv,
+                artist_mappings=mappings,
+                keep_threshold=args.score_cutoff,
+            )
+            report_no_anv = classify_all_releases(releases, index_no_anv, matcher_no_anv)
+            # Apply the SAME pin exemption to the no-ANV report. This keeps
+            # prune_ids_no_anv − prune_ids a pure #305 (alias) signal: a pinned
+            # release that would prune under BOTH passes is removed from both
+            # sets and never pollutes the uplift diff.
+            apply_release_overrides(report_no_anv, override_ids)
+            dump_classification(
+                args.dump_classification,
+                report,
+                report_no_anv,
+                override_ids,
+                releases,
+            )
 
         # Step 6: Get table sizes for the report
         logger.info("Measuring table sizes...")

--- a/tests/integration/test_verify_cache_dump_classification.py
+++ b/tests/integration/test_verify_cache_dump_classification.py
@@ -1,0 +1,233 @@
+"""End-to-end coverage for verify_cache --dump-classification (discogs-etl#217 Phase 0).
+
+Runs the real ``async_main`` dry-run path against a seeded Postgres cache and a
+hand-built SQLite library, then asserts on the artifact files the prune audit
+consumes. Exercises the whole wire path: the primary classification + override
+pass, the second no-ANV classification pass, and the on-disk dump.
+
+The fixture is shaped to make every classification deterministic against a tiny
+2-artist library:
+
+- id=1 Luke Vibert / "Drum 'n' Bass for Papa"   -> KEEP in both passes (canonical)
+- id=2 Plug / "Drum 'n' Bass for Papa"           -> KEEP with ANV, PRUNE without
+      (the #305 alias rescue: "Plug" is Luke Vibert's alternate_artist_name)
+- id=3 Juana Molina / "DOGA"                     -> KEEP in both passes (canonical)
+- id=4 Zzyzx Qxqxqx / "Xyzzy Plugh"              -> junk, PINNED -> lands in KEEP
+- id=5 Foobar Nonexist / "Nowhere Album"         -> junk, not pinned -> PRUNE
+
+Release formats are the normalized categories the import stage writes ('CD',
+'Vinyl'), not raw Discogs descriptors, so the exact-match format filter passes.
+
+See the module-loading note in the sibling integration tests for the importlib
+dance (#109).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import sqlite3
+import sys
+from pathlib import Path
+
+import psycopg
+import pytest
+
+pytestmark = pytest.mark.pg
+
+REPO_ROOT = Path(__file__).parent.parent.parent
+SCHEMA_DIR = REPO_ROOT / "schema"
+
+_VERIFY_CACHE_PATH = REPO_ROOT / "scripts" / "verify_cache.py"
+if "verify_cache" in sys.modules:
+    _vc = sys.modules["verify_cache"]
+else:
+    _spec = importlib.util.spec_from_file_location("verify_cache", _VERIFY_CACHE_PATH)
+    assert _spec is not None and _spec.loader is not None
+    _vc = importlib.util.module_from_spec(_spec)
+    sys.modules["verify_cache"] = _vc
+    _spec.loader.exec_module(_vc)
+
+
+# The alias-rescue release: keeps via alternate_artist_name, prunes without it.
+ALIAS_RELEASE_ID = 2
+# The always-pruned, non-pinned junk release.
+JUNK_PRUNE_ID = 5
+# The pinned junk release (would prune, but the override keeps it).
+PINNED_ID = 4
+# A single release credited to TWO primary artists (extra=0), one in-library
+# (KEEP) and one junk (PRUNE). classify_all_releases classifies it per artist
+# group, so its id lands in BOTH keep_ids and prune_ids; the dump must resolve
+# it to KEEP (production copy-swap retains keep ∪ review) and NOT list it as
+# pruned.
+MULTI_ARTIST_KEEP_ID = 6
+
+
+def _seed_cache(db_url: str) -> None:
+    """Apply the cache schema and insert the fixture releases."""
+    conn = psycopg.connect(db_url, autocommit=True)
+    try:
+        with conn.cursor() as cur:
+            cur.execute(SCHEMA_DIR.joinpath("create_database.sql").read_text())
+            cur.execute(SCHEMA_DIR.joinpath("create_functions.sql").read_text())
+            cur.executemany(
+                "INSERT INTO release (id, title, format) VALUES (%s, %s, %s)",
+                [
+                    (1, "Drum 'n' Bass for Papa", "CD"),
+                    (2, "Drum 'n' Bass for Papa", "CD"),
+                    (3, "DOGA", "CD"),
+                    (4, "Xyzzy Plugh", "CD"),
+                    (5, "Nowhere Album", "CD"),
+                    (6, "DOGA", "CD"),
+                ],
+            )
+            cur.executemany(
+                "INSERT INTO release_artist (release_id, artist_name, extra) VALUES (%s, %s, 0)",
+                [
+                    (1, "Luke Vibert"),
+                    (2, "Plug"),
+                    (3, "Juana Molina"),
+                    (4, "Zzyzx Qxqxqx"),
+                    (5, "Foobar Nonexist"),
+                    # id=6: two primary artists -> KEEP via Juana Molina, PRUNE
+                    # via the junk credit. Exercises the keep/prune overlap.
+                    (6, "Juana Molina"),
+                    (6, "Foobar Nonexist"),
+                ],
+            )
+    finally:
+        conn.close()
+
+
+def _build_library(path: Path) -> None:
+    """Write a SQLite library.db: one artist with an alias, one without."""
+    conn = sqlite3.connect(str(path))
+    try:
+        cur = conn.cursor()
+        cur.execute(
+            "CREATE TABLE library (id INTEGER PRIMARY KEY, artist TEXT, title TEXT, "
+            "format TEXT, alternate_artist_name TEXT)"
+        )
+        cur.executemany(
+            "INSERT INTO library (artist, title, format, alternate_artist_name) "
+            "VALUES (?, ?, ?, ?)",
+            [
+                # Artist WITH an alternate_artist_name (the #305 path).
+                ("Luke Vibert", "Drum 'n' Bass for Papa", "CD", "Plug"),
+                # Artist WITHOUT an alternate.
+                ("Juana Molina", "DOGA", "CD", None),
+            ],
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _read_ids(path: Path) -> set[int]:
+    text = path.read_text().strip()
+    return {int(line) for line in text.splitlines() if line}
+
+
+@pytest.fixture()
+def dump_dir(tmp_path, fresh_db_url, monkeypatch):
+    """Seed cache + library, run async_main --dump-classification, return the dump dir."""
+    _seed_cache(fresh_db_url)
+
+    library_db = tmp_path / "library.db"
+    _build_library(library_db)
+
+    keep_file = tmp_path / "keep_release_ids.txt"
+    keep_file.write_text(f"{PINNED_ID}\n")
+
+    out_dir = tmp_path / "prune-audit"
+
+    argv = [
+        "verify_cache.py",
+        str(library_db),
+        fresh_db_url,
+        "--dump-classification",
+        str(out_dir),
+        "--keep-release-ids",
+        str(keep_file),
+    ]
+    monkeypatch.setattr(sys, "argv", argv)
+    # Dry run (no --prune / --copy-to): the dump fires before the branch, and
+    # the cache is never mutated.
+    asyncio.run(_vc.async_main())
+    return out_dir
+
+
+class TestDumpClassificationEndToEnd:
+    def test_all_artifact_files_written(self, dump_dir):
+        for name in (
+            "keep_ids.txt",
+            "prune_ids.txt",
+            "review_ids.txt",
+            "override_ids.txt",
+            "prune_ids_no_anv.txt",
+            "prune_releases.jsonl",
+            "counts.json",
+        ):
+            assert (dump_dir / name).exists(), f"missing {name}"
+
+    def test_id_files_partition_the_release_set(self, dump_dir):
+        """(i) keep / prune / review partition all six releases, disjointly."""
+        keep = _read_ids(dump_dir / "keep_ids.txt")
+        prune = _read_ids(dump_dir / "prune_ids.txt")
+        review = _read_ids(dump_dir / "review_ids.txt")
+
+        assert keep | prune | review == {1, 2, 3, 4, 5, 6}
+        assert keep & prune == set()
+        assert keep & review == set()
+        assert prune & review == set()
+
+        # The concrete expected split (post-override).
+        assert keep == {1, 2, 3, 4, MULTI_ARTIST_KEEP_ID}
+        assert prune == {JUNK_PRUNE_ID}
+        assert review == set()
+
+    def test_multi_artist_release_resolves_to_keep_not_prune(self, dump_dir):
+        """A release that is KEEP via one primary artist and PRUNE via another
+        must land in keep_ids only — production copy-swap retains it, so the
+        audit must not count it as a coverage gap."""
+        keep = _read_ids(dump_dir / "keep_ids.txt")
+        prune = _read_ids(dump_dir / "prune_ids.txt")
+        assert MULTI_ARTIST_KEEP_ID in keep
+        assert MULTI_ARTIST_KEEP_ID not in prune
+
+    def test_override_ids_file_reflects_keep_release_ids(self, dump_dir):
+        """(ii) override_ids.txt is exactly the passed --keep-release-ids set."""
+        assert _read_ids(dump_dir / "override_ids.txt") == {PINNED_ID}
+
+    def test_no_anv_superset_and_diff_is_alias_release(self, dump_dir):
+        """(iii) prune_ids_no_anv superset of prune_ids; the difference is the alias rescue."""
+        prune = _read_ids(dump_dir / "prune_ids.txt")
+        prune_no_anv = _read_ids(dump_dir / "prune_ids_no_anv.txt")
+
+        assert prune_no_anv >= prune
+        # The only release that flips prune->keep under the ANV index is the
+        # alias-credited one (#305 uplift).
+        assert prune_no_anv - prune == {ALIAS_RELEASE_ID}
+
+    def test_prune_releases_jsonl_carries_raw_fields(self, dump_dir):
+        """prune_releases.jsonl has one object per pruned id with raw artist/title."""
+        import json
+
+        lines = (dump_dir / "prune_releases.jsonl").read_text().splitlines()
+        objs = [json.loads(line) for line in lines]
+        assert [o["id"] for o in objs] == [JUNK_PRUNE_ID]
+        assert objs[0]["artist"] == "Foobar Nonexist"
+        assert objs[0]["title"] == "Nowhere Album"
+
+    def test_counts_json_matches_id_files(self, dump_dir):
+        import json
+
+        counts = json.loads((dump_dir / "counts.json").read_text())
+        assert counts["keep"] == 5
+        assert counts["prune"] == 1
+        assert counts["review"] == 0
+        assert counts["override_applied"] == 1
+        assert counts["dedup_note"] is None
+        # total_release_rows is the fan-out row count (id=6 has two credits), so
+        # it exceeds the six distinct release ids.
+        assert counts["total_release_rows"] == 7

--- a/tests/unit/test_run_pipeline.py
+++ b/tests/unit/test_run_pipeline.py
@@ -1853,3 +1853,162 @@ class TestPostImportReloadInvariant:
         check_idx = events.index(("check", True))
         report_idx = next(i for i, (kind, _) in enumerate(events) if kind == "report")
         assert check_idx < report_idx
+
+
+class TestPruneAuditDumpArgs:
+    """prune_audit_dump_args() opt-in via PRUNE_AUDIT_DUMP_DIR (discogs-etl#217 Phase 0)."""
+
+    def test_unset_env_returns_empty(self, monkeypatch) -> None:
+        monkeypatch.delenv("PRUNE_AUDIT_DUMP_DIR", raising=False)
+        assert run_pipeline.prune_audit_dump_args() == []
+
+    def test_empty_env_returns_empty(self, monkeypatch) -> None:
+        monkeypatch.setenv("PRUNE_AUDIT_DUMP_DIR", "")
+        assert run_pipeline.prune_audit_dump_args() == []
+
+    def test_set_env_returns_dated_dump_flag(self, monkeypatch) -> None:
+        import re
+
+        monkeypatch.setenv("PRUNE_AUDIT_DUMP_DIR", "/data/audit")
+        args = run_pipeline.prune_audit_dump_args()
+        assert args[0] == "--dump-classification"
+        assert re.fullmatch(r"/data/audit/prune-audit-\d{4}-\d{2}-\d{2}", args[1]), args[1]
+
+
+class TestPruneAuditDumpWiring:
+    """PRUNE_AUDIT_DUMP_DIR plumbs --dump-classification into the verify_cache prune step.
+
+    Default off (env unset) leaves the prune invocation exactly as before, so a
+    normal monthly rebuild pays no extra classification pass.
+    """
+
+    def _capture_prune_cmd(self, *, dump_env, monkeypatch) -> list[str]:
+        import psycopg
+
+        if dump_env is None:
+            monkeypatch.delenv("PRUNE_AUDIT_DUMP_DIR", raising=False)
+        else:
+            monkeypatch.setenv("PRUNE_AUDIT_DUMP_DIR", dump_env)
+
+        captured: list[list[str]] = []
+
+        def fake_run_step(step_name, cmd, *a, **k):
+            captured.append(cmd)
+
+        mock_cursor = MagicMock()
+        mock_cursor.fetchone.return_value = [True]
+        mock_cursor.fetchall.return_value = []
+        mock_conn = MagicMock()
+        mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
+        mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+
+        with (
+            patch.object(run_pipeline, "run_step", side_effect=fake_run_step),
+            patch.object(run_pipeline, "check_reload_invariant"),
+            patch.object(run_pipeline, "run_sql_statements_parallel"),
+            patch.object(run_pipeline, "run_vacuum"),
+            patch.object(run_pipeline, "set_tables_logged"),
+            patch.object(run_pipeline, "report_sizes"),
+            patch.object(psycopg, "connect", return_value=mock_conn),
+        ):
+            run_pipeline._run_database_build_post_import(
+                "postgresql:///test",
+                Path("/tmp/csv"),
+                Path("/tmp/library.db"),
+                sys.executable,
+            )
+
+        prune_cmds = [
+            c for c in captured if any("verify_cache.py" in str(x) for x in c) and "--prune" in c
+        ]
+        assert len(prune_cmds) == 1, f"expected one prune invocation, got {len(prune_cmds)}"
+        return prune_cmds[0]
+
+    def _capture_stateful_verify_cmds(
+        self, *, dump_env, monkeypatch, target_db_url=None
+    ) -> list[list[str]]:
+        """Drive the stateful _run_database_build and return its verify_cache cmds.
+
+        Covers the two call sites that _run_database_build_post_import doesn't:
+        the copy-to arm and the stateful prune arm.
+        """
+        import psycopg
+
+        if dump_env is None:
+            monkeypatch.delenv("PRUNE_AUDIT_DUMP_DIR", raising=False)
+        else:
+            monkeypatch.setenv("PRUNE_AUDIT_DUMP_DIR", dump_env)
+
+        captured: list[list[str]] = []
+
+        def fake_run_step(step_name, cmd, *a, **k):
+            captured.append(cmd)
+
+        mock_cursor = MagicMock()
+        mock_cursor.fetchone.return_value = [True]
+        mock_cursor.fetchall.return_value = [
+            ("idx_release_artist_name_trgm",),
+            ("idx_release_title_trgm",),
+        ]
+        mock_conn = MagicMock()
+        mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
+        mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+
+        with (
+            patch.object(run_pipeline, "run_step", side_effect=fake_run_step),
+            patch.object(run_pipeline, "wait_for_postgres"),
+            patch.object(run_pipeline, "run_sql_file"),
+            patch.object(run_pipeline, "run_sql_statements_parallel"),
+            patch.object(run_pipeline, "set_tables_unlogged"),
+            patch.object(run_pipeline, "set_tables_logged"),
+            patch.object(run_pipeline, "run_vacuum"),
+            patch.object(run_pipeline, "report_sizes"),
+            patch.object(run_pipeline, "write_keep_release_ids", return_value=0),
+            patch.object(run_pipeline, "check_reload_invariant") as mock_check,
+            patch.object(psycopg, "connect", return_value=mock_conn),
+        ):
+            mock_check.return_value = run_pipeline.ReloadInvariantResult(
+                ok=True, release_count=1, artist_coverage=1.0, track_coverage=1.0
+            )
+            run_pipeline._run_database_build(
+                "postgresql:///test",
+                Path("/tmp/csv"),
+                Path("/tmp/library.db"),
+                sys.executable,
+                target_db_url=target_db_url,
+            )
+
+        return [c for c in captured if any("verify_cache.py" in str(x) for x in c)]
+
+    def test_dump_flag_present_when_env_set(self, monkeypatch) -> None:
+        cmd = self._capture_prune_cmd(dump_env="/data/audit", monkeypatch=monkeypatch)
+        assert "--dump-classification" in cmd
+        dump_dir = cmd[cmd.index("--dump-classification") + 1]
+        assert dump_dir.startswith("/data/audit/prune-audit-")
+
+    def test_dump_flag_absent_when_env_unset(self, monkeypatch) -> None:
+        cmd = self._capture_prune_cmd(dump_env=None, monkeypatch=monkeypatch)
+        assert "--dump-classification" not in cmd
+
+    def test_dump_flag_in_stateful_prune_arm(self, monkeypatch) -> None:
+        cmds = self._capture_stateful_verify_cmds(dump_env="/data/audit", monkeypatch=monkeypatch)
+        prune = [c for c in cmds if "--prune" in c]
+        assert len(prune) == 1
+        assert "--dump-classification" in prune[0]
+
+    def test_dump_flag_in_copy_to_arm(self, monkeypatch) -> None:
+        cmds = self._capture_stateful_verify_cmds(
+            dump_env="/data/audit", monkeypatch=monkeypatch, target_db_url="postgresql:///target"
+        )
+        copy = [c for c in cmds if "--copy-to" in c]
+        assert len(copy) == 1
+        assert "--dump-classification" in copy[0]
+
+    def test_dump_flag_absent_in_stateful_arms_when_env_unset(self, monkeypatch) -> None:
+        for target in (None, "postgresql:///target"):
+            cmds = self._capture_stateful_verify_cmds(
+                dump_env=None, monkeypatch=monkeypatch, target_db_url=target
+            )
+            assert cmds, "expected a verify_cache invocation to capture"
+            for c in cmds:
+                assert "--dump-classification" not in c

--- a/tests/unit/test_verify_cache.py
+++ b/tests/unit/test_verify_cache.py
@@ -668,6 +668,7 @@ _classify_fuzzy_chunk = _vc._classify_fuzzy_chunk
 prune_releases_copy_swap = _vc.prune_releases_copy_swap
 load_keep_release_ids = _vc.load_keep_release_ids
 apply_release_overrides = _vc.apply_release_overrides
+dump_classification = _vc.dump_classification
 
 parse_args = _vc.parse_args
 
@@ -1068,6 +1069,165 @@ class TestApplyReleaseOverrides:
         assert report.review_ids == {103}
 
 
+class TestDumpClassificationArg:
+    """--dump-classification parses to a Path (discogs-etl#217 Phase 0)."""
+
+    def test_default_none(self, tmp_path):
+        db = tmp_path / "library.db"
+        db.touch()
+        args = parse_args([str(db)])
+        assert args.dump_classification is None
+
+    def test_parsed_as_path(self, tmp_path):
+        db = tmp_path / "library.db"
+        db.touch()
+        out = tmp_path / "prune-audit"
+        args = parse_args([str(db), "--dump-classification", str(out)])
+        assert args.dump_classification == out
+
+
+class TestDumpClassification:
+    """dump_classification writes the prune-audit artifact (discogs-etl#217)."""
+
+    def _make_report(self, keep_ids, prune_ids, review_ids=()):
+        return ClassificationReport(
+            keep_ids=set(keep_ids),
+            prune_ids=set(prune_ids),
+            review_ids=set(review_ids),
+            review_by_artist={},
+            artist_originals={},
+            total_releases=len(keep_ids) + len(prune_ids) + len(review_ids),
+        )
+
+    def test_writes_all_artifact_files(self, tmp_path):
+        report = self._make_report(keep_ids={1}, prune_ids={2, 3}, review_ids={4})
+        report_no_anv = self._make_report(keep_ids={1}, prune_ids={2, 3}, review_ids={4})
+        releases = [
+            (1, "Luke Vibert", "Drum 'n' Bass for Papa", "CD"),
+            (2, "Plug", "Drum 'n' Bass for Papa", "CD"),
+            (3, "Zzyzx Qxqxqx", "Xyzzy Plugh", None),
+            (4, "Juana Molina", "DOGA", "LP"),
+        ]
+        out = tmp_path / "prune-audit"
+        dump_classification(out, report, report_no_anv, {5001}, releases)
+
+        for name in (
+            "keep_ids.txt",
+            "prune_ids.txt",
+            "review_ids.txt",
+            "override_ids.txt",
+            "prune_ids_no_anv.txt",
+            "prune_releases.jsonl",
+            "counts.json",
+        ):
+            assert (out / name).exists(), f"missing {name}"
+
+    def test_id_files_are_sorted_newline_delimited(self, tmp_path):
+        report = self._make_report(keep_ids={30, 10, 20}, prune_ids=set())
+        dump_classification(tmp_path, report, self._make_report(set(), set()), set(), [])
+        assert (tmp_path / "keep_ids.txt").read_text() == "10\n20\n30\n"
+
+    def test_override_ids_file_reflects_passed_set(self, tmp_path):
+        report = self._make_report(keep_ids={9001}, prune_ids=set())
+        dump_classification(tmp_path, report, self._make_report(set(), set()), {9001}, [])
+        assert (tmp_path / "override_ids.txt").read_text() == "9001\n"
+
+    def test_prune_releases_jsonl_has_raw_fields(self, tmp_path):
+        report = self._make_report(keep_ids={1}, prune_ids={2, 3})
+        releases = [
+            (1, "Luke Vibert", "Drum 'n' Bass for Papa", "CD"),
+            (2, "Plug", "Drum 'n' Bass for Papa", "CD"),
+            (3, "Zzyzx Qxqxqx", "Xyzzy Plugh", None),
+        ]
+        dump_classification(tmp_path, report, self._make_report(set(), set()), set(), releases)
+        lines = (tmp_path / "prune_releases.jsonl").read_text().splitlines()
+        objs = [json.loads(line) for line in lines]
+        # One object per pruned id, sorted by id.
+        assert [o["id"] for o in objs] == [2, 3]
+        assert objs[0] == {
+            "id": 2,
+            "artist": "Plug",
+            "title": "Drum 'n' Bass for Papa",
+            "format": "CD",
+        }
+        assert objs[1]["format"] is None
+
+    def test_prune_releases_jsonl_dedupes_multi_artist_fanout(self, tmp_path):
+        """A release credited to multiple primary artists appears once, and the
+        chosen artist is the lexicographically smallest for reproducibility."""
+        report = self._make_report(keep_ids=set(), prune_ids={7})
+        # Row order is reversed vs. alphabetical to prove min-artist wins.
+        releases = [
+            (7, "John Coltrane", "In a Sentimental Mood", "LP"),
+            (7, "Duke Ellington", "In a Sentimental Mood", "LP"),
+        ]
+        dump_classification(tmp_path, report, self._make_report(set(), set()), set(), releases)
+        lines = (tmp_path / "prune_releases.jsonl").read_text().splitlines()
+        assert len(lines) == 1
+        obj = json.loads(lines[0])
+        assert obj["id"] == 7
+        assert obj["artist"] == "Duke Ellington"
+
+    def test_counts_json_shape(self, tmp_path):
+        report = self._make_report(keep_ids={1, 2}, prune_ids={3}, review_ids={4})
+        report_no_anv = self._make_report(keep_ids={1, 2}, prune_ids={3}, review_ids={4})
+        dump_classification(tmp_path, report, report_no_anv, {9001}, [])
+        counts = json.loads((tmp_path / "counts.json").read_text())
+        assert counts == {
+            "keep": 2,
+            "prune": 1,
+            "review": 1,
+            "override_applied": 1,
+            "total_release_rows": 4,
+            "dedup_note": None,
+        }
+
+    def test_creates_output_dir(self, tmp_path):
+        report = self._make_report(keep_ids={1}, prune_ids=set())
+        nested = tmp_path / "a" / "b" / "prune-audit"
+        dump_classification(nested, report, self._make_report(set(), set()), set(), [])
+        assert (nested / "counts.json").exists()
+
+    def test_multi_artist_overlap_resolves_to_keep(self, tmp_path):
+        """A release in both keep_ids and prune_ids (KEEP via one artist, PRUNE
+        via another) is written as KEEP and excluded from the pruned set and the
+        prune_releases.jsonl — matching what the copy-swap actually removes."""
+        report = self._make_report(keep_ids={6}, prune_ids={5, 6}, review_ids=set())
+        releases = [
+            (5, "Junk Artist", "Nowhere", "CD"),
+            (6, "Juana Molina", "DOGA", "CD"),
+        ]
+        dump_classification(tmp_path, report, self._make_report(set(), set()), set(), releases)
+        keep = set(map(int, (tmp_path / "keep_ids.txt").read_text().split()))
+        prune = set(map(int, (tmp_path / "prune_ids.txt").read_text().split()))
+        assert keep == {6}
+        assert prune == {5}
+        pruned_ids = [
+            json.loads(line)["id"]
+            for line in (tmp_path / "prune_releases.jsonl").read_text().splitlines()
+        ]
+        assert pruned_ids == [5]
+
+    def test_review_wins_over_prune_on_overlap(self, tmp_path):
+        """KEEP > REVIEW > PRUNE precedence: an id in both review and prune is
+        review (retained), not pruned."""
+        report = self._make_report(keep_ids=set(), prune_ids={8, 9}, review_ids={8})
+        dump_classification(tmp_path, report, self._make_report(set(), set()), set(), [])
+        review = set(map(int, (tmp_path / "review_ids.txt").read_text().split()))
+        prune = set(map(int, (tmp_path / "prune_ids.txt").read_text().split()))
+        assert review == {8}
+        assert prune == {9}
+
+    def test_no_anv_prune_set_is_partitioned(self, tmp_path):
+        """prune_ids_no_anv is resolved with the same precedence, so a no-ANV
+        overlap release doesn't inflate the #305 uplift diff."""
+        report = self._make_report(keep_ids=set(), prune_ids=set())
+        report_no_anv = self._make_report(keep_ids={6}, prune_ids={2, 6}, review_ids=set())
+        dump_classification(tmp_path, report, report_no_anv, set(), [])
+        prune_no_anv = set(map(int, (tmp_path / "prune_ids_no_anv.txt").read_text().split()))
+        assert prune_no_anv == {2}
+
+
 # ---------------------------------------------------------------------------
 # format_bytes
 # ---------------------------------------------------------------------------
@@ -1460,6 +1620,44 @@ class TestAlternateArtistNameIndex:
         norm_title = normalize_title("Drum 'n' Bass for Papa")
         assert "plug" in idx.all_artists
         assert ("plug", norm_title) in idx.exact_pairs
+
+    def test_from_sqlite_use_alternate_false_skips_alias(self, tmp_path):
+        """from_sqlite(use_alternate=False) reproduces pre-#305 matching.
+
+        Selecting only ``artist, title, format`` (3 columns) leaves
+        ``has_alternate`` False, so the alias is never indexed. The canonical
+        artist pair still resolves; only the ANV/alias key is dropped. This is
+        the second-pass index the prune audit uses to measure the #305 uplift
+        (discogs-etl#217 Phase 0).
+        """
+        import sqlite3
+
+        db_path = tmp_path / "library.db"
+        conn = sqlite3.connect(str(db_path))
+        cur = conn.cursor()
+        cur.execute(
+            "CREATE TABLE library (id INTEGER PRIMARY KEY, artist TEXT, title TEXT, "
+            "format TEXT, alternate_artist_name TEXT)"
+        )
+        cur.execute(
+            "INSERT INTO library (artist, title, format, alternate_artist_name) "
+            "VALUES ('Luke Vibert', \"Drum 'n' Bass for Papa\", 'CD', 'Plug')"
+        )
+        conn.commit()
+        conn.close()
+
+        norm_title = normalize_title("Drum 'n' Bass for Papa")
+        norm_canonical = normalize_artist("Luke Vibert")
+
+        # Default path indexes the alias (post-#305).
+        idx_default = LibraryIndex.from_sqlite(db_path)
+        assert ("plug", norm_title) in idx_default.exact_pairs
+
+        # use_alternate=False drops the alias but keeps the canonical pair.
+        idx_no_anv = LibraryIndex.from_sqlite(db_path, use_alternate=False)
+        assert ("plug", norm_title) not in idx_no_anv.exact_pairs
+        assert "plug" not in idx_no_anv.all_artists
+        assert (norm_canonical, norm_title) in idx_no_anv.exact_pairs
 
 
 class TestAlternateArtistNameClassification:


### PR DESCRIPTION
Part of #217 (Phase 0 instrumentation). This is the autonomous Phase 0 of the prune-coverage audit; it does **not** close #217 (the audit isn't done — Phase 1 capture + Phase 2 analysis remain).

## What this adds

The prune classification (keep/prune/review id sets) exists only in memory during a rebuild and is emitted today as counts only. In `--prune` mode the pre-prune population is deleted immediately after classification, so it can't be recovered post-hoc. This captures it.

**`scripts/verify_cache.py`**
- `--dump-classification DIR` writes, immediately after `apply_release_overrides`: `keep_ids.txt` / `prune_ids.txt` / `review_ids.txt` / `override_ids.txt` (sorted, newline-delimited), `prune_releases.jsonl` (one `{id, artist, title, format}` per pruned id, deduped across multi-artist fan-out), and `counts.json` (`dedup_note` left null for Phase 2 to fill).
- `LibraryIndex.from_sqlite(use_alternate=True)` — when `False`, never selects `alternate_artist_name`, so `has_alternate` stays False and ANV/alias indexing is skipped, reproducing **pre-#305** matching exactly.
- Under `--dump-classification`, `async_main` runs a **second, no-ANV classification pass** and dumps its prune set to `prune_ids_no_anv.txt`, making the #305 recall uplift a pure file diff in Phase 2.

**`scripts/run_pipeline.py`**
- `PRUNE_AUDIT_DUMP_DIR` (default **unset**) appends `--dump-classification $DIR/prune-audit-<UTC-date>` to the `verify_cache.py` prune / copy-to invocations. Default off — a normal monthly rebuild pays no extra classification pass.

**`docs/automation.md`** documents the opt-in env in the rebuild-cache section.

## Design note — symmetric override on the no-ANV pass

The same pinned-override exemption is applied to **both** the primary and the no-ANV report before dumping. Both sides being post-override keeps `prune_ids_no_anv − prune_ids` a *pure* #305 (alias) signal: a pinned release that would prune under both passes is removed from both sets and never pollutes the uplift diff. This is what makes Phase 2's "pure diff of the two dumped files" correct — it does not have to re-subtract overrides.

## Safety

Read-only with respect to cache **data** — the only writes are local artifact files; the cache is never mutated. The extra classification pass runs **only** under `--dump-classification` (audit runs), never on a normal rebuild.

## Tests
- Unit (`tests/unit/test_verify_cache.py`): `from_sqlite(use_alternate=False)` drops the alias but keeps the canonical pair; `--dump-classification` arg parsing; `dump_classification` file formats, JSONL fan-out dedup, and counts shape.
- Unit (`tests/unit/test_run_pipeline.py`): `prune_audit_dump_args()` env gating + dated path; wiring test that the flag lands in the prune step only when the env is set.
- pg end-to-end (`tests/integration/test_verify_cache_dump_classification.py`): seeds a Postgres cache + a SQLite library (one artist with an `alternate_artist_name`, one without), runs `async_main --dump-classification --keep-release-ids`, and asserts (i) the four id files partition the release set, (ii) `override_ids.txt` reflects the passed `--keep-release-ids`, (iii) `prune_ids_no_anv ⊇ prune_ids` and the difference is exactly the alias-only release.

Local `ruff check` / `ruff format --check` clean; full unit suite and the pg-marked suite green.