### PR TITLE
feat(#217): prune-audit analysis tooling (Phase 2)

### DIFF
--- a/docs/automation.md
+++ b/docs/automation.md
@@ -37,6 +37,17 @@ After the pipeline succeeds, the workflow runs `scripts/check_cache_drift.py` ag
 |---------|-------------|
 | `PRUNE_AUDIT_DUMP_DIR` | Opt-in for the prune-coverage audit ([discogs-etl#217](https://github.com/WXYC/discogs-etl/issues/217) Phase 0). **Default unset — leave it unset for normal rebuilds.** When set, `run_pipeline.py` appends `--dump-classification $PRUNE_AUDIT_DUMP_DIR/prune-audit-<UTC-date>` to the `verify_cache.py` prune step. That step then writes the prune classification (keep/prune/review id sets, the pruned releases' raw artist/title, the applied pinned-override ids, and a second no-ANV classification pass for the #305 uplift diff) to that directory, and runs one extra classification pass. It is read-only with respect to cache **data** — only local artifact files are written. Set this (to a path that survives the run, e.g. under the EC2 work dir) only on the deliberate audit rebuild that Phase 1 of #217 calls for. |
 
+**Analyzing the dump (#217 Phase 2):** once a `prune-audit-<date>/` directory exists, `scripts/analyze_prune_audit.py` turns it into the Phase 2 answers — counts with the pinned/non-pinned split, the dedup delta, the #305 uplift (`prune_ids_no_anv − prune_ids`), and a residual false-negative rate (a seeded 200-sample of pruned releases re-scored against the library index, with a Wilson interval). It's read-only apart from the report/CSV it emits (and, with `--write-dedup-note`, the dump's `counts.json`):
+
+```
+python scripts/analyze_prune_audit.py <prune-audit-dir> \
+    --library-db data/library.db \
+    --final-release-count <post-rebuild release count> \
+    --output-dir ./phase2-out --write-dedup-note
+```
+
+Confirm the comparable-to-history series (non-pinned `bulk_import` survivors, vs 38,662 / 39,016) against prod with the `SELECT` the report prints. The comparable series is `bulk_import` minus override ids — a bare `release` count is **not** comparable to converter output. Pass the **same `library.db` snapshot the rebuild used** to `--library-db` (the daily `sync-library.yml` mutates it) so the false-negative re-scoring matches the classification it's auditing; a drifted snapshot can flip borderline calls.
+
 **Upstream dependency**: a successful `sync-library.yml` run must have uploaded `library.db` to the `streaming-data-v1` release on `WXYC/library-metadata-lookup` before this workflow fires, or the `Download library.db from LML release artifact` step fails with `release asset not found`. The default `${{ github.token }}` has read scope on the public LML repo; no extra PAT required.
 
 **Interpreting a failed run** (#219):

--- a/scripts/analyze_prune_audit.py
+++ b/scripts/analyze_prune_audit.py
@@ -1,0 +1,641 @@
+#!/usr/bin/env python3
+"""Analyze a ``prune-audit-<date>/`` dump — discogs-etl#217 Phase 2.
+
+Phase 0 (``verify_cache.py --dump-classification``) captures the prune
+classification during a monthly rebuild. This script turns that on-disk dump
+into the Phase 2 answers, as pure file arithmetic plus an optional re-scoring
+pass:
+
+1. **Counts + pinned/non-pinned split** — keep / prune / review, ``pinned =
+   |keep ∩ override|``, ``non-pinned survivors = |keep − override|``, and (given
+   the post-rebuild ``release`` count) the **dedup delta** ``(keep + review) −
+   release`` — the ``dedup_releases.py`` collapse that happens after the prune.
+2. **#305 uplift** — ``|prune_ids_no_anv − prune_ids|``, releases pruned under
+   pre-#305 logic but kept now via ``alternate_artist_name`` (marginal over
+   pins). A pure diff of the two dumped id files.
+3. **Residual false-negative rate** — a deterministic sample of ``prune_ids``
+   (``random.Random(217)``) re-scored against the library index (reuses
+   ``verify_cache``'s ``LibraryIndex`` + rapidfuzz scorer). The re-scoring is
+   **faithful to the phase the prune actually used**: an exact-library-artist
+   prune is re-judged title-only + format (Phase 2), a fuzzy prune by the
+   artist×title geometric mean (Phase 4) — applying one formula to both would
+   inflate the exact-artist prunes' scores and over-count false negatives. Each
+   row is called a **true reject** (correct prune — no library album, or a
+   format edition) or a **candidate false negative** (a library artist
+   near-miss), with the miss mechanism noted, and the rate is reported with a
+   Wilson score interval. Needs ``--library-db``.
+
+Everything is read-only. The only writes are the report, the per-row CSV, and —
+with ``--write-dedup-note`` — the ``dedup_note`` field of the dump's
+``counts.json``.
+
+Usage::
+
+    python analyze_prune_audit.py PRUNE_AUDIT_DIR \\
+        --library-db data/library.db \\
+        --final-release-count 38662 \\
+        --output-dir ./phase2-out
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import importlib.util
+import json
+import math
+import random
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+from rapidfuzz import fuzz, process
+
+# ---------------------------------------------------------------------------
+# Reuse verify_cache's LibraryIndex + normalizers. Guard the import so the
+# module object is shared if verify_cache is already loaded (mirrors the test
+# modules — a second copy breaks identity checks and pickling; see #109).
+# ---------------------------------------------------------------------------
+_VC_PATH = Path(__file__).parent / "verify_cache.py"
+if "verify_cache" in sys.modules:
+    _vc = sys.modules["verify_cache"]
+else:
+    _spec = importlib.util.spec_from_file_location("verify_cache", _VC_PATH)
+    assert _spec is not None and _spec.loader is not None
+    _vc = importlib.util.module_from_spec(_spec)
+    sys.modules["verify_cache"] = _vc
+    _spec.loader.exec_module(_vc)
+
+LibraryIndex = _vc.LibraryIndex
+normalize_artist = _vc.normalize_artist
+normalize_title = _vc.normalize_title
+
+# Classifier thresholds, mirrored from verify_cache.MultiIndexMatcher /
+# classify_artist_fuzzy so the re-scoring uses the same cutoffs the prune did.
+DEFAULT_KEEP_THRESHOLD = 0.75
+DEFAULT_REVIEW_THRESHOLD = 0.65
+DEFAULT_ARTIST_THRESHOLD = 60  # token_set_ratio 0-100, artist-match floor
+DEFAULT_SAMPLE_SIZE = 200
+DEFAULT_SEED = 217
+
+
+# ---------------------------------------------------------------------------
+# Dump loading
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class AuditDump:
+    """The parsed contents of a ``prune-audit-<date>/`` directory."""
+
+    keep: set[int]
+    prune: set[int]
+    review: set[int]
+    override: set[int]
+    prune_no_anv: set[int]
+    counts: dict
+    # release_id -> {"artist", "title", "format"} for every pruned id
+    prune_releases: dict[int, dict]
+
+
+def read_ids(path: Path) -> set[int]:
+    """Read a sorted, newline-delimited id file into a set (missing -> empty)."""
+    if not path.exists():
+        return set()
+    return {int(line) for line in path.read_text().split() if line.strip()}
+
+
+def load_prune_releases(path: Path) -> dict[int, dict]:
+    """Load ``prune_releases.jsonl`` into ``{id: {artist,title,format}}``."""
+    out: dict[int, dict] = {}
+    if not path.exists():
+        return out
+    for line in path.read_text().splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        obj = json.loads(line)
+        out[int(obj["id"])] = obj
+    return out
+
+
+def load_audit(audit_dir: Path) -> AuditDump:
+    """Load every artifact in *audit_dir* into an :class:`AuditDump`."""
+    counts_path = audit_dir / "counts.json"
+    counts = json.loads(counts_path.read_text()) if counts_path.exists() else {}
+    return AuditDump(
+        keep=read_ids(audit_dir / "keep_ids.txt"),
+        prune=read_ids(audit_dir / "prune_ids.txt"),
+        review=read_ids(audit_dir / "review_ids.txt"),
+        override=read_ids(audit_dir / "override_ids.txt"),
+        prune_no_anv=read_ids(audit_dir / "prune_ids_no_anv.txt"),
+        counts=counts,
+        prune_releases=load_prune_releases(audit_dir / "prune_releases.jsonl"),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Statistics
+# ---------------------------------------------------------------------------
+
+
+def wilson_interval(successes: int, n: int, z: float = 1.96) -> tuple[float, float]:
+    """Wilson score interval for a binomial proportion.
+
+    Returns ``(low, high)`` clamped to ``[0, 1]``. ``n == 0`` -> ``(0.0, 0.0)``.
+    Default ``z = 1.96`` is the 95% two-sided level. Preferred over the normal
+    approximation because the sample proportion is often near 0 here (few
+    false negatives), where the Wald interval misbehaves.
+    """
+    if n <= 0:
+        return (0.0, 0.0)
+    p = successes / n
+    z2 = z * z
+    denom = 1.0 + z2 / n
+    center = (p + z2 / (2 * n)) / denom
+    margin = (z / denom) * math.sqrt(p * (1 - p) / n + z2 / (4 * n * n))
+    return (max(0.0, center - margin), min(1.0, center + margin))
+
+
+# ---------------------------------------------------------------------------
+# Step 1 + 2: counts, splits, uplift, dedup delta
+# ---------------------------------------------------------------------------
+
+
+def compute_summary(audit: AuditDump, final_release_count: int | None = None) -> dict:
+    """Compute the Phase 2 headline numbers from the dump (pure file arithmetic).
+
+    - keep / prune / review counts
+    - ``pinned`` = ``|keep ∩ override|``
+    - ``non_pinned_survivors`` = ``|keep − override|`` (the comparable-to-history
+      series vs 38,662 / 39,016, before the prod ``bulk_import`` confirmation)
+    - ``uplift_305`` = ``|prune_no_anv − prune|``
+    - ``dedup_delta`` = ``(keep + review) − final_release_count`` (``None`` when
+      the final ``release`` count isn't supplied)
+    """
+    survivors = len(audit.keep) + len(audit.review)
+    summary = {
+        "keep": len(audit.keep),
+        "prune": len(audit.prune),
+        "review": len(audit.review),
+        "override_ids": len(audit.override),
+        "pinned": len(audit.keep & audit.override),
+        "non_pinned_survivors": len(audit.keep - audit.override),
+        "survivors_keep_plus_review": survivors,
+        "uplift_305": len(audit.prune_no_anv - audit.prune),
+        "final_release_count": final_release_count,
+        "dedup_delta": (survivors - final_release_count)
+        if final_release_count is not None
+        else None,
+    }
+    return summary
+
+
+def uplift_305_ids(audit: AuditDump) -> list[int]:
+    """Sorted ids rescued by the ANV index (``prune_no_anv − prune``)."""
+    return sorted(audit.prune_no_anv - audit.prune)
+
+
+# ---------------------------------------------------------------------------
+# Step 3: false-negative sampling + re-scoring
+# ---------------------------------------------------------------------------
+
+
+def sample_prune_ids(prune: set[int], sample_size: int, seed: int) -> list[int]:
+    """Deterministically sample up to *sample_size* pruned ids.
+
+    Sorted first so the pool is order-independent, then sampled with a seeded
+    ``random.Random`` — same dump + same seed -> same sample. Returns all ids
+    (sorted) when the set is smaller than *sample_size*.
+    """
+    pool = sorted(prune)
+    if len(pool) <= sample_size:
+        return pool
+    rng = random.Random(seed)
+    return sorted(rng.sample(pool, sample_size))
+
+
+def _is_substring_variant(norm_artist: str, lib_artist: str, min_len: int = 4) -> bool:
+    """True when one normalized artist name contains the other (but they differ).
+
+    Guards against trivial short-token containment with *min_len*.
+    """
+    if not norm_artist or not lib_artist or norm_artist == lib_artist:
+        return False
+    shorter = min(norm_artist, lib_artist, key=len)
+    if len(shorter) < min_len:
+        return False
+    return norm_artist in lib_artist or lib_artist in norm_artist
+
+
+def _decide_call(
+    artist_score: float,
+    combined: float,
+    is_substring: bool,
+    keep_threshold: float,
+    review_threshold: float,
+    artist_floor: float,
+) -> tuple[str, str]:
+    """Pure band logic for a re-scored miss (all scores in ``[0, 1]``).
+
+    Returns ``(call, mechanism)``. Kept separate from the rapidfuzz scoring so
+    the threshold boundaries are testable without version-sensitive fuzzy
+    scores. See :func:`classify_miss` for the mechanism descriptions.
+    """
+    if artist_score < artist_floor:
+        return ("true_reject", "no_artist_match")
+    if review_threshold <= combined < keep_threshold:
+        return ("candidate_false_negative", "near_keep_threshold")
+    if is_substring:
+        return ("candidate_false_negative", "substring_variant")
+    if combined >= keep_threshold:
+        return ("candidate_false_negative", "scores_above_keep_on_rescore")
+    return ("true_reject", "weak_match")
+
+
+def _decide_title_only(
+    title_score: float, keep_threshold: float, review_threshold: float
+) -> tuple[str, str]:
+    """Pure band logic for an **exact-artist** prune (title-only, all in [0, 1]).
+
+    The prune's Phase-2 path (``verify_cache.classify_known_artist`` +
+    ``classify_all_releases`` format filter) keeps an exact library artist's
+    release when title ``>= keep``, reviews it in ``[review, keep)`` (still
+    retained), and prunes it below ``review``. So a *pruned* exact-artist
+    release with a title that now re-scores ``>= review`` is a discrepancy worth
+    inspecting; below ``review`` it is a genuine title miss (the album isn't in
+    the library) and a correct reject.
+    """
+    if title_score >= keep_threshold:
+        return ("candidate_false_negative", "exact_artist_title_above_keep_on_rescore")
+    if title_score >= review_threshold:
+        return ("candidate_false_negative", "exact_artist_rescore_review")
+    return ("true_reject", "title_miss")
+
+
+def _row(
+    phase: str,
+    call: str,
+    mechanism: str,
+    artist_score: float,
+    best_lib_artist: str,
+    title_score: float,
+    combined: float,
+) -> dict:
+    return {
+        "phase": phase,
+        "call": call,
+        "mechanism": mechanism,
+        "artist_score": artist_score,
+        "best_lib_artist": best_lib_artist,
+        "title_score": title_score,
+        "combined": combined,
+    }
+
+
+def classify_miss(
+    raw_artist: str,
+    raw_title: str,
+    index: LibraryIndex,
+    keep_threshold: float = DEFAULT_KEEP_THRESHOLD,
+    review_threshold: float = DEFAULT_REVIEW_THRESHOLD,
+    artist_threshold: int = DEFAULT_ARTIST_THRESHOLD,
+) -> dict:
+    """Re-score one pruned release against the library index, faithful to the phase.
+
+    ``verify_cache.classify_all_releases`` prunes in *different* ways depending
+    on how the Discogs artist relates to the library, so re-scoring every prune
+    with one formula (the Phase-4 geometric mean) over-flags the exact-artist
+    prunes: their artist score is ~1.0, which inflates ``sqrt(artist·title)``
+    and turns a correct title/format prune into a spurious "candidate FN". This
+    reconstructs the phase the prune actually used:
+
+    **Exact library artist** (``norm_artist`` in the index) — Phase-2 title-only
+    + format filter (see :func:`_decide_title_only`):
+
+    - ``format_mismatch`` — the exact ``(artist, title)`` pair was retained by
+      title but dropped by the format filter -> **true reject** (a deliberate
+      edition-level prune, not an artist false negative).
+    - ``title_miss`` — title re-scores below ``review`` -> **true reject** (the
+      album genuinely isn't in the library).
+    - ``exact_artist_rescore_review`` / ``exact_artist_title_above_keep_on_rescore``
+      — title now re-scores at/above the review/keep line although the release
+      was pruned -> **candidate FN** (a discrepancy, e.g. a library snapshot that
+      drifted from the one the prune ran against).
+
+    **Fuzzy / non-library artist** — Phase-4 geometry (see :func:`_decide_call`),
+    best artist by ``token_set_ratio`` then title within that artist's albums,
+    ``combined = sqrt(artist·title)``:
+
+    - ``no_artist_match`` — best artist below the floor -> **true reject**.
+    - ``near_keep_threshold`` — ``combined`` in ``[review, keep)`` -> **candidate FN**.
+    - ``substring_variant`` — a sub/superstring of a library artist -> **candidate FN**.
+    - ``scores_above_keep_on_rescore`` — ``combined >= keep`` -> **candidate FN**.
+    - ``weak_match`` — ``combined`` below ``review`` -> **true reject**.
+
+    Returns a row dict with ``phase`` (``exact`` / ``fuzzy``), ``call``,
+    ``mechanism``, and the scores (all ``[0, 1]``).
+    """
+    norm_artist = normalize_artist(raw_artist or "")
+    norm_title = normalize_title(raw_title or "")
+
+    # Phase-2 reconstruction: is the Discogs artist an exact library artist?
+    exact_titles = index.artist_to_titles_list.get(norm_artist)
+    if exact_titles is not None:
+        if (norm_artist, norm_title) in index.exact_pairs:
+            # Exact pair -> classify_known_artist returns KEEP; the only way it
+            # still lands in prune is the format filter.
+            return _row("exact", "true_reject", "format_mismatch", 1.0, norm_artist, 1.0, 1.0)
+        title_result = process.extractOne(norm_title, exact_titles, scorer=fuzz.token_set_ratio)
+        title_score = (float(title_result[1]) if title_result else 0.0) / 100.0
+        call, mechanism = _decide_title_only(title_score, keep_threshold, review_threshold)
+        # combined == title_score: the artist is exact, so title carries the call.
+        return _row("exact", call, mechanism, 1.0, norm_artist, title_score, title_score)
+
+    # Phase-3/4 reconstruction: fuzzy artist match.
+    result = process.extractOne(norm_artist, index.all_artists, scorer=fuzz.token_set_ratio)
+    if result is None:
+        return _row("fuzzy", "true_reject", "empty_library", 0.0, "", 0.0, 0.0)
+    best_artist, artist_score, _ = result
+
+    titles = index.artist_to_titles_list.get(best_artist) or []
+    if titles:
+        title_result = process.extractOne(norm_title, titles, scorer=fuzz.token_set_ratio)
+        title_score = float(title_result[1]) if title_result else 0.0
+    else:
+        title_score = 0.0
+
+    combined = float((float(artist_score) * title_score) ** 0.5) / 100.0
+    call, mechanism = _decide_call(
+        artist_score=float(artist_score) / 100.0,
+        combined=combined,
+        is_substring=_is_substring_variant(norm_artist, best_artist),
+        keep_threshold=keep_threshold,
+        review_threshold=review_threshold,
+        artist_floor=artist_threshold / 100.0,
+    )
+    return _row(
+        "fuzzy",
+        call,
+        mechanism,
+        float(artist_score) / 100.0,
+        best_artist,
+        title_score / 100.0,
+        combined,
+    )
+
+
+def score_sample(
+    sample_ids: list[int],
+    audit: AuditDump,
+    index: LibraryIndex,
+    keep_threshold: float = DEFAULT_KEEP_THRESHOLD,
+    review_threshold: float = DEFAULT_REVIEW_THRESHOLD,
+    artist_threshold: int = DEFAULT_ARTIST_THRESHOLD,
+) -> list[dict]:
+    """Re-score every sampled id, joining to ``prune_releases`` for raw text."""
+    rows: list[dict] = []
+    for rid in sample_ids:
+        rel = audit.prune_releases.get(rid, {})
+        raw_artist = rel.get("artist") or ""
+        raw_title = rel.get("title") or ""
+        call = classify_miss(
+            raw_artist, raw_title, index, keep_threshold, review_threshold, artist_threshold
+        )
+        rows.append(
+            {
+                "id": rid,
+                "artist": raw_artist,
+                "title": raw_title,
+                "format": rel.get("format"),
+                **call,
+            }
+        )
+    return rows
+
+
+def false_negative_rate(rows: list[dict]) -> dict:
+    """Summarize a scored sample: candidate-FN count, rate, Wilson interval."""
+    n = len(rows)
+    fn = sum(1 for r in rows if r["call"] == "candidate_false_negative")
+    low, high = wilson_interval(fn, n)
+    mechanisms: dict[str, int] = {}
+    for r in rows:
+        if r["call"] == "candidate_false_negative":
+            mechanisms[r["mechanism"]] = mechanisms.get(r["mechanism"], 0) + 1
+    return {
+        "sample_size": n,
+        "candidate_false_negatives": fn,
+        "rate": (fn / n) if n else 0.0,
+        "wilson_low": low,
+        "wilson_high": high,
+        "fn_mechanisms": mechanisms,
+    }
+
+
+def write_sample_csv(path: Path, rows: list[dict]) -> None:
+    """Write the per-row re-scoring CSV."""
+    fields = [
+        "id",
+        "artist",
+        "title",
+        "format",
+        "phase",
+        "call",
+        "mechanism",
+        "artist_score",
+        "best_lib_artist",
+        "title_score",
+        "combined",
+    ]
+    with open(path, "w", encoding="utf-8", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=fields, extrasaction="ignore")
+        writer.writeheader()
+        for row in rows:
+            writer.writerow(row)
+
+
+# ---------------------------------------------------------------------------
+# Reporting + counts.json patch
+# ---------------------------------------------------------------------------
+
+# The comparable-to-history series (vs 38,662 / 39,016) is non-pinned
+# bulk_import survivors. Confirm the file arithmetic against prod with this:
+COMPARABLE_SERIES_SQL = (
+    "SELECT count(*) FROM cache_metadata cm "
+    "WHERE cm.source = 'bulk_import' "
+    "AND cm.release_id NOT IN ("
+    "SELECT discogs_release_id FROM lml_cache.library_release_override "
+    "WHERE discogs_release_id IS NOT NULL)"
+)
+
+
+def format_report(
+    summary: dict,
+    fn_summary: dict | None,
+    uplift_sample: list[int],
+) -> str:
+    """Render a Markdown Phase 2 report."""
+    lines: list[str] = []
+    lines.append("# Prune-audit analysis (discogs-etl#217 Phase 2)\n")
+
+    lines.append("## Counts (partitioned; pinned split)\n")
+    lines.append(f"- KEEP: {summary['keep']:,}")
+    lines.append(f"- PRUNE: {summary['prune']:,}")
+    lines.append(f"- REVIEW: {summary['review']:,}")
+    lines.append(f"- survivors (keep + review): {summary['survivors_keep_plus_review']:,}")
+    lines.append(f"- override ids applied: {summary['override_ids']:,}")
+    lines.append(f"- pinned survivors (keep ∩ override): {summary['pinned']:,}")
+    lines.append(
+        f"- **non-pinned survivors (keep − override): {summary['non_pinned_survivors']:,}** "
+        "— approximate comparable-to-history series (vs 38,662 / 39,016). This counts "
+        "KEEP survivors from *all* cache sources; the exact history is `bulk_import`-only, "
+        "so confirm with the SQL below before quoting a gain vs those figures."
+    )
+    if summary["final_release_count"] is not None:
+        lines.append(f"- final `release` count: {summary['final_release_count']:,}")
+        lines.append(f"- **dedup delta ((keep+review) − release): {summary['dedup_delta']:,}**")
+    else:
+        lines.append("- dedup delta: _not computed_ (pass `--final-release-count`)")
+    lines.append("")
+    lines.append(
+        "Confirm the comparable series against prod:\n\n```sql\n"
+        + COMPARABLE_SERIES_SQL
+        + "\n```\n"
+    )
+
+    lines.append("## #305 uplift (marginal over pins)\n")
+    lines.append(
+        f"- **uplift = |prune_no_anv − prune| = {summary['uplift_305']:,}** — releases pruned "
+        "under pre-#305 logic, kept now via `alternate_artist_name`."
+    )
+    if uplift_sample:
+        preview = ", ".join(str(i) for i in uplift_sample[:10])
+        lines.append(f"- spot-check ids (first 10): {preview}")
+    lines.append("")
+
+    if fn_summary is not None:
+        lines.append("## Residual false-negative rate\n")
+        lines.append(f"- sample size: {fn_summary['sample_size']:,} (seed {DEFAULT_SEED})")
+        lines.append(f"- candidate false negatives: {fn_summary['candidate_false_negatives']:,}")
+        lines.append(
+            f"- **rate: {fn_summary['rate']:.3%} "
+            f"(95% Wilson [{fn_summary['wilson_low']:.3%}, {fn_summary['wilson_high']:.3%}])**"
+        )
+        if fn_summary["fn_mechanisms"]:
+            lines.append("- candidate-FN mechanisms:")
+            for mech, count in sorted(fn_summary["fn_mechanisms"].items()):
+                lines.append(f"  - {mech}: {count}")
+        lines.append("")
+    else:
+        lines.append("## Residual false-negative rate\n")
+        lines.append("- _not computed_ (pass `--library-db` to enable re-scoring)\n")
+
+    return "\n".join(lines)
+
+
+def write_dedup_note(counts_path: Path, dedup_delta: int | None) -> None:
+    """Patch ``counts.json`` in place, filling the ``dedup_note`` slot.
+
+    No-op (with a warning) when the delta is unknown or ``counts.json`` is
+    absent — so a ``--write-dedup-note`` run without ``--final-release-count``
+    never clobbers a value a prior run computed.
+    """
+    if dedup_delta is None:
+        print(
+            "warning: dedup delta unknown (no --final-release-count); leaving dedup_note unchanged",
+            file=sys.stderr,
+        )
+        return
+    if not counts_path.exists():
+        print(f"warning: {counts_path} not found; cannot write dedup_note", file=sys.stderr)
+        return
+    counts = json.loads(counts_path.read_text())
+    counts["dedup_note"] = f"dedup collapse (keep+review - release) = {dedup_delta}"
+    counts_path.write_text(json.dumps(counts, indent=2) + "\n")
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Analyze a verify_cache prune-audit dump (discogs-etl#217 Phase 2)."
+    )
+    parser.add_argument("audit_dir", type=Path, help="Path to a prune-audit-<date>/ directory")
+    parser.add_argument(
+        "--library-db",
+        type=Path,
+        default=None,
+        help="library.db to enable false-negative re-scoring (step 3). Omit to skip.",
+    )
+    parser.add_argument(
+        "--final-release-count",
+        type=int,
+        default=None,
+        help="Post-rebuild `release` row count, to compute the dedup delta.",
+    )
+    parser.add_argument(
+        "--sample-size",
+        type=int,
+        default=DEFAULT_SAMPLE_SIZE,
+        help="Prune sample size (default 200)",
+    )
+    parser.add_argument("--seed", type=int, default=DEFAULT_SEED, help="Sample seed (default 217)")
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=None,
+        help="Write report.md + sample.csv here (default: the audit dir).",
+    )
+    parser.add_argument(
+        "--write-dedup-note",
+        action="store_true",
+        help="Patch the dump's counts.json dedup_note with the computed delta.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    if not args.audit_dir.is_dir():
+        print(f"error: {args.audit_dir} is not a directory", file=sys.stderr)
+        return 1
+    if args.library_db is not None and not args.library_db.exists():
+        # Guard before LibraryIndex.from_sqlite -> sqlite3.connect, which would
+        # otherwise create an empty db file and fail with a confusing
+        # "no such table: library".
+        print(f"error: --library-db {args.library_db} does not exist", file=sys.stderr)
+        return 1
+
+    audit = load_audit(args.audit_dir)
+    summary = compute_summary(audit, args.final_release_count)
+    uplift_sample = uplift_305_ids(audit)
+
+    fn_summary = None
+    sample_rows: list[dict] = []
+    if args.library_db is not None:
+        index = LibraryIndex.from_sqlite(args.library_db)
+        sample_ids = sample_prune_ids(audit.prune, args.sample_size, args.seed)
+        sample_rows = score_sample(sample_ids, audit, index)
+        fn_summary = false_negative_rate(sample_rows)
+
+    out_dir = args.output_dir or args.audit_dir
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    report = format_report(summary, fn_summary, uplift_sample)
+    (out_dir / "report.md").write_text(report + "\n")
+    if sample_rows:
+        write_sample_csv(out_dir / "sample.csv", sample_rows)
+
+    if args.write_dedup_note:
+        write_dedup_note(args.audit_dir / "counts.json", summary["dedup_delta"])
+
+    print(report)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_analyze_prune_audit.py
+++ b/tests/unit/test_analyze_prune_audit.py
@@ -1,0 +1,484 @@
+"""Tests for scripts/analyze_prune_audit.py (discogs-etl#217 Phase 2 tooling)."""
+
+import csv
+import importlib.util
+import json
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+_SCRIPT_PATH = Path(__file__).parent.parent.parent / "scripts" / "analyze_prune_audit.py"
+if "analyze_prune_audit" in sys.modules:
+    _apa = sys.modules["analyze_prune_audit"]
+else:
+    _spec = importlib.util.spec_from_file_location("analyze_prune_audit", _SCRIPT_PATH)
+    assert _spec is not None and _spec.loader is not None
+    _apa = importlib.util.module_from_spec(_spec)
+    sys.modules["analyze_prune_audit"] = _apa
+    _spec.loader.exec_module(_apa)
+
+LibraryIndex = _apa.LibraryIndex
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_ids(path: Path, ids) -> None:
+    path.write_text("".join(f"{i}\n" for i in sorted(ids)))
+
+
+def _make_dump(
+    tmp_path: Path,
+    *,
+    keep=(),
+    prune=(),
+    review=(),
+    override=(),
+    prune_no_anv=(),
+    prune_releases=(),
+    counts=None,
+) -> Path:
+    d = tmp_path / "prune-audit-2026-08-01"
+    d.mkdir(parents=True, exist_ok=True)
+    _write_ids(d / "keep_ids.txt", keep)
+    _write_ids(d / "prune_ids.txt", prune)
+    _write_ids(d / "review_ids.txt", review)
+    _write_ids(d / "override_ids.txt", override)
+    _write_ids(d / "prune_ids_no_anv.txt", prune_no_anv)
+    with open(d / "prune_releases.jsonl", "w", encoding="utf-8") as f:
+        for obj in prune_releases:
+            f.write(json.dumps(obj) + "\n")
+    default_counts = {
+        "keep": len(keep),
+        "prune": len(prune),
+        "review": len(review),
+        "override_applied": len(override),
+        "total_release_rows": len(keep) + len(prune) + len(review),
+        "dedup_note": None,
+    }
+    (d / "counts.json").write_text(json.dumps(counts or default_counts, indent=2) + "\n")
+    return d
+
+
+# ---------------------------------------------------------------------------
+# Wilson interval
+# ---------------------------------------------------------------------------
+
+
+class TestWilsonInterval:
+    def test_zero_n_returns_zero_zero(self):
+        assert _apa.wilson_interval(0, 0) == (0.0, 0.0)
+
+    def test_zero_successes(self):
+        low, high = _apa.wilson_interval(0, 200)
+        assert low == 0.0
+        assert high == pytest.approx(0.0188, abs=1e-3)
+
+    def test_all_successes(self):
+        low, high = _apa.wilson_interval(200, 200)
+        assert high == 1.0
+        assert low == pytest.approx(0.9812, abs=1e-3)
+
+    def test_ten_of_two_hundred(self):
+        low, high = _apa.wilson_interval(10, 200)
+        assert low == pytest.approx(0.0274, abs=2e-3)
+        assert high == pytest.approx(0.0896, abs=2e-3)
+        assert low < 0.05 < high
+
+
+# ---------------------------------------------------------------------------
+# Loading
+# ---------------------------------------------------------------------------
+
+
+class TestLoadAudit:
+    def test_read_ids_missing_file_is_empty(self, tmp_path):
+        assert _apa.read_ids(tmp_path / "nope.txt") == set()
+
+    def test_loads_all_artifacts(self, tmp_path):
+        d = _make_dump(
+            tmp_path,
+            keep=[1, 2, 3],
+            prune=[5],
+            review=[4],
+            override=[3],
+            prune_no_anv=[2, 5],
+            prune_releases=[{"id": 5, "artist": "Junk", "title": "Nowhere", "format": "CD"}],
+        )
+        audit = _apa.load_audit(d)
+        assert audit.keep == {1, 2, 3}
+        assert audit.prune == {5}
+        assert audit.review == {4}
+        assert audit.override == {3}
+        assert audit.prune_no_anv == {2, 5}
+        assert audit.prune_releases[5]["artist"] == "Junk"
+        assert audit.counts["prune"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Summary / uplift
+# ---------------------------------------------------------------------------
+
+
+class TestComputeSummary:
+    def test_counts_pinned_split_uplift_dedup(self, tmp_path):
+        d = _make_dump(
+            tmp_path,
+            keep=[1, 2, 3, 4],
+            prune=[5],
+            review=[],
+            override=[4],
+            prune_no_anv=[2, 5],
+        )
+        audit = _apa.load_audit(d)
+        s = _apa.compute_summary(audit, final_release_count=3)
+        assert s["keep"] == 4
+        assert s["prune"] == 1
+        assert s["review"] == 0
+        assert s["pinned"] == 1  # {1,2,3,4} ∩ {4}
+        assert s["non_pinned_survivors"] == 3  # {1,2,3}
+        assert s["survivors_keep_plus_review"] == 4
+        assert s["uplift_305"] == 1  # {2,5} − {5}
+        assert s["dedup_delta"] == 1  # 4 − 3
+
+    def test_dedup_delta_none_without_final_count(self, tmp_path):
+        d = _make_dump(tmp_path, keep=[1], prune=[2])
+        s = _apa.compute_summary(_apa.load_audit(d))
+        assert s["dedup_delta"] is None
+        assert s["final_release_count"] is None
+
+    def test_uplift_ids_sorted(self, tmp_path):
+        d = _make_dump(tmp_path, prune=[5], prune_no_anv=[9, 2, 5])
+        assert _apa.uplift_305_ids(_apa.load_audit(d)) == [2, 9]
+
+
+# ---------------------------------------------------------------------------
+# Sampling
+# ---------------------------------------------------------------------------
+
+
+class TestSamplePruneIds:
+    def test_small_set_returns_all_sorted(self):
+        assert _apa.sample_prune_ids({3, 1, 2}, 200, 217) == [1, 2, 3]
+
+    def test_deterministic_with_seed(self):
+        pool = set(range(1000))
+        a = _apa.sample_prune_ids(pool, 200, 217)
+        b = _apa.sample_prune_ids(pool, 200, 217)
+        assert a == b
+        assert len(a) == 200
+        assert a == sorted(a)
+
+    def test_different_seed_differs(self):
+        pool = set(range(1000))
+        assert _apa.sample_prune_ids(pool, 200, 217) != _apa.sample_prune_ids(pool, 200, 99)
+
+
+# ---------------------------------------------------------------------------
+# Decision bands (pure, deterministic)
+# ---------------------------------------------------------------------------
+
+
+class TestDecideCall:
+    def test_below_artist_floor_is_true_reject(self):
+        assert _apa._decide_call(0.5, 0.9, False, 0.75, 0.65, 0.60) == (
+            "true_reject",
+            "no_artist_match",
+        )
+
+    def test_near_keep_threshold_is_candidate(self):
+        assert _apa._decide_call(0.9, 0.70, False, 0.75, 0.65, 0.60) == (
+            "candidate_false_negative",
+            "near_keep_threshold",
+        )
+
+    def test_review_boundary_is_near(self):
+        assert _apa._decide_call(0.9, 0.65, False, 0.75, 0.65, 0.60)[1] == "near_keep_threshold"
+
+    def test_substring_below_review_is_candidate(self):
+        assert _apa._decide_call(0.9, 0.40, True, 0.75, 0.65, 0.60) == (
+            "candidate_false_negative",
+            "substring_variant",
+        )
+
+    def test_scores_above_keep_is_candidate(self):
+        assert _apa._decide_call(0.9, 0.80, False, 0.75, 0.65, 0.60) == (
+            "candidate_false_negative",
+            "scores_above_keep_on_rescore",
+        )
+
+    def test_weak_match_is_true_reject(self):
+        assert _apa._decide_call(0.9, 0.40, False, 0.75, 0.65, 0.60) == (
+            "true_reject",
+            "weak_match",
+        )
+
+
+class TestSubstringVariant:
+    def test_containment(self):
+        assert _apa._is_substring_variant("stereolab reissue", "stereolab")
+
+    def test_equal_is_not_variant(self):
+        assert not _apa._is_substring_variant("stereolab", "stereolab")
+
+    def test_short_shared_is_guarded(self):
+        assert not _apa._is_substring_variant("abc", "abc def")
+
+
+# ---------------------------------------------------------------------------
+# classify_miss (integration with a real LibraryIndex)
+# ---------------------------------------------------------------------------
+
+
+class TestClassifyMiss:
+    @pytest.fixture
+    def index(self):
+        return LibraryIndex.from_rows(
+            [
+                ("Juana Molina", "DOGA", "CD"),
+                ("Stereolab", "Aluminum Tunes", "CD"),
+                ("Cat Power", "Moon Pix", "CD"),
+            ]
+        )
+
+    def test_unknown_artist_is_true_reject(self, index):
+        row = _apa.classify_miss("Zzyzx Qxqxqx", "Xyzzy Plugh", index)
+        assert row["phase"] == "fuzzy"
+        assert row["call"] == "true_reject"
+        assert row["mechanism"] == "no_artist_match"
+
+    def test_exact_pair_pruned_is_format_mismatch(self, index):
+        # An exact (artist, title) library pair that still landed in prune was
+        # dropped by the format filter — a deliberate edition prune, NOT a
+        # false negative. The old uniform geometry mislabeled this a candidate FN.
+        row = _apa.classify_miss("Juana Molina", "DOGA", index)
+        assert row["phase"] == "exact"
+        assert row["call"] == "true_reject"
+        assert row["mechanism"] == "format_mismatch"
+
+    def test_exact_artist_title_miss_is_true_reject(self, index):
+        # Exact library artist, but the album isn't in the library -> title-only
+        # score below review -> correct reject (not an artist-level FN).
+        row = _apa.classify_miss("Juana Molina", "Totally Different Nonexistent Record", index)
+        assert row["phase"] == "exact"
+        assert row["call"] == "true_reject"
+        assert row["mechanism"] == "title_miss"
+
+    def test_substring_artist_junk_title_is_substring_variant(self, index):
+        # Fuzzy (non-exact) artist that contains a library artist; junk title, so
+        # combined stays below review and the substring mechanism fires.
+        row = _apa.classify_miss("Stereolab Reissue", "Zzzz Nonexistent Qqqq", index)
+        assert row["phase"] == "fuzzy"
+        assert row["best_lib_artist"] == "stereolab"
+        assert row["call"] == "candidate_false_negative"
+        assert row["mechanism"] == "substring_variant"
+
+    def test_fuzzy_near_artist_exact_title_is_candidate(self, index):
+        # A misspelled artist ("Molena" for "Molina") with an exact-title match
+        # re-scores above keep on the fuzzy path -> genuine candidate FN.
+        row = _apa.classify_miss("Juana Molena", "DOGA", index)
+        assert row["phase"] == "fuzzy"
+        assert row["best_lib_artist"] == "juana molina"
+        assert row["call"] == "candidate_false_negative"
+
+
+class TestDecideTitleOnly:
+    def test_above_keep_is_candidate(self):
+        assert _apa._decide_title_only(0.80, 0.75, 0.65) == (
+            "candidate_false_negative",
+            "exact_artist_title_above_keep_on_rescore",
+        )
+
+    def test_review_band_is_candidate(self):
+        assert _apa._decide_title_only(0.70, 0.75, 0.65) == (
+            "candidate_false_negative",
+            "exact_artist_rescore_review",
+        )
+
+    def test_review_boundary_is_candidate(self):
+        assert _apa._decide_title_only(0.65, 0.75, 0.65)[1] == "exact_artist_rescore_review"
+
+    def test_below_review_is_title_miss(self):
+        assert _apa._decide_title_only(0.50, 0.75, 0.65) == ("true_reject", "title_miss")
+
+
+# ---------------------------------------------------------------------------
+# score_sample + false_negative_rate
+# ---------------------------------------------------------------------------
+
+
+class TestScoreSampleAndRate:
+    @pytest.fixture
+    def audit(self, tmp_path):
+        d = _make_dump(
+            tmp_path,
+            prune=[5, 6],
+            prune_releases=[
+                {"id": 5, "artist": "Zzyzx Qxqxqx", "title": "Xyzzy Plugh", "format": None},
+                # Misspelled artist + exact title -> a genuine fuzzy-path FN.
+                {"id": 6, "artist": "Juana Molena", "title": "DOGA", "format": "CD"},
+            ],
+        )
+        return _apa.load_audit(d)
+
+    @pytest.fixture
+    def index(self):
+        return LibraryIndex.from_rows([("Juana Molina", "DOGA", "CD")])
+
+    def test_score_and_rate(self, audit, index):
+        sample = _apa.sample_prune_ids(audit.prune, 200, 217)
+        rows = _apa.score_sample(sample, audit, index)
+        assert {r["id"] for r in rows} == {5, 6}
+        summary = _apa.false_negative_rate(rows)
+        assert summary["sample_size"] == 2
+        # id=6 (fuzzy near-match) is a candidate FN; id=5 (junk) a true reject.
+        assert summary["candidate_false_negatives"] == 1
+        assert summary["rate"] == pytest.approx(0.5)
+        assert summary["wilson_low"] < 0.5 < summary["wilson_high"]
+
+
+# ---------------------------------------------------------------------------
+# Output writers
+# ---------------------------------------------------------------------------
+
+
+class TestWriteSampleCsv:
+    def test_writes_header_and_rows(self, tmp_path):
+        rows = [
+            {
+                "id": 5,
+                "artist": "Junk",
+                "title": "Nowhere",
+                "format": None,
+                "phase": "fuzzy",
+                "call": "true_reject",
+                "mechanism": "no_artist_match",
+                "artist_score": 0.2,
+                "best_lib_artist": "juana molina",
+                "title_score": 0.1,
+                "combined": 0.14,
+            }
+        ]
+        path = tmp_path / "sample.csv"
+        _apa.write_sample_csv(path, rows)
+        parsed = list(csv.DictReader(path.open()))
+        assert parsed[0]["id"] == "5"
+        assert parsed[0]["phase"] == "fuzzy"
+        assert parsed[0]["call"] == "true_reject"
+        assert parsed[0]["mechanism"] == "no_artist_match"
+
+
+class TestFormatReport:
+    def test_report_contains_key_numbers(self, tmp_path):
+        d = _make_dump(tmp_path, keep=[1, 2, 3, 4], prune=[5], override=[4], prune_no_anv=[2, 5])
+        audit = _apa.load_audit(d)
+        summary = _apa.compute_summary(audit, final_release_count=3)
+        report = _apa.format_report(summary, None, _apa.uplift_305_ids(audit))
+        assert "non-pinned survivors" in report
+        assert "#305 uplift" in report
+        assert "cache_metadata" in report  # the comparable-series SQL
+        assert "not computed" in report  # FN section without --library-db
+
+
+class TestWriteDedupNote:
+    def test_patches_counts_json(self, tmp_path):
+        d = _make_dump(tmp_path, keep=[1], prune=[2])
+        _apa.write_dedup_note(d / "counts.json", 1234)
+        counts = json.loads((d / "counts.json").read_text())
+        assert "1234" in counts["dedup_note"]
+
+    def test_none_delta_does_not_clobber(self, tmp_path):
+        d = _make_dump(
+            tmp_path,
+            keep=[1],
+            prune=[2],
+            counts={
+                "keep": 1,
+                "prune": 1,
+                "review": 0,
+                "override_applied": 0,
+                "total_release_rows": 2,
+                "dedup_note": "prior value",
+            },
+        )
+        _apa.write_dedup_note(d / "counts.json", None)
+        counts = json.loads((d / "counts.json").read_text())
+        assert counts["dedup_note"] == "prior value"
+
+    def test_missing_counts_json_is_noop(self, tmp_path):
+        # No counts.json present: warn, don't raise.
+        _apa.write_dedup_note(tmp_path / "counts.json", 5)
+        assert not (tmp_path / "counts.json").exists()
+
+
+# ---------------------------------------------------------------------------
+# End-to-end main()
+# ---------------------------------------------------------------------------
+
+
+class TestMainEndToEnd:
+    def _library_db(self, tmp_path: Path) -> Path:
+        db = tmp_path / "library.db"
+        conn = sqlite3.connect(str(db))
+        cur = conn.cursor()
+        cur.execute(
+            "CREATE TABLE library (id INTEGER PRIMARY KEY, artist TEXT, title TEXT, "
+            "format TEXT, alternate_artist_name TEXT)"
+        )
+        cur.executemany(
+            "INSERT INTO library (artist, title, format, alternate_artist_name) VALUES (?,?,?,?)",
+            [("Juana Molina", "DOGA", "CD", None)],
+        )
+        conn.commit()
+        conn.close()
+        return db
+
+    def test_full_run_writes_report_csv_and_dedup_note(self, tmp_path):
+        d = _make_dump(
+            tmp_path,
+            keep=[1, 2, 3, 4],
+            prune=[5, 6],
+            override=[4],
+            prune_no_anv=[2, 5, 6],
+            prune_releases=[
+                {"id": 5, "artist": "Zzyzx Qxqxqx", "title": "Xyzzy Plugh", "format": None},
+                {"id": 6, "artist": "Juana Molina", "title": "DOGA", "format": "CD"},
+            ],
+        )
+        library_db = self._library_db(tmp_path)
+        out = tmp_path / "phase2-out"
+        rc = _apa.main(
+            [
+                str(d),
+                "--library-db",
+                str(library_db),
+                "--final-release-count",
+                "3",
+                "--output-dir",
+                str(out),
+                "--write-dedup-note",
+            ]
+        )
+        assert rc == 0
+        assert (out / "report.md").exists()
+        assert (out / "sample.csv").exists()
+        # dedup_note patched in the ORIGINAL dump's counts.json
+        counts = json.loads((d / "counts.json").read_text())
+        assert counts["dedup_note"] is not None
+        # report reflects the split
+        report = (out / "report.md").read_text()
+        assert "non-pinned survivors" in report
+
+    def test_missing_dir_returns_error(self, tmp_path):
+        assert _apa.main([str(tmp_path / "nope")]) == 1
+
+    def test_missing_library_db_returns_error_without_creating_file(self, tmp_path):
+        d = _make_dump(tmp_path, keep=[1], prune=[2])
+        missing = tmp_path / "nope.db"
+        assert _apa.main([str(d), "--library-db", str(missing)]) == 1
+        # Guarded before sqlite3.connect, so no empty db file is left behind.
+        assert not missing.exists()


### PR DESCRIPTION
Part of #217 (Phase 2 tooling). Prep so that running Phase 2 the moment a `prune-audit-<date>/` artifact lands is a single command — no new logic to write under time pressure. Does **not** close #217 (the analysis runs against the real artifact after the operator-gated Phase 1 rebuild).

## What it adds

`scripts/analyze_prune_audit.py` reads a Phase 0 dump and produces the Phase 2 answers. Read-only apart from the report/CSV it writes (and, with `--write-dedup-note`, the dump's `counts.json`):

1. **Counts + pinned/non-pinned split** — keep/prune/review, `pinned = |keep ∩ override|`, `non-pinned survivors = |keep − override|` (the comparable-to-history series vs 38,662/39,016), and the **dedup delta** `(keep+review) − <post-rebuild release count>`.
2. **#305 uplift** — `|prune_ids_no_anv − prune_ids|`, a pure diff of the two dumped id files (marginal over pins, matching the Phase 0 dump semantics).
3. **Residual false-negative rate** — a deterministic 200-sample (`random.Random(217)`) of `prune_ids`, joined to `prune_releases.jsonl` for raw artist/title, re-scored against the library index (reuses `verify_cache`'s `LibraryIndex` + rapidfuzz scorer). Each row is called **true-reject** vs **candidate-false-negative** with the miss mechanism (`no_artist_match`, `near_keep_threshold`, `substring_variant`, `scores_above_keep_on_rescore`, `weak_match`), and the rate is reported with a **Wilson score interval**.

Outputs a Markdown report + per-row CSV, and prints the prod `SELECT` that confirms the comparable `bulk_import`-minus-overrides series.

```
python scripts/analyze_prune_audit.py <prune-audit-dir> \
    --library-db data/library.db \
    --final-release-count <release count> \
    --output-dir ./phase2-out --write-dedup-note
```

## Notes
- The band decision is factored into a pure `_decide_call(...)` so the threshold logic is tested deterministically, independent of version-sensitive rapidfuzz scores.
- `docs/automation.md` documents the Phase 2 invocation next to the `PRUNE_AUDIT_DUMP_DIR` row.
- Phase 2's **doc corrections** (`CLAUDE.md` / `docs/architecture.md` two-stage expectation) and any **fix tickets** are deliberately left for the run against the *real* artifact, when there are real numbers to state.

## Tests
`tests/unit/test_analyze_prune_audit.py` (31): Wilson interval vs known values (0/200, 10/200, 200/200, n=0), dump loading, counts/split/uplift/dedup arithmetic, seeded-sample determinism, every `_decide_call` band + boundaries, `classify_miss` against a real `LibraryIndex`, scoring + rate, CSV/report/dedup-note writers, and an end-to-end `main()` run.

Local `ruff` clean; full unit suite green (1009 passed).