### PR TITLE
fix(sync-library): emit empty string for SQL NULL instead of literal 'NULL' text

### DIFF
--- a/scripts/sync-library.sh
+++ b/scripts/sync-library.sh
@@ -128,11 +128,26 @@ MYSQL_PORT="${DB_PORT:-3306}"
 # reads for the XML-converter artist filter -- here it rides along on every
 # library.db row instead of only feeding that allowlist. See
 # WXYC/discogs-etl#334.
+#
+# ALTERNATE_ARTIST_NAME, ALBUM_ARTIST, and the CROSS_REFERENCE_NAMES subquery
+# are wrapped in IFNULL(<expr>, '') because `mysql -B -N` on this server
+# prints a genuine SQL NULL as the literal 4-character text "NULL", not the
+# "\N" sentinel tsv_to_sqlite.py's parser expects -- and since ALBUM_ARTIST
+# feeds the library_fts index, an unwrapped NULL became a literal 'NULL'
+# string that a typed search for "null" then matched against the whole
+# catalog (verified in prod: 64,780 album_artist / 63,904
+# cross_reference_names rows). IFNULL only ever substitutes for a *real* SQL
+# NULL, so an artist or cross-reference genuinely named the text "NULL"
+# still passes through untouched -- this is deliberately a SQL-layer fix, not
+# Python string-sniffing in tsv_to_sqlite.py, which would risk corrupting
+# that row instead. The other columns in this SELECT (ID, TITLE,
+# PRESENTATION_NAME, CALL_LETTERS, both CALL_NUMBERS, and both REFERENCE_NAME
+# columns) are always populated and are left unwrapped.
 ETL_OUTPUT=$(mktemp)
 CSV_FILE=$(mktemp)
 if ! MYSQL_PWD="$LIBRARY_DB_PASSWORD" mysql -h "$MYSQL_HOST" -P "$MYSQL_PORT" -u "$LIBRARY_DB_USER" \
     --default-character-set=utf8 -B -N "$LIBRARY_DB_NAME" \
-    -e "SELECT r.ID, r.TITLE, lc.PRESENTATION_NAME, lc.CALL_LETTERS, lc.CALL_NUMBERS, r.CALL_NUMBERS, g.REFERENCE_NAME, f.REFERENCE_NAME, r.ALTERNATE_ARTIST_NAME, r.ALBUM_ARTIST, (SELECT GROUP_CONCAT(DISTINCT xlc.PRESENTATION_NAME SEPARATOR ' | ') FROM LIBRARY_CODE_CROSS_REFERENCE xcr, LIBRARY_CODE xlc WHERE xlc.ID = CASE WHEN xcr.CROSS_REFERENCING_ARTIST_ID = lc.ID THEN xcr.CROSS_REFERENCED_LIBRARY_CODE_ID WHEN xcr.CROSS_REFERENCED_LIBRARY_CODE_ID = lc.ID THEN xcr.CROSS_REFERENCING_ARTIST_ID ELSE NULL END AND (xcr.CROSS_REFERENCING_ARTIST_ID = lc.ID OR xcr.CROSS_REFERENCED_LIBRARY_CODE_ID = lc.ID) AND xlc.ID != lc.ID) FROM LIBRARY_RELEASE r JOIN LIBRARY_CODE lc ON r.LIBRARY_CODE_ID = lc.ID JOIN FORMAT f ON r.FORMAT_ID = f.ID JOIN GENRE g ON lc.GENRE_ID = g.ID" \
+    -e "SELECT r.ID, r.TITLE, lc.PRESENTATION_NAME, lc.CALL_LETTERS, lc.CALL_NUMBERS, r.CALL_NUMBERS, g.REFERENCE_NAME, f.REFERENCE_NAME, IFNULL(r.ALTERNATE_ARTIST_NAME, ''), IFNULL(r.ALBUM_ARTIST, ''), IFNULL((SELECT GROUP_CONCAT(DISTINCT xlc.PRESENTATION_NAME SEPARATOR ' | ') FROM LIBRARY_CODE_CROSS_REFERENCE xcr, LIBRARY_CODE xlc WHERE xlc.ID = CASE WHEN xcr.CROSS_REFERENCING_ARTIST_ID = lc.ID THEN xcr.CROSS_REFERENCED_LIBRARY_CODE_ID WHEN xcr.CROSS_REFERENCED_LIBRARY_CODE_ID = lc.ID THEN xcr.CROSS_REFERENCING_ARTIST_ID ELSE NULL END AND (xcr.CROSS_REFERENCING_ARTIST_ID = lc.ID OR xcr.CROSS_REFERENCED_LIBRARY_CODE_ID = lc.ID) AND xlc.ID != lc.ID), '') FROM LIBRARY_RELEASE r JOIN LIBRARY_CODE lc ON r.LIBRARY_CODE_ID = lc.ID JOIN FORMAT f ON r.FORMAT_ID = f.ID JOIN GENRE g ON lc.GENRE_ID = g.ID" \
     > "$CSV_FILE" 2> "$ETL_OUTPUT"; then
     ERROR_DETAILS=$(cat "$ETL_OUTPUT" | tail -1 | sed 's/"/\\"/g')
     cat "$ETL_OUTPUT" >> "$LOG_FILE"
@@ -156,12 +171,19 @@ log "Fetched $ROW_COUNT rows from MySQL"
 # no COMPILATION_TRACK_ARTIST table, so a "doesn't exist" failure here is expected
 # and must not fail the overall library sync (or any other CTA-fetch error, since
 # CTA is supplementary -- LIBRARY_RELEASE must never be blocked by it).
+#
+# TRACK_TITLE is wrapped in IFNULL(TRACK_TITLE, '') for the same reason as
+# ALBUM_ARTIST/ALTERNATE_ARTIST_NAME above: this is the same `mysql -B -N`
+# invocation style, so a genuine SQL NULL here renders as the literal text
+# "NULL" too. LIBRARY_RELEASE_ID and ARTIST_NAME are documented NOT NULL
+# (see _import_compilation_track_artists in tsv_to_sqlite.py) and stay
+# unwrapped.
 CTA_CSV_FILE=$(mktemp)
 CTA_ETL_OUTPUT=$(mktemp)
 CTA_TSV_ARGS=()
 if MYSQL_PWD="$LIBRARY_DB_PASSWORD" mysql -h "$MYSQL_HOST" -P "$MYSQL_PORT" -u "$LIBRARY_DB_USER" \
     --default-character-set=utf8 -B -N "$LIBRARY_DB_NAME" \
-    -e "SELECT LIBRARY_RELEASE_ID, ARTIST_NAME, TRACK_TITLE FROM COMPILATION_TRACK_ARTIST ORDER BY LIBRARY_RELEASE_ID" \
+    -e "SELECT LIBRARY_RELEASE_ID, ARTIST_NAME, IFNULL(TRACK_TITLE, '') FROM COMPILATION_TRACK_ARTIST ORDER BY LIBRARY_RELEASE_ID" \
     > "$CTA_CSV_FILE" 2> "$CTA_ETL_OUTPUT"; then
     CTA_ROW_COUNT=$(wc -l < "$CTA_CSV_FILE" | tr -d ' ')
     log "Fetched $CTA_ROW_COUNT compilation track artist rows from MySQL"

--- a/tests/e2e/test_sync_library_e2e.py
+++ b/tests/e2e/test_sync_library_e2e.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import re
 import sqlite3
 import subprocess
 import sys
@@ -243,3 +244,155 @@ class TestCompilationTrackLocationInvocation:
         # Only the "Various Artists" row is compilation-shelf (Stereolab isn't);
         # is_compilation_artist is the same wxyc_etl classifier discogs-etl uses.
         assert comp_ids == {20001}
+
+
+# --- literal-NULL-string bugfix (verified in prod 2026-08-02) --------------
+#
+# ``mysql -B -N`` (the CLI mode sync-library.sh uses) prints a genuine SQL
+# NULL on this server as the literal 4-character text "NULL", not the "\N"
+# sentinel tsv_to_sqlite.py's parser expects. Left unwrapped, that literal
+# text lands in SQLite as the *string* 'NULL' -- and since album_artist feeds
+# library_fts, a typed search for "null" matched the whole catalog.
+#
+# The fix is in the SQL text (IFNULL(<col>, '')), not in tsv_to_sqlite.py's
+# Python: an artist genuinely named "NULL" must survive, so string-sniffing
+# for the text 'NULL' would silently corrupt that row instead. There is no
+# MySQL server available in this environment, so these tests execute the
+# *actual* wrapped column expressions -- extracted live from
+# scripts/sync-library.sh -- against SQLite, which implements IFNULL
+# identically to MySQL for a plain column reference. This is a stronger,
+# self-updating proof than a hand-duplicated SQL string: if the wrap is
+# missing or malformed, the test fails for the right reason (the bare column
+# selects real NULL/None instead of '').
+_SYNC_SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "sync-library.sh"
+
+# Anchor on the actual `-e "SELECT ..."` mysql invocations, not the whole file
+# -- the file's own explanatory comments (necessarily) mention these same
+# column names in prose, and a naive whole-file search could match a comment
+# instead of the live SQL.
+_LIBRARY_SELECT_RE = re.compile(
+    r"-e \"(SELECT r\.ID.*?"
+    r"FROM LIBRARY_RELEASE r JOIN LIBRARY_CODE lc ON r\.LIBRARY_CODE_ID = lc\.ID "
+    r"JOIN FORMAT f ON r\.FORMAT_ID = f\.ID JOIN GENRE g ON lc\.GENRE_ID = g\.ID)\"",
+    re.DOTALL,
+)
+_CTA_SELECT_RE = re.compile(
+    r"-e \"(SELECT LIBRARY_RELEASE_ID.*?FROM COMPILATION_TRACK_ARTIST ORDER BY LIBRARY_RELEASE_ID)\"",
+    re.DOTALL,
+)
+
+
+def _library_select_text() -> str:
+    match = _LIBRARY_SELECT_RE.search(_SYNC_SCRIPT.read_text())
+    assert match, f"could not locate the LIBRARY_RELEASE SELECT in {_SYNC_SCRIPT.name}"
+    return match.group(1)
+
+
+def _cta_select_text() -> str:
+    match = _CTA_SELECT_RE.search(_SYNC_SCRIPT.read_text())
+    assert match, f"could not locate the COMPILATION_TRACK_ARTIST SELECT in {_SYNC_SCRIPT.name}"
+    return match.group(1)
+
+
+def _extract_column_expr(select_text: str, table_alias: str, column: str) -> str:
+    """Return whatever expression currently selects `column` in `select_text`
+    (the isolated SQL SELECT clause, not the whole script): either the bare
+    `alias.COLUMN` reference or an `IFNULL(alias.COLUMN, '')` wrap, whichever
+    the script actually contains right now."""
+    pattern = re.compile(
+        rf"(IFNULL\({re.escape(table_alias)}\.{re.escape(column)}, ''\)"
+        rf"|{re.escape(table_alias)}\.{re.escape(column)})"
+    )
+    match = pattern.search(select_text)
+    assert match, f"could not find {table_alias}.{column} in the SELECT clause"
+    return match.group(1)
+
+
+def _extract_bare_column_expr(select_text: str, column: str) -> str:
+    """Same as _extract_column_expr but for the un-aliased CTA SELECT."""
+    pattern = re.compile(rf"(IFNULL\({re.escape(column)}, ''\)|{re.escape(column)})")
+    match = pattern.search(select_text)
+    assert match, f"could not find {column} in the SELECT clause"
+    return match.group(1)
+
+
+class TestLibrarySelectRealNullVsLiteralNullText:
+    """A real SQL NULL must become '' (via IFNULL); an artist/track genuinely
+    named the text "NULL" must pass through untouched."""
+
+    def test_album_artist_real_null_becomes_empty_string_literal_null_text_survives(
+        self,
+    ) -> None:
+        expr = _extract_column_expr(_library_select_text(), "r", "ALBUM_ARTIST")
+
+        conn = sqlite3.connect(":memory:")
+        conn.execute("CREATE TABLE r (ALBUM_ARTIST TEXT)")
+        conn.execute("INSERT INTO r (ALBUM_ARTIST) VALUES (NULL)")
+        conn.execute("INSERT INTO r (ALBUM_ARTIST) VALUES ('NULL')")
+        rows = [row[0] for row in conn.execute(f"SELECT {expr} FROM r").fetchall()]
+        conn.close()
+
+        assert rows == ["", "NULL"], (
+            "a real SQL NULL album_artist must become '' and a literal text "
+            "'NULL' album_artist must survive unchanged"
+        )
+
+    def test_alternate_artist_name_real_null_becomes_empty_string_literal_null_text_survives(
+        self,
+    ) -> None:
+        expr = _extract_column_expr(_library_select_text(), "r", "ALTERNATE_ARTIST_NAME")
+
+        conn = sqlite3.connect(":memory:")
+        conn.execute("CREATE TABLE r (ALTERNATE_ARTIST_NAME TEXT)")
+        conn.execute("INSERT INTO r (ALTERNATE_ARTIST_NAME) VALUES (NULL)")
+        conn.execute("INSERT INTO r (ALTERNATE_ARTIST_NAME) VALUES ('NULL')")
+        rows = [row[0] for row in conn.execute(f"SELECT {expr} FROM r").fetchall()]
+        conn.close()
+
+        assert rows == ["", "NULL"]
+
+    def test_cross_reference_names_ifnull_pattern_converts_null_subquery_to_empty_string(
+        self,
+    ) -> None:
+        """The real cross_reference_names expression is a correlated
+        GROUP_CONCAT subquery using MySQL-only syntax (``SEPARATOR``, an
+        old-style comma-join) that doesn't parse under SQLite, so this
+        doesn't execute the literal production text the way the two tests
+        above do. It instead proves the same *pattern* the fix applies to
+        that subquery -- IFNULL wrapped around an expression that yields SQL
+        NULL when no cross-reference exists (the common case: 63,904 NULL
+        rows in prod) -- converts that NULL to ''. The wiring test in
+        tests/unit/test_sync_library_null_handling.py separately pins that
+        the actual subquery in sync-library.sh is wrapped this way.
+        """
+        conn = sqlite3.connect(":memory:")
+        conn.execute("CREATE TABLE lc (id INTEGER PRIMARY KEY)")
+        conn.execute("CREATE TABLE xref (lc_id INTEGER, other_name TEXT)")
+        conn.execute("INSERT INTO lc (id) VALUES (1)")
+        # No matching xref row for lc.id = 1 -> the correlated subquery below
+        # returns SQL NULL, mirroring the no-cross-reference case in prod.
+        rows = conn.execute(
+            "SELECT IFNULL("
+            "  (SELECT group_concat(other_name) FROM xref WHERE xref.lc_id = lc.id),"
+            "  ''"
+            ") FROM lc"
+        ).fetchall()
+        conn.close()
+
+        assert rows == [("",)]
+
+
+class TestCompilationTrackArtistRealNullVsLiteralNullText:
+    def test_track_title_real_null_becomes_empty_string_literal_null_text_survives(
+        self,
+    ) -> None:
+        expr = _extract_bare_column_expr(_cta_select_text(), "TRACK_TITLE")
+
+        conn = sqlite3.connect(":memory:")
+        conn.execute("CREATE TABLE t (TRACK_TITLE TEXT)")
+        conn.execute("INSERT INTO t (TRACK_TITLE) VALUES (NULL)")
+        conn.execute("INSERT INTO t (TRACK_TITLE) VALUES ('NULL')")
+        rows = [row[0] for row in conn.execute(f"SELECT {expr} FROM t").fetchall()]
+        conn.close()
+
+        assert rows == ["", "NULL"]

--- a/tests/unit/test_sync_library_null_handling.py
+++ b/tests/unit/test_sync_library_null_handling.py
@@ -1,0 +1,135 @@
+"""Pin the SQL-layer NULL-handling fix in the daily sync's MySQL SELECTs.
+
+``mysql -B -N`` (the CLI mode ``scripts/sync-library.sh`` uses to dump
+tubafrenzy's ``LIBRARY_RELEASE``/``COMPILATION_TRACK_ARTIST`` tables) prints a
+genuine SQL NULL as the literal 4-character text ``NULL`` on this server, not
+the ``\\N`` sentinel ``tsv_to_sqlite.py``'s parser expects. Left unwrapped,
+that literal text lands in SQLite as the *string* ``'NULL'`` instead of SQL
+NULL -- and since ``album_artist`` feeds the ``library_fts`` index, a typed
+search for "null" matched the entire catalog (verified in prod 2026-08-02:
+64,780 ``album_artist`` rows and 63,904 ``cross_reference_names`` rows held
+the literal string).
+
+The fix lives in the SQL text itself (``IFNULL(<col>, '')``), not in
+``tsv_to_sqlite.py``: an artist genuinely named "NULL" must survive, and
+string-sniffing for the text ``'NULL'`` in Python would silently corrupt that
+row instead. IFNULL only ever substitutes for a *real* SQL NULL, so a literal
+``'NULL'`` value passes through untouched while a genuine NULL becomes ``''``.
+
+These tests inspect the SELECT text in ``scripts/sync-library.sh`` directly
+(no MySQL server is available in this environment to run the query against)
+mirroring the wiring-test convention already used for this same script in
+``test_sync_library_derive_wiring.py``. See WXYC/discogs-etl (literal-NULL
+bugfix).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SYNC_SCRIPT = REPO_ROOT / "scripts" / "sync-library.sh"
+
+# The LIBRARY_RELEASE SELECT (11 columns) that feeds the primary library TSV.
+_LIBRARY_SELECT_RE = re.compile(
+    r"-e \"(SELECT r\.ID.*?"
+    r"FROM LIBRARY_RELEASE r JOIN LIBRARY_CODE lc ON r\.LIBRARY_CODE_ID = lc\.ID "
+    r"JOIN FORMAT f ON r\.FORMAT_ID = f\.ID JOIN GENRE g ON lc\.GENRE_ID = g\.ID)\"",
+    re.DOTALL,
+)
+
+# The COMPILATION_TRACK_ARTIST SELECT (3 columns) that feeds the supplementary
+# compilation-track-artist TSV (WXYC/discogs-etl#332).
+_CTA_SELECT_RE = re.compile(
+    r"-e \"(SELECT LIBRARY_RELEASE_ID.*?FROM COMPILATION_TRACK_ARTIST ORDER BY LIBRARY_RELEASE_ID)\"",
+    re.DOTALL,
+)
+
+
+def _library_select() -> str:
+    source = SYNC_SCRIPT.read_text()
+    match = _LIBRARY_SELECT_RE.search(source)
+    assert match, (
+        "could not locate the LIBRARY_RELEASE SELECT in sync-library.sh -- "
+        "has the query been reshaped?"
+    )
+    return match.group(1)
+
+
+def _cta_select() -> str:
+    source = SYNC_SCRIPT.read_text()
+    match = _CTA_SELECT_RE.search(source)
+    assert match, (
+        "could not locate the COMPILATION_TRACK_ARTIST SELECT in sync-library.sh -- "
+        "has the query been reshaped?"
+    )
+    return match.group(1)
+
+
+class TestLibrarySelectNullableTextColumnsWrapped:
+    """Nullable TEXT columns feeding the FTS-searchable library TSV must emit
+    ``''`` (via IFNULL) for a real SQL NULL, never the literal text ``NULL``."""
+
+    def test_album_artist_wrapped_in_ifnull(self) -> None:
+        assert "IFNULL(r.ALBUM_ARTIST, '')" in _library_select()
+
+    def test_alternate_artist_name_wrapped_in_ifnull(self) -> None:
+        """ALTERNATE_ARTIST_NAME is the same shape of column as ALBUM_ARTIST:
+        nullable TEXT (~3,935 of ~65k rows populated per
+        docs/discogs-etl-technical-overview.md), and it feeds the same
+        library_fts index, so it is exposed to the identical bug."""
+        assert "IFNULL(r.ALTERNATE_ARTIST_NAME, '')" in _library_select()
+
+    def test_cross_reference_names_subquery_wrapped_in_ifnull(self) -> None:
+        """The 11th column is a correlated GROUP_CONCAT subquery that returns
+        SQL NULL when a library code has no cross-references (the common
+        case: 63,904 NULL rows in prod). The *entire* subquery must be
+        wrapped, not just its inner expression."""
+        select_text = _library_select()
+        assert "IFNULL((SELECT GROUP_CONCAT" in select_text
+        # The subquery's closing paren must be immediately followed by the
+        # IFNULL default arg and then the outer FROM clause -- i.e. the wrap
+        # closes right before the query moves on to LIBRARY_RELEASE r JOIN...,
+        # not merely appearing somewhere earlier in the string.
+        assert re.search(
+            r"AND xlc\.ID != lc\.ID\), ''\) FROM LIBRARY_RELEASE r JOIN",
+            select_text,
+        ), "cross_reference_names subquery is not wrapped all the way to its closing paren"
+
+    def test_not_null_columns_left_unwrapped(self) -> None:
+        """Columns that are always populated must NOT be wrapped -- doing so
+        would be unjustified scope creep on this fix. Guards against a future
+        edit accidentally over-applying IFNULL."""
+        select_text = _library_select()
+        always_populated = [
+            "r.ID",
+            "r.TITLE",
+            "lc.PRESENTATION_NAME",
+            "lc.CALL_LETTERS",
+            "lc.CALL_NUMBERS",
+            "r.CALL_NUMBERS",
+            "g.REFERENCE_NAME",
+            "f.REFERENCE_NAME",
+        ]
+        for col in always_populated:
+            assert f"IFNULL({col}" not in select_text, f"{col} should not be IFNULL-wrapped"
+            assert col in select_text, f"{col} should still be selected plainly"
+
+
+class TestCompilationTrackArtistSelectNullableTextColumnsWrapped:
+    """The supplementary COMPILATION_TRACK_ARTIST SELECT is dumped via the
+    same ``mysql -B -N`` invocation style, so its nullable TEXT column
+    (TRACK_TITLE) is exposed to the identical literal-``NULL``-text bug."""
+
+    def test_track_title_wrapped_in_ifnull(self) -> None:
+        assert "IFNULL(TRACK_TITLE, '')" in _cta_select()
+
+    def test_not_null_columns_left_unwrapped(self) -> None:
+        """LIBRARY_RELEASE_ID and ARTIST_NAME are documented NOT NULL
+        (scripts/tsv_to_sqlite.py's _import_compilation_track_artists
+        docstring) -- they must stay unwrapped."""
+        select_text = _cta_select()
+        for col in ("LIBRARY_RELEASE_ID", "ARTIST_NAME"):
+            assert f"IFNULL({col}" not in select_text, f"{col} should not be IFNULL-wrapped"
+            assert col in select_text, f"{col} should still be selected plainly"

--- a/tests/unit/test_tsv_to_sqlite.py
+++ b/tests/unit/test_tsv_to_sqlite.py
@@ -127,6 +127,58 @@ class TestTsvToSqlite:
         assert row[0] is None
         assert row[1] is None
 
+    def test_empty_fields_are_stored_as_empty_string_not_null_or_literal_null(
+        self, tmp_path: Path
+    ) -> None:
+        """Empty TSV fields -- the shape sync-library.sh now emits for a real
+        SQL NULL after the IFNULL(<col>, '') wrap -- land as '' in SQLite, not
+        None and not the literal string 'NULL'.
+
+        This pins the actual post-fix production contract end to end: the
+        wrap turns a genuine NULL into an empty field on the wire (proven at
+        the SQL layer in tests/e2e/test_sync_library_e2e.py), and this parser
+        must carry that empty field through as ''. It complements
+        test_null_handling above (which still exercises the \\N sentinel that
+        tsv_to_sqlite.py keeps mapping to SQL NULL for other callers, but
+        which the live -B -N sync no longer emits).
+
+        album_artist and cross_reference_names are the two columns that held
+        the literal string 'NULL' on ~64k prod rows; the assertion that
+        MATCH 'null' returns nothing is the exact regression the fix closes.
+        """
+        tsv = _make_tsv(
+            [
+                # album_artist (col 10) and cross_reference_names (col 11) are
+                # empty -- the post-IFNULL shape for a real NULL. The empty
+                # trailing field must not break the 11-column count.
+                ["1", "Aluminum Tunes", "Stereolab", "ST", "100", "1", "Rock", "CD", "", "", ""],
+            ]
+        )
+        tsv_file = tmp_path / "input.tsv"
+        tsv_file.write_text(tsv, encoding="utf-8")
+        db_path = tmp_path / "library.db"
+
+        count = tsv_to_sqlite(str(tsv_file), str(db_path))
+
+        # An empty trailing field is preserved by rstrip("\n").split("\t"),
+        # so the row is a valid 11-field row and is imported (not skipped).
+        assert count == 1
+
+        conn = sqlite3.connect(str(db_path))
+        row = conn.execute(
+            "SELECT alternate_artist_name, album_artist, cross_reference_names"
+            " FROM library WHERE id = 1"
+        ).fetchone()
+        # The empty fields are the empty string, never None or 'NULL'.
+        assert row == ("", "", "")
+        # The literal-'NULL'-string bug: an empty album_artist must not put a
+        # 'null' token into the FTS index.
+        null_hits = conn.execute(
+            "SELECT rowid FROM library_fts WHERE library_fts MATCH 'null'"
+        ).fetchall()
+        conn.close()
+        assert null_hits == []
+
     def test_eleven_column_validation(self, tmp_path: Path) -> None:
         """Rows with != 11 fields are skipped; valid rows are still imported."""
         tsv = (


### PR DESCRIPTION
## Summary

Fixes a production correctness bug in the daily `library.db` sync. `scripts/sync-library.sh` dumps tubafrenzy's `LIBRARY_RELEASE` and `COMPILATION_TRACK_ARTIST` tables with `mysql -B -N`, which on the Kattare server renders a genuine SQL `NULL` as the **literal 4-character text `NULL`** — not the `\N` sentinel that `scripts/tsv_to_sqlite.py`'s parser translates to SQL NULL. So every real NULL landed in `library.db` as the **string** `'NULL'`.

Measured against the 2026-08-02 prod `library.db` (64,826 rows):

- `album_artist = 'NULL'` on **64,780 rows**
- `cross_reference_names = 'NULL'` on **63,904 rows**

`album_artist` is an indexed FTS column (it feeds `library_fts`), so `MATCH 'null'` returned the whole artifact set — any LML full-text query carrying the token "null" pulled back the entire catalog. This is a real library-matching bug, not just dirty data.

## Fix

Wrap the nullable TEXT columns in `IFNULL(<expr>, '')` **at the SQL layer**, so a real SQL NULL becomes `''` before `mysql` ever renders it:

- `LIBRARY_RELEASE` SELECT: `ALTERNATE_ARTIST_NAME`, `ALBUM_ARTIST`, and the correlated `cross_reference_names` `GROUP_CONCAT` subquery.
- `COMPILATION_TRACK_ARTIST` SELECT: `TRACK_TITLE`.

Always-populated / NOT NULL columns are deliberately left unwrapped (no scope creep).

**Why SQL-layer, not Python:** an artist or track genuinely named the text "NULL" must survive. `IFNULL` only substitutes for a *real* SQL NULL, so a genuine `'NULL'` value passes through untouched while a real NULL becomes `''`. String-sniffing the text `'NULL'` in `tsv_to_sqlite.py` would silently corrupt the legitimately-named row instead.

## Tests

- `tests/unit/test_sync_library_null_handling.py` (new) — pins which columns are wrapped in `IFNULL` and which are left unwrapped, by inspecting the live SELECT text in `scripts/sync-library.sh`.
- `tests/e2e/test_sync_library_e2e.py` — executes the actual wrapped column expressions (extracted live from the script) against in-memory SQLite to prove real-NULL → `''` and literal-`'NULL'` → survives.

## Caveat

No MySQL server exists in CI/dev, so the tests exercise the portable `IFNULL(<col>, '')` fragment via SQLite (which implements `IFNULL` identically to MySQL for a plain column reference), **not** the literal Kattare query end-to-end. Full production verification needs a `sync-library.sh` dry-run against staging MySQL. The bug itself was empirically confirmed against the live CLI and the 2026-08-02 prod `library.db`.

## Related

- Should land **before** the parity runs in https://github.com/WXYC/discogs-etl/issues/346 (removes a systematic normalization special-case from that harness).
- The `cross_reference_names` subquery wrapped here comes from https://github.com/WXYC/discogs-etl/issues/334.

Closes #347
