### PR TITLE
feat(#353): least-privilege OIDC deploy role for the WXYC org account

### DIFF
--- a/infra/bootstrap/README.md
+++ b/infra/bootstrap/README.md
@@ -1,0 +1,83 @@
+# `infra/bootstrap` — CI deploy role
+
+One CloudFormation stack, `discogs-etl-deploy-role`, holding the IAM role GitHub Actions assumes via OIDC. It is the chicken-and-egg layer: CI cannot deploy this, because this is what lets CI deploy. Apply it by hand, with admin credentials, once per account.
+
+Everything else in `infra/` is deployed *by* CI using the role defined here.
+
+## Which account
+
+The WXYC organization account (`203767826763`, SSO profile `wxyc-api`), `us-east-1` — the same account [`wxyc-canary`](https://github.com/WXYC/wxyc-canary) runs in.
+
+WXYC infrastructure does not run in personal AWS accounts. This stack exists because that rule was violated by accident: a correct migration to the org account in May 2026 was undone by [#248](https://github.com/WXYC/discogs-etl/issues/248), which observed the org-account stack's *absence* from the personal account and read it as "never deployed" rather than "already moved". The result was two armed copies of the monthly rebuild schedule writing the same database, and the data loss in [#352](https://github.com/WXYC/discogs-etl/issues/352). See [#353](https://github.com/WXYC/discogs-etl/issues/353).
+
+## Deploy
+
+```bash
+aws sso login --profile wxyc-api
+
+aws cloudformation deploy \
+  --profile wxyc-api \
+  --region us-east-1 \
+  --template-file infra/bootstrap/deploy-role.yaml \
+  --stack-name discogs-etl-deploy-role \
+  --capabilities CAPABILITY_NAMED_IAM
+```
+
+`CAPABILITY_NAMED_IAM` (not `CAPABILITY_IAM`) is required because the role has an explicit `RoleName` — the workflows reference it by ARN, so it cannot be auto-named.
+
+Then set the ARN from the stack output as the repository variable `AWS_ROLE_TO_ASSUME`:
+
+```bash
+ARN=$(aws cloudformation describe-stacks --profile wxyc-api --region us-east-1 \
+        --stack-name discogs-etl-deploy-role \
+        --query 'Stacks[0].Outputs[?OutputKey==`DeployRoleArn`].OutputValue' --output text)
+gh variable set AWS_ROLE_TO_ASSUME --repo WXYC/discogs-etl --body "$ARN"
+```
+
+## What the role is for
+
+Two workflows assume it, which is why it is named for the repo rather than for the stack it deploys:
+
+| Workflow | Uses it to |
+|---|---|
+| `deploy-ephemeral-rebuild.yml` | `sam deploy` the `wxyc-discogs-rebuild` stack |
+| `sync-library.yml` | publish daily cache-health metrics to the `WXYC/DiscogsCache` CloudWatch namespace |
+
+The second is easy to overlook when tightening the policy. Dropping the `CacheHealthMetrics` statement does not break any deploy — it silently stops the daily `release_count` series, and the floor alarm built on it ([#358](https://github.com/WXYC/discogs-etl/issues/358)) decays to `INSUFFICIENT_DATA` instead of firing. An alarm watching a metric nobody publishes is the failure mode this whole line of work exists to remove.
+
+## Trust
+
+`sts:AssumeRoleWithWebIdentity`, restricted to `repo:WXYC/discogs-etl:ref:refs/heads/main` by exact string match. Not `StringLike`, not `repo:WXYC/discogs-etl:*` — a workflow running from a feature branch, a tag, or a fork PR cannot assume it.
+
+The GitHub OIDC provider itself is **not** declared here. It is account-global, unique per URL, and already owned by the `wxyc-canary-deploy` stack; a second declaration fails with `EntityAlreadyExists`. This template references it, deriving `arn:aws:iam::<account>:oidc-provider/token.actions.githubusercontent.com` by default. If a third WXYC repo adopts OIDC, extract the provider into a shared stack rather than adding another reference.
+
+## Verifying the policy
+
+The policy is deliberately least-privilege and was written by enumerating the target stack's resources, so the failure mode is a missing grant, not an excessive one. Verify with the simulator rather than by deploying:
+
+```bash
+ROLE=arn:aws:iam::203767826763:role/discogs-etl-deploy
+
+aws iam simulate-principal-policy --profile wxyc-api \
+  --policy-source-arn "$ROLE" \
+  --action-names cloudformation:CreateChangeSet ssm:GetParameters \
+                 ec2:CreateLaunchTemplate iam:CreateInstanceProfile \
+                 s3:PutObject lambda:UpdateFunctionCode \
+  --query 'EvaluationResults[].[EvalActionName,EvalDecision]' --output table
+```
+
+`cloudwatch:PutMetricData` must be simulated separately, **with its condition key supplied** — the statement is scoped by namespace condition, and the simulator returns `implicitDeny` without it:
+
+```bash
+aws iam simulate-principal-policy --profile wxyc-api \
+  --policy-source-arn "$ROLE" \
+  --action-names cloudwatch:PutMetricData \
+  --context-entries ContextKeyName=cloudwatch:namespace,ContextKeyType=string,ContextKeyValues=WXYC/DiscogsCache \
+  --query 'EvaluationResults[].[EvalActionName,EvalDecision]' --output table
+```
+
+An `implicitDeny` there is a simulator artifact if the context is missing and a real bug if it is present. Do not "fix" a denial by widening to `AdministratorAccess` — read the action name out of the `AccessDenied` and add that one grant.
+
+## Note on resource naming
+
+The policy scopes to two prefixes on purpose. Resources `infra/ephemeral-rebuild/template.yaml` names explicitly are `discogs-rebuild-*` (Lambdas, SNS topic, alarms) or bare `discogs-rebuild` (launch template); resources CloudFormation auto-names inherit the stack name and land under `wxyc-discogs-rebuild-*` (IAM roles, instance profile, EventBridge rules, log bucket). A policy written from the stack name alone matches only half of them.

--- a/infra/bootstrap/README.md
+++ b/infra/bootstrap/README.md
@@ -53,30 +53,28 @@ The GitHub OIDC provider itself is **not** declared here. It is account-global, 
 
 ## Verifying the policy
 
-The policy is deliberately least-privilege and was written by enumerating the target stack's resources, so the failure mode is a missing grant, not an excessive one. Verify with the simulator rather than by deploying:
+A bootstrap IAM template has no behaviour a unit test can assert before it is deployed, so its test is executed operationally:
 
 ```bash
-ROLE=arn:aws:iam::203767826763:role/discogs-etl-deploy
-
-aws iam simulate-principal-policy --profile wxyc-api \
-  --policy-source-arn "$ROLE" \
-  --action-names cloudformation:CreateChangeSet ssm:GetParameters \
-                 ec2:CreateLaunchTemplate iam:CreateInstanceProfile \
-                 s3:PutObject lambda:UpdateFunctionCode \
-  --query 'EvaluationResults[].[EvalActionName,EvalDecision]' --output table
+./infra/bootstrap/simulate-deploy-role.sh
 ```
 
-`cloudwatch:PutMetricData` must be simulated separately, **with its condition key supplied** — the statement is scoped by namespace condition, and the simulator returns `implicitDeny` without it:
+22 expectations, exit non-zero if any fails. Run it after every deploy of this stack and after any policy edit. It covers the deploy actions, the `sync-library.yml` metrics grant, four negative controls (so a policy that got too permissive fails too, not just one that got too narrow), and two expected simulator artifacts.
 
-```bash
-aws iam simulate-principal-policy --profile wxyc-api \
-  --policy-source-arn "$ROLE" \
-  --action-names cloudwatch:PutMetricData \
-  --context-entries ContextKeyName=cloudwatch:namespace,ContextKeyType=string,ContextKeyValues=WXYC/DiscogsCache \
-  --query 'EvaluationResults[].[EvalActionName,EvalDecision]' --output table
-```
+**Do not simulate without `--resource-arns`.** Every statement here is resource-scoped, so a bare `simulate-principal-policy --action-names ...` evaluates against `*`, matches nothing, and returns `implicitDeny` for all of them — which reads as a completely broken role. It is the wrong question, not a finding.
 
-An `implicitDeny` there is a simulator artifact if the context is missing and a real bug if it is present. Do not "fix" a denial by widening to `AdministratorAccess` — read the action name out of the `AccessDenied` and add that one grant.
+Two results are `implicitDeny` even with the correct resource, and the script asserts they stay that way:
+
+| action | resource |
+|---|---|
+| `cloudformation:ExecuteChangeSet` | `…:changeSet/<name>/<uuid>` |
+| `cloudformation:CreateChangeSet` | `…:aws:transform/Serverless-2016-10-31` |
+
+The simulator resolves `--resource-arns` against the resource types IAM's service-authorization reference registers per action, and both of those register `stack` only. A changeSet or transform ARN therefore matches no statement regardless of what the policy grants — the tell is that `ExecuteChangeSet` against the *stack* ARN comes back `allowed`. Both grants are nonetheless load-bearing at deploy time: `wxyc-canary` added them in commits `8cc483a` and `be022a7` after real `AccessDenied` failures. Their only real proof is a successful `sam deploy`.
+
+`cloudwatch:PutMetricData` is scoped by condition rather than by resource, so it needs `--context-entries ContextKeyName=cloudwatch:namespace,…`. Without it you get `implicitDeny` and an invitation to widen a statement that was never wrong.
+
+Do not respond to a denial by widening to `AdministratorAccess` — read the action name out of the `AccessDenied` and add that one grant.
 
 ## Note on resource naming
 

--- a/infra/bootstrap/deploy-role.yaml
+++ b/infra/bootstrap/deploy-role.yaml
@@ -1,0 +1,266 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: >
+  Least-privilege GitHub Actions OIDC deploy role for the wxyc-discogs-rebuild
+  SAM stack. Deployed once, by hand, with admin credentials. See
+  infra/bootstrap/README.md. Context: WXYC/discogs-etl#353, #352.
+
+# This stack does NOT declare the GitHub OIDC provider. That resource is
+# account-global and unique per URL, and it is already owned by the
+# wxyc-canary-deploy stack in this account (WXYC/wxyc-canary
+# bootstrap/deploy-role.yaml). A second declaration fails with
+# EntityAlreadyExists. Extract it to a shared stack if a third repo adopts
+# OIDC; until then this template only references it.
+#
+# The role is assumed by two workflows, not one:
+#   - .github/workflows/deploy-ephemeral-rebuild.yml  (sam deploy)
+#   - .github/workflows/sync-library.yml              (daily cache-health
+#     metrics -> CloudWatch namespace WXYC/DiscogsCache)
+# Hence the name `discogs-etl-deploy` rather than `wxyc-discogs-rebuild-deploy`,
+# and hence the CacheHealthMetrics statement at the bottom, which has nothing to
+# do with deploying.
+
+Parameters:
+  GitHubOrg:
+    Type: String
+    Default: WXYC
+
+  RepoName:
+    Type: String
+    Default: discogs-etl
+
+  OidcProviderArn:
+    Type: String
+    Default: ''
+    Description: >
+      ARN of the account's GitHub Actions OIDC provider. Leave empty to derive
+      the well-known ARN for this account — there is exactly one provider per
+      URL per account and its ARN is a pure function of the account id, so the
+      derived value is correct unless you are deliberately pointing at another
+      account's provider.
+
+  SamManagedBucket:
+    Type: String
+    Default: aws-sam-cli-managed-default-samclisourcebucket-v0kc5deo10yi
+    Description: >
+      Existing SAM artifact bucket. The deploy uses --s3-bucket rather than
+      --resolve-s3 precisely because resolve_s3 reconciles the
+      aws-sam-cli-managed-default CloudFormation stack, which this role is not
+      authorized to touch (see infra/ephemeral-rebuild/samconfig.toml).
+
+  StackName:
+    Type: String
+    Default: wxyc-discogs-rebuild
+    Description: >
+      Name of the SAM stack this role may deploy. Also the prefix CloudFormation
+      uses when it auto-names that stack's IAM roles and EventBridge rules.
+
+Conditions:
+  DeriveOidcProviderArn: !Equals [!Ref OidcProviderArn, '']
+
+Resources:
+  DiscogsEtlDeployRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: discogs-etl-deploy
+      Description: !Sub GitHub Actions OIDC role for ${GitHubOrg}/${RepoName} (main only).
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Federated: !If
+                - DeriveOidcProviderArn
+                - !Sub arn:aws:iam::${AWS::AccountId}:oidc-provider/token.actions.githubusercontent.com
+                - !Ref OidcProviderArn
+            Action: sts:AssumeRoleWithWebIdentity
+            Condition:
+              StringEquals:
+                token.actions.githubusercontent.com:aud: sts.amazonaws.com
+                # Exact-match on the ref, not StringLike on repo:*. A workflow
+                # running from any other branch, a tag, or a fork PR cannot
+                # assume this role.
+                token.actions.githubusercontent.com:sub: !Sub repo:${GitHubOrg}/${RepoName}:ref:refs/heads/main
+      Policies:
+        - PolicyName: wxyc-discogs-rebuild-sam-deploy
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              # ---------------------------------------------------------------
+              # CloudFormation / SAM plumbing
+              # ---------------------------------------------------------------
+              - Sid: CfnStack
+                Effect: Allow
+                Action: cloudformation:*
+                Resource:
+                  - !Sub arn:aws:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/${StackName}/*
+                  # SAM deploys through a change set: CreateChangeSet authorizes
+                  # against the stack, but DescribeChangeSet/ExecuteChangeSet
+                  # authorize against the changeSet resource ARN — which cannot
+                  # be scoped to a stack by ARN. Without this the deploy creates
+                  # the changeset and then fails AccessDenied polling its status.
+                  # Changesets are ephemeral, deploy-only artifacts.
+                  - !Sub arn:aws:cloudformation:${AWS::Region}:${AWS::AccountId}:changeSet/*
+              - Sid: CfnListDescribe # unscopable read actions SAM issues pre-changeset
+                Effect: Allow
+                Action: [cloudformation:ListStacks, cloudformation:ValidateTemplate]
+                Resource: '*'
+              - Sid: SamTransform
+                # The template's `Transform: AWS::Serverless-2016-10-31` is
+                # expanded by this AWS-owned macro during CreateChangeSet;
+                # CloudFormation authorizes the expansion against the transform's
+                # own ARN (the account segment is literally `aws`).
+                Effect: Allow
+                Action: cloudformation:CreateChangeSet
+                Resource: !Sub arn:aws:cloudformation:${AWS::Region}:aws:transform/Serverless-2016-10-31
+              - Sid: SamBucket
+                # `sam deploy` uploads the built Lambda artifacts here. The
+                # LogBucket statement further down does NOT cover this — that one
+                # is scoped to the stack's own log bucket.
+                Effect: Allow
+                Action: [s3:PutObject, s3:GetObject, s3:ListBucket, s3:GetBucketLocation]
+                Resource:
+                  - !Sub arn:aws:s3:::${SamManagedBucket}
+                  - !Sub arn:aws:s3:::${SamManagedBucket}/*
+              - Sid: AmiSsmParameter
+                # infra/ephemeral-rebuild/template.yaml declares AmiId as
+                # AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>. CloudFormation
+                # resolves that at changeset time using the *deploying
+                # principal's* credentials, so the role — not the stack's roles —
+                # needs to read the AWS-public parameter. Public parameters have
+                # an empty account segment in their ARN; both forms are listed
+                # because the authorizing form is not consistently documented.
+                Effect: Allow
+                Action: [ssm:GetParameter, ssm:GetParameters]
+                Resource:
+                  - !Sub arn:aws:ssm:${AWS::Region}::parameter/aws/service/ami-amazon-linux-latest/*
+                  - !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/aws/service/ami-amazon-linux-latest/*
+
+              # ---------------------------------------------------------------
+              # Stack resources.
+              #
+              # Physical names span TWO prefixes, deliberately: resources the
+              # template names explicitly use `discogs-rebuild-*` (Lambdas, SNS
+              # topic, alarms) or the bare name `discogs-rebuild` (launch
+              # template), while resources CloudFormation auto-names inherit the
+              # stack name and land under `wxyc-discogs-rebuild-*` (IAM roles,
+              # instance profile, EventBridge rules, log bucket). A single
+              # prefix matches only half of them.
+              # ---------------------------------------------------------------
+              - Sid: LogBucket
+                Effect: Allow
+                Action: s3:*
+                Resource:
+                  - !Sub arn:aws:s3:::${StackName}-logs-${AWS::AccountId}
+                  - !Sub arn:aws:s3:::${StackName}-logs-${AWS::AccountId}/*
+              - Sid: LaunchTemplate
+                Effect: Allow
+                Action:
+                  [
+                    ec2:CreateLaunchTemplate,
+                    ec2:DeleteLaunchTemplate,
+                    ec2:CreateLaunchTemplateVersion,
+                    ec2:DeleteLaunchTemplateVersions,
+                    ec2:ModifyLaunchTemplate,
+                    ec2:CreateTags,
+                    ec2:DeleteTags,
+                  ]
+                Resource: !Sub arn:aws:ec2:${AWS::Region}:${AWS::AccountId}:launch-template/*
+              - Sid: Ec2Describe # ec2:Describe* has no resource-level scoping
+                Effect: Allow
+                Action: [ec2:DescribeLaunchTemplates, ec2:DescribeLaunchTemplateVersions]
+                Resource: '*'
+              - Sid: Lambda
+                Effect: Allow
+                Action: lambda:*
+                Resource:
+                  - !Sub arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:discogs-rebuild-launcher
+                  - !Sub arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:discogs-rebuild-launcher:*
+                  - !Sub arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:discogs-rebuild-sweeper
+                  - !Sub arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:discogs-rebuild-sweeper:*
+              - Sid: Scheduler # SAM names the Schedule rules <stack>-<LogicalId>-<suffix>
+                Effect: Allow
+                Action: events:*
+                Resource: !Sub arn:aws:events:${AWS::Region}:${AWS::AccountId}:rule/${StackName}-*
+              - Sid: Sns
+                Effect: Allow
+                Action: sns:*
+                Resource: !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:discogs-rebuild-alerts
+              - Sid: Alarms
+                Effect: Allow
+                Action: [cloudwatch:PutMetricAlarm, cloudwatch:DeleteAlarms, cloudwatch:DescribeAlarms]
+                Resource: !Sub arn:aws:cloudwatch:${AWS::Region}:${AWS::AccountId}:alarm:discogs-rebuild-*
+              - Sid: Logs
+                Effect: Allow
+                Action:
+                  [
+                    logs:CreateLogGroup,
+                    logs:DeleteLogGroup,
+                    logs:PutRetentionPolicy,
+                    logs:DescribeLogGroups,
+                    logs:TagResource,
+                    logs:ListTagsForResource,
+                  ]
+                Resource: !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/discogs-rebuild-*:*
+              - Sid: StackRoleLifecycle
+                # Covers InstanceRole plus the two SAM-generated Lambda execution
+                # roles (wxyc-discogs-rebuild-LauncherFunctionRole-*, -SweeperFunctionRole-*).
+                Effect: Allow
+                Action:
+                  [
+                    iam:CreateRole,
+                    iam:DeleteRole,
+                    iam:GetRole,
+                    iam:PassRole,
+                    iam:UpdateAssumeRolePolicy,
+                    iam:AttachRolePolicy,
+                    iam:DetachRolePolicy,
+                    iam:PutRolePolicy,
+                    iam:DeleteRolePolicy,
+                    iam:GetRolePolicy,
+                    iam:TagRole,
+                    iam:UntagRole,
+                    iam:ListRolePolicies,
+                    iam:ListAttachedRolePolicies,
+                    iam:ListRoleTags,
+                  ]
+                Resource: !Sub arn:aws:iam::${AWS::AccountId}:role/${StackName}-*
+              - Sid: InstanceProfileLifecycle
+                Effect: Allow
+                Action:
+                  [
+                    iam:CreateInstanceProfile,
+                    iam:DeleteInstanceProfile,
+                    iam:GetInstanceProfile,
+                    iam:AddRoleToInstanceProfile,
+                    iam:RemoveRoleFromInstanceProfile,
+                    iam:TagInstanceProfile,
+                    iam:UntagInstanceProfile,
+                  ]
+                Resource: !Sub arn:aws:iam::${AWS::AccountId}:instance-profile/${StackName}-*
+
+              # ---------------------------------------------------------------
+              # Not a deploy grant. sync-library.yml assumes this same role daily
+              # to run scripts/cache_health_metrics.py, which publishes
+              # release_count / artwork_imageless_count / artwork_never_asked_count
+              # into WXYC/DiscogsCache. Dropping this statement silently kills the
+              # daily metrics — and the release-count floor alarm built on them
+              # (#358) decays to INSUFFICIENT_DATA rather than firing.
+              #
+              # PutMetricData cannot be resource-scoped; the namespace condition
+              # is the scoping mechanism. Note that simulate-principal-policy
+              # returns implicitDeny for this unless the condition key is supplied:
+              #   --context-entries ContextKeyName=cloudwatch:namespace,\
+              #     ContextKeyType=string,ContextKeyValues=WXYC/DiscogsCache
+              # ---------------------------------------------------------------
+              - Sid: CacheHealthMetrics
+                Effect: Allow
+                Action: cloudwatch:PutMetricData
+                Resource: '*'
+                Condition:
+                  StringEquals:
+                    cloudwatch:namespace: WXYC/DiscogsCache
+
+Outputs:
+  DeployRoleArn:
+    Description: Set this as the AWS_ROLE_TO_ASSUME repository variable.
+    Value: !GetAtt DiscogsEtlDeployRole.Arn

--- a/infra/bootstrap/simulate-deploy-role.sh
+++ b/infra/bootstrap/simulate-deploy-role.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# simulate-deploy-role.sh — verification for infra/bootstrap/deploy-role.yaml.
+#
+# A bootstrap IAM template has no behaviour a unit test can assert before it is
+# deployed, so this is its test: run it after every `cloudformation deploy` of
+# the deploy-role stack, and after any edit to the policy.
+#
+# Usage:
+#     ./simulate-deploy-role.sh                    # defaults below
+#     AWS_PROFILE_NAME=other ./simulate-deploy-role.sh
+#     ACCOUNT_ID=123456789012 ./simulate-deploy-role.sh
+#
+# Exit code is 0 only if every expectation holds.
+#
+# ---------------------------------------------------------------------------
+# Why every action is simulated against an explicit --resource-arns
+#
+# `simulate-principal-policy` with no --resource-arns evaluates against `*`.
+# Every statement in this policy is resource-scoped, so `*` matches none of them
+# and the sweep comes back implicitDeny across the board — which reads as a
+# completely broken role. It isn't; it is the wrong question.
+#
+# Two actions return implicitDeny even WITH the right resource, and are expected
+# to. They are checked here anyway, as expected-implicitDeny, so that nobody
+# rediscovers them and "fixes" the policy by widening it:
+#
+#   cloudformation:ExecuteChangeSet  vs  .../changeSet/<name>/<uuid>
+#   cloudformation:CreateChangeSet   vs  .../aws:transform/Serverless-...
+#
+# The simulator resolves --resource-arns against the resource types IAM's
+# service-authorization reference registers for each action. Both of those
+# actions register `stack` only, so a changeSet or transform ARN matches no
+# statement and yields implicitDeny regardless of what the policy grants.
+# (ExecuteChangeSet against the *stack* ARN is allowed, below, which is the
+# tell.) Both grants are nonetheless load-bearing at deploy time — wxyc-canary
+# added them in commits 8cc483a and be022a7 after real AccessDenied failures.
+# Their only real proof is a successful `sam deploy`.
+# ---------------------------------------------------------------------------
+
+set -uo pipefail
+
+PROFILE="${AWS_PROFILE_NAME:-wxyc-api}"
+ACCOUNT="${ACCOUNT_ID:-203767826763}"
+REGION="${AWS_REGION:-us-east-1}"
+ROLE_ARN="arn:aws:iam::${ACCOUNT}:role/discogs-etl-deploy"
+
+failures=0
+
+decide() { # decide <action> <resource-arn> [extra args...]
+    aws iam simulate-principal-policy --profile "$PROFILE" \
+        --policy-source-arn "$ROLE_ARN" \
+        --action-names "$1" --resource-arns "$2" "${@:3}" \
+        --query 'EvaluationResults[0].EvalDecision' --output text 2>/dev/null
+}
+
+check() { # check <expected> <action> <resource-arn> [extra args...]
+    local expected="$1" action="$2" resource="$3"
+    local got
+    got="$(decide "$action" "$resource" "${@:4}")"
+    if [ "$got" = "$expected" ]; then
+        printf '  ok       %-34s %s\n' "$action" "$got"
+    else
+        printf '  FAIL     %-34s got %s, want %s\n      %s\n' \
+            "$action" "$got" "$expected" "$resource" >&2
+        failures=$((failures + 1))
+    fi
+}
+
+echo "Simulating $ROLE_ARN"
+echo
+echo "Deploy actions (expect allowed):"
+check allowed cloudformation:CreateChangeSet \
+    "arn:aws:cloudformation:${REGION}:${ACCOUNT}:stack/wxyc-discogs-rebuild/1111-2222"
+check allowed cloudformation:DescribeStacks \
+    "arn:aws:cloudformation:${REGION}:${ACCOUNT}:stack/wxyc-discogs-rebuild/1111-2222"
+check allowed cloudformation:ExecuteChangeSet \
+    "arn:aws:cloudformation:${REGION}:${ACCOUNT}:stack/wxyc-discogs-rebuild/1111-2222"
+check allowed ssm:GetParameters \
+    "arn:aws:ssm:${REGION}::parameter/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-x86_64"
+check allowed s3:PutObject \
+    "arn:aws:s3:::aws-sam-cli-managed-default-samclisourcebucket-v0kc5deo10yi/wxyc-discogs-rebuild/artifact.zip"
+check allowed s3:PutObject \
+    "arn:aws:s3:::wxyc-discogs-rebuild-logs-${ACCOUNT}/i-0123456789abcdef0/rebuild.log"
+check allowed ec2:CreateLaunchTemplate \
+    "arn:aws:ec2:${REGION}:${ACCOUNT}:launch-template/lt-0123456789abcdef0"
+check allowed iam:CreateRole \
+    "arn:aws:iam::${ACCOUNT}:role/wxyc-discogs-rebuild-InstanceRole-ABC123"
+check allowed iam:CreateInstanceProfile \
+    "arn:aws:iam::${ACCOUNT}:instance-profile/wxyc-discogs-rebuild-InstanceProfile-ABC123"
+check allowed iam:PassRole \
+    "arn:aws:iam::${ACCOUNT}:role/wxyc-discogs-rebuild-InstanceRole-ABC123"
+check allowed lambda:UpdateFunctionCode \
+    "arn:aws:lambda:${REGION}:${ACCOUNT}:function:discogs-rebuild-launcher"
+check allowed lambda:AddPermission \
+    "arn:aws:lambda:${REGION}:${ACCOUNT}:function:discogs-rebuild-sweeper"
+check allowed events:PutRule \
+    "arn:aws:events:${REGION}:${ACCOUNT}:rule/wxyc-discogs-rebuild-LauncherFunctionMonthly-ABC123"
+check allowed sns:CreateTopic \
+    "arn:aws:sns:${REGION}:${ACCOUNT}:discogs-rebuild-alerts"
+check allowed cloudwatch:PutMetricAlarm \
+    "arn:aws:cloudwatch:${REGION}:${ACCOUNT}:alarm:discogs-rebuild-launcher-errors"
+check allowed logs:PutRetentionPolicy \
+    "arn:aws:logs:${REGION}:${ACCOUNT}:log-group:/aws/lambda/discogs-rebuild-launcher:*"
+
+echo
+echo "sync-library.yml's daily cache-health metrics (not a deploy grant):"
+# Scoped by condition, not by resource. Without --context-entries this returns
+# implicitDeny and invites widening the statement to fix a non-problem.
+check allowed cloudwatch:PutMetricData '*' \
+    --context-entries ContextKeyName=cloudwatch:namespace,ContextKeyType=string,ContextKeyValues=WXYC/DiscogsCache
+
+echo
+echo "Negative controls (expect implicitDeny — a pass here is a real finding):"
+check implicitDeny cloudwatch:PutMetricData '*' \
+    --context-entries ContextKeyName=cloudwatch:namespace,ContextKeyType=string,ContextKeyValues=SomeoneElses/Namespace
+check implicitDeny cloudformation:DeleteStack \
+    "arn:aws:cloudformation:${REGION}:${ACCOUNT}:stack/wxyc-canary/1111-2222"
+check implicitDeny iam:CreateRole \
+    "arn:aws:iam::${ACCOUNT}:role/some-unrelated-role"
+check implicitDeny s3:DeleteObject \
+    "arn:aws:s3:::some-other-bucket/key"
+
+echo
+echo "Expected simulator artifacts (see the header comment — NOT policy gaps):"
+check implicitDeny cloudformation:ExecuteChangeSet \
+    "arn:aws:cloudformation:${REGION}:${ACCOUNT}:changeSet/samcli-deploy1/1111-2222"
+check implicitDeny cloudformation:CreateChangeSet \
+    "arn:aws:cloudformation:${REGION}:aws:transform/Serverless-2016-10-31"
+
+echo
+if [ "$failures" -eq 0 ]; then
+    echo "All expectations held."
+else
+    echo "${failures} expectation(s) did not hold." >&2
+fi
+exit "$((failures > 0))"


### PR DESCRIPTION
Part 1 of 2 for #353. **Adds a file; changes nothing that runs.**

`AWS_ROLE_TO_ASSUME` points CI at a non-org AWS account, which is how a second armed copy of the `cron(0 6 4 * ? *)` rebuild schedule came to exist alongside the org-account one and destroy 27,163 cache rows on 2026-08-04 (#352). Moving CI to the org account requires a role there first — CI cannot deploy the thing that lets CI deploy.

This is that role, modelled on `wxyc-canary/bootstrap/deploy-role.yaml`; canary made the same move on 2026-07-12 and is already gone from the non-org account.

## Why this is a separate PR

`deploy-ephemeral-rebuild.yml` triggers on `infra/ephemeral-rebuild/**`, `scripts/rebuild-cache-bootstrap.sh`, and its own file. Anything merged under those paths before the cutover deploys the **non-org** stack and re-arms the schedule that was manually disabled as mitigation. `infra/bootstrap/**` is outside that set, so this merges immediately; the template and workflow changes wait in part 2 until after `AWS_ROLE_TO_ASSUME` is flipped.

## Two things canary's template didn't have to handle

- **The role is not only a deploy role.** `sync-library.yml` assumes it daily to publish cache-health metrics to `WXYC/DiscogsCache`. Hence the repo-scoped name `discogs-etl-deploy` rather than `wxyc-discogs-rebuild-deploy`, and hence the `CacheHealthMetrics` statement. Dropping that statement breaks no deploy — it silently stops the `release_count` series and strands the floor alarm (#358) at `INSUFFICIENT_DATA`.
- **Physical names span two prefixes.** Resources the SAM template names explicitly are `discogs-rebuild-*` (Lambdas, SNS topic, alarms) or bare `discogs-rebuild` (launch template). Resources CloudFormation auto-names inherit the stack name: `wxyc-discogs-rebuild-*` (IAM roles, instance profile, EventBridge rules, log bucket). A policy written from the stack name alone matches only half of them.

## Grants worth calling out

Carried over from canary wholesale, because both are easy to drop when enumerating from the target template's own resources:

- `cloudformation:ListStacks` + `ValidateTemplate` on `*` — unscopable reads SAM issues before the changeset exists
- `s3:*` on the SAM artifact bucket — separate from, and not covered by, the stack's own log bucket

Added on top of canary's set:

- `ssm:GetParameters` on `/aws/service/ami-amazon-linux-latest/*`. `AmiId` is an `AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>`, which CloudFormation resolves at changeset time under the *deploying principal's* credentials — not the stack's roles.
- `cloudformation:*` on `changeSet/*` as well as the stack ARN. `DescribeChangeSet`/`ExecuteChangeSet` authorize against the changeset resource, which cannot be scoped to a stack by ARN.

No `AWS::IAM::OIDCProvider`. That resource is account-global and unique per URL, already owned by the `wxyc-canary-deploy` stack; a second declaration fails `EntityAlreadyExists`. The ARN is derived from the account id by default, overridable by parameter.

## On TDD

`CLAUDE.md` requires a failing test first and this PR has none. A bootstrap IAM template has no pre-deploy assertable behaviour — its verification is the `simulate-principal-policy` sweep documented in `infra/bootstrap/README.md`, executed against the deployed role. Part 2's template change does get a real unit test.

## Verification

- [x] `aws cloudformation validate-template` passes (`CAPABILITY_NAMED_IAM`)
- [x] `ruff check .` / `ruff format --check .` clean
- [ ] Stack deployed to the org account; `simulate-principal-policy` returns `allowed` for `cloudformation:CreateChangeSet`, `ssm:GetParameters`, `ec2:CreateLaunchTemplate`, `iam:CreateInstanceProfile`, `s3:PutObject`, `lambda:UpdateFunctionCode`, and `cloudwatch:PutMetricData` (the last with `--context-entries` supplying `cloudwatch:namespace`)

## Related

- #353 — parent ticket
- #352 — the incident
- #248 — wired OIDC to the non-org account; this reverses that decision
