### PR TITLE
feat(#365): mint the catalog:read service-account token per run

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -169,9 +169,10 @@ Functionality that was previously local to this repo has been extracted to share
 Retiring the `wxycmusic` MySQL means moving that daily build's catalog source to Backend-Service — but only once a Backend-sourced `library.db` is proven field-equivalent to the MySQL-sourced one, or every downstream consumer (LML search, streaming checks, compilation matching, dj-site catalog, iOS metadata) silently regresses. `scripts/catalog_parity_diff.py` builds both sides and diffs them:
 
 ```bash
-PARITY_DIR=$(mktemp -d)          # fresh each run: both --*-db paths must not already exist
-export LIBRARY_DB_PASSWORD=...   # never in the DSN -- see below
-export BACKEND_CATALOG_TOKEN=... # service-account JWT with catalog:read
+PARITY_DIR=$(mktemp -d)              # fresh each run: both --*-db paths must not already exist
+export LIBRARY_DB_PASSWORD=...       # never in the DSN -- see below
+export BACKEND_CATALOG_EMAIL=catalog-parity@wxyc.org
+export BACKEND_CATALOG_PASSWORD=...  # the service account's password; the harness mints per run
 
 python scripts/catalog_parity_diff.py \
     --mysql-source "mysql://$LIBRARY_DB_USER@127.0.0.1:13306/$LIBRARY_DB_NAME" \
@@ -182,7 +183,41 @@ python scripts/catalog_parity_diff.py \
 ```
 
 - **MySQL side** reproduces the daily build exactly: the same `mysql -B -N` CLI invocation (a Python driver cannot authenticate against tubafrenzy's MySQL), the same two SELECTs — a unit test lifts every `-e "SELECT ..."` out of `sync-library.sh` and asserts set equality with the harness's copies, because a baseline built from a *different* query would make parity measure the harness rather than the migration — and the same TSV parser. The password comes from **`LIBRARY_DB_PASSWORD`** and reaches the CLI via `MYSQL_PWD`: embedding it in the DSN would put it in *this* process's argv (visible to `ps`, echoed by `set -x` and by GitHub Actions command traces) and would need percent-encoding for `/`, `#`, `?`, `%`. A missing `COMPILATION_TRACK_ARTIST` table is tolerated, as in the daily sync.
-- **Backend side** is decision D3 / Option B ([wiki#89](https://github.com/WXYC/wiki/issues/89), 2026-08-03): the gzipped-NDJSON `GET /library/catalog` + `GET /library/catalog/compilation-tracks` exports ([Backend-Service#1965](https://github.com/WXYC/Backend-Service/issues/1965)) over HTTPS with a service-account bearer token in **`BACKEND_CATALOG_TOKEN`** (needs `catalog:read`). Option B was chosen over a direct-Postgres producer precisely so no prod-DB credential has to live in GitHub Actions; plain `http://` to anything but a loopback address is refused, and so is any cross-origin redirect — urllib copies `Authorization` into a redirected request, so a 302 from a proxy or hijacked DNS would otherwise replay the token to a host nobody named.
+- **Backend side** is decision D3 / Option B ([wiki#89](https://github.com/WXYC/wiki/issues/89), 2026-08-03): the gzipped-NDJSON `GET /library/catalog` + `GET /library/catalog/compilation-tracks` exports ([Backend-Service#1965](https://github.com/WXYC/Backend-Service/issues/1965)) over HTTPS with a service-account bearer token (needs `catalog:read`). Option B was chosen over a direct-Postgres producer precisely so no prod-DB credential has to live in GitHub Actions; plain `http://` to anything but a loopback address is refused, and so is any cross-origin redirect — urllib copies `Authorization` into a redirected request, so a 302 from a proxy or hijacked DNS would otherwise replay the token to a host nobody named.
+
+#### Minting and rotating the parity service account (#365)
+
+The bearer above **cannot be a stored secret**. `requirePermissions` accepts only a JWKS-verified JWT, and better-auth issues those with a 15-minute expiry (its default, which Backend-Service does not override) — so what CI stores is the service account's *password*, and `catalog_parity_diff.py` mints a token per run from `BACKEND_CATALOG_EMAIL` + `BACKEND_CATALOG_PASSWORD`. `BACKEND_CATALOG_TOKEN` still works for a one-off run with a JWT already in hand. Two optional overrides exist for non-prod: `BACKEND_AUTH_URL` (defaults to `<--backend-source>/auth`) and `BACKEND_AUTH_ORIGIN` (defaults to `https://dj.wxyc.org`, which must be one of the auth server's `BETTER_AUTH_TRUSTED_ORIGINS` — better-auth's CSRF guard rejects an origin-less sign-in).
+
+**Mint** (one-time, needs an admin session on `api.wxyc.org/auth`):
+
+```bash
+# 1. Admin sign-in -> session token.
+SESSION=$(curl -sS -X POST https://api.wxyc.org/auth/sign-in/email \
+    -H 'Content-Type: application/json' -H 'Origin: https://dj.wxyc.org' \
+    -d "{\"email\":\"$ADMIN_EMAIL\",\"password\":\"$ADMIN_PASSWORD\"}" | jq -r .token)
+
+# 2. Create the principal with a password, no email, no setup token.
+PASSWORD=$(python3 -c 'import secrets; print(secrets.token_urlsafe(48))')
+curl -sS -X POST https://api.wxyc.org/auth/admin/create-user \
+    -H "Authorization: Bearer $SESSION" -H 'Content-Type: application/json' \
+    -H 'Origin: https://dj.wxyc.org' \
+    -d "{\"email\":\"catalog-parity@wxyc.org\",\"name\":\"Catalog Parity\",\"password\":\"$PASSWORD\",\"data\":{\"emailVerified\":true}}"
+
+# 3. Store it where CI reads it.
+gh secret set BACKEND_CATALOG_EMAIL --repo WXYC/discogs-etl --body catalog-parity@wxyc.org
+gh secret set BACKEND_CATALOG_PASSWORD --repo WXYC/discogs-etl --body "$PASSWORD"
+```
+
+**Rotate**: repeat step 2 as `POST /auth/admin/set-user-password` with `{"userId": "...", "newPassword": "..."}`, then step 3. Nothing else consumes these secrets, so rotation is atomic from the soak's point of view as long as it doesn't land mid-run.
+
+Three things about that procedure are load-bearing:
+
+- **`admin/create-user`, not `admin/provision-user`.** The org's own wrapper refuses a caller-supplied password and emails an account-setup link whose token is valid for **7 days** (`shared/authentication/src/account-setup-token.ts`) — the length of the soak. Setting the password afterwards does not revoke it, so anyone who could read that mailbox could reset the account mid-soak. better-auth's admin endpoint takes the password directly and mints no token. Backend-Service handles this path explicitly: a `hooks.after` branch auto-verifies the email (BS#1118) and the `user.create.after` hook inserts the org `member` row, which is where the `catalog:read` permission actually comes from.
+- **`member` is the least-privileged role that carries `catalog:read`.** Every WXYC role has it; `member` is the floor. The residual grants are `bin:read/write` (its own DJ bin) and `flowsheet:read` — no catalog write, no flowsheet write. A truly catalog-read-only role would need a new entry in the shared `WXYCRole` union across three repos.
+- **No `role` field in the create-user body.** That field is better-auth's *global* admin role (`user.role`), not the org role — leaving it at the default keeps the account outside the admin plugin entirely.
+
+If the account ever needs revoking: rotate the password (which orphans the stored secret), and ban the user if the compromise is active — the JWT payload carries `banned` and `requirePermissions` 403s on it, so a ban takes effect within one 15-minute token turnover rather than waiting out the year-long session.
 
 Four properties worth knowing before reading a parity report:
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -187,31 +187,40 @@ python scripts/catalog_parity_diff.py \
 
 #### Minting and rotating the parity service account (#365)
 
-The bearer above **cannot be a stored secret**. `requirePermissions` accepts only a JWKS-verified JWT, and better-auth issues those with a 15-minute expiry (its default, which Backend-Service does not override) — so what CI stores is the service account's *password*, and `catalog_parity_diff.py` mints a token per run from `BACKEND_CATALOG_EMAIL` + `BACKEND_CATALOG_PASSWORD`. `BACKEND_CATALOG_TOKEN` still works for a one-off run with a JWT already in hand. Two optional overrides exist for non-prod: `BACKEND_AUTH_URL` (defaults to `<--backend-source>/auth`) and `BACKEND_AUTH_ORIGIN` (defaults to `https://dj.wxyc.org`, which must be one of the auth server's `BETTER_AUTH_TRUSTED_ORIGINS` — better-auth's CSRF guard rejects an origin-less sign-in).
+The bearer above **cannot be a stored secret**. `requirePermissions` accepts only a JWKS-verified JWT, and better-auth issues those with a 15-minute expiry (its default, which Backend-Service does not override) — so what CI stores is the service account's *password*, and `catalog_parity_diff.py` mints a token per run from `BACKEND_CATALOG_EMAIL` + `BACKEND_CATALOG_PASSWORD`. `BACKEND_CATALOG_TOKEN` still works for a one-off run with a JWT already in hand: it takes precedence, and if it turns out to be stale the run falls back to minting from the credential pair rather than failing on a 15-minute-old token it could replace. Two optional overrides exist for non-prod: `BACKEND_AUTH_URL` (defaults to `<--backend-source>/auth`) and `BACKEND_AUTH_ORIGIN` (defaults to `https://dj.wxyc.org`, which must be one of the auth server's `BETTER_AUTH_TRUSTED_ORIGINS` — better-auth's CSRF guard rejects an origin-less sign-in).
 
 A run outlives its 15-minute token, so the harness refreshes — and how it refreshes is shaped by the two rate limiters in front of `/auth/sign-in` (the express one, 10 per 15 min; better-auth's own, 3 per 10s). It caches the *session* and refreshes by re-exchanging at `/auth/token`, which is exempt from the express limiter; only an exchange that itself 401s (a dead session) costs a second sign-in, and there are at most two sign-ins per run. The two budgets are separate — spending the sign-in allowance must never disable refreshing against a session that still works. A 429 whose retry hint exceeds 10s is **not** waited out: the run fails quoting the hint, because retrying into a 15-minute window is a guaranteed second refusal and the operator wants the real number. If that happens, check whether something else is signing in as the service account.
 
 **Mint** (one-time, needs an admin session on `api.wxyc.org/auth`):
 
+Every password below reaches `curl` on **stdin**, never in argv — same reason `LIBRARY_DB_PASSWORD` goes through `MYSQL_PWD` above. `-d "{...$PASSWORD...}"` would put it in a command line that `ps` shows to every user on the box and that `set -x` echoes into the scrollback.
+
 ```bash
 # 1. Admin sign-in -> session token.
-SESSION=$(curl -sS -X POST https://api.wxyc.org/auth/sign-in/email \
-    -H 'Content-Type: application/json' -H 'Origin: https://dj.wxyc.org' \
-    -d "{\"email\":\"$ADMIN_EMAIL\",\"password\":\"$ADMIN_PASSWORD\"}" | jq -r .token)
+SESSION=$(jq -n --arg e "$ADMIN_EMAIL" --arg p "$ADMIN_PASSWORD" '{email:$e,password:$p}' \
+    | curl -sS -X POST https://api.wxyc.org/auth/sign-in/email \
+        -H 'Content-Type: application/json' -H 'Origin: https://dj.wxyc.org' \
+        --data-binary @- | jq -r .token)
 
 # 2. Create the principal with a password, no email, no setup token.
+#    Keep USER_ID: rotation and revocation both need it.
 PASSWORD=$(python3 -c 'import secrets; print(secrets.token_urlsafe(48))')
-curl -sS -X POST https://api.wxyc.org/auth/admin/create-user \
-    -H "Authorization: Bearer $SESSION" -H 'Content-Type: application/json' \
-    -H 'Origin: https://dj.wxyc.org' \
-    -d "{\"email\":\"catalog-parity@wxyc.org\",\"name\":\"Catalog Parity\",\"password\":\"$PASSWORD\",\"data\":{\"emailVerified\":true}}"
+USER_ID=$(jq -n --arg p "$PASSWORD" \
+    '{email:"catalog-parity@wxyc.org",name:"Catalog Parity",password:$p,data:{emailVerified:true}}' \
+    | curl -sS -X POST https://api.wxyc.org/auth/admin/create-user \
+        -H "Authorization: Bearer $SESSION" -H 'Content-Type: application/json' \
+        -H 'Origin: https://dj.wxyc.org' --data-binary @- | jq -r .user.id)
 
 # 3. Store it where CI reads it.
 gh secret set BACKEND_CATALOG_EMAIL --repo WXYC/discogs-etl --body catalog-parity@wxyc.org
-gh secret set BACKEND_CATALOG_PASSWORD --repo WXYC/discogs-etl --body "$PASSWORD"
+printf %s "$PASSWORD" | gh secret set BACKEND_CATALOG_PASSWORD --repo WXYC/discogs-etl --body-file -
 ```
 
-**Rotate**: repeat step 2 as `POST /auth/admin/set-user-password` with `{"userId": "...", "newPassword": "..."}`, then step 3. Nothing else consumes these secrets, so rotation is atomic from the soak's point of view as long as it doesn't land mid-run.
+If `USER_ID` was not captured at mint time, recover it with `POST /auth/admin/list-users` (`{"searchField":"email","searchValue":"catalog-parity@wxyc.org"}`) rather than guessing.
+
+**Rotate**: repeat step 2 as `POST /auth/admin/set-user-password` with `{"userId":"$USER_ID","newPassword":"..."}`, then **revoke the old sessions** — `POST /auth/admin/revoke-user-sessions` with `{"userId":"$USER_ID"}` — then step 3. The revocation is not optional bookkeeping: `set-user-password` revokes nothing, and Backend-Service pins `session.expiresIn` to **365 days** (`shared/authentication/src/auth.definition.ts`), so a rotation without it orphans the stored secret while leaving every previously-minted session able to keep exchanging for `catalog:read` JWTs for a year. The harness signs out the session it mints (`_TokenSource.close`, in a `finally`), so in the normal case there is nothing left to revoke — this covers the runs that died before they could.
+
+Nothing else consumes these secrets, so rotation is atomic from the soak's point of view as long as it doesn't land mid-run.
 
 Three things about that procedure are load-bearing:
 
@@ -219,7 +228,7 @@ Three things about that procedure are load-bearing:
 - **`member` is the least-privileged role that carries `catalog:read`.** Every WXYC role has it; `member` is the floor. The residual grants are `bin:read/write` (its own DJ bin) and `flowsheet:read` — no catalog write, no flowsheet write. A truly catalog-read-only role would need a new entry in the shared `WXYCRole` union across three repos.
 - **No `role` field in the create-user body.** That field is better-auth's *global* admin role (`user.role`), not the org role — leaving it at the default keeps the account outside the admin plugin entirely.
 
-If the account ever needs revoking: rotate the password (which orphans the stored secret), and ban the user if the compromise is active — the JWT payload carries `banned` and `requirePermissions` 403s on it, so a ban takes effect within one 15-minute token turnover rather than waiting out the year-long session.
+If the account ever needs revoking: rotate the password **and** revoke the sessions (both above — the password alone leaves year-long sessions live), and ban the user if the compromise is active. The JWT payload carries `banned` and `requirePermissions` 403s on it, so a ban takes effect within one 15-minute token turnover; it is the only one of the three that also invalidates a JWT already in flight.
 
 Four properties worth knowing before reading a parity report:
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -189,6 +189,8 @@ python scripts/catalog_parity_diff.py \
 
 The bearer above **cannot be a stored secret**. `requirePermissions` accepts only a JWKS-verified JWT, and better-auth issues those with a 15-minute expiry (its default, which Backend-Service does not override) — so what CI stores is the service account's *password*, and `catalog_parity_diff.py` mints a token per run from `BACKEND_CATALOG_EMAIL` + `BACKEND_CATALOG_PASSWORD`. `BACKEND_CATALOG_TOKEN` still works for a one-off run with a JWT already in hand. Two optional overrides exist for non-prod: `BACKEND_AUTH_URL` (defaults to `<--backend-source>/auth`) and `BACKEND_AUTH_ORIGIN` (defaults to `https://dj.wxyc.org`, which must be one of the auth server's `BETTER_AUTH_TRUSTED_ORIGINS` — better-auth's CSRF guard rejects an origin-less sign-in).
 
+A run outlives its 15-minute token, so the harness refreshes — and how it refreshes is shaped by the two rate limiters in front of `/auth/sign-in` (the express one, 10 per 15 min; better-auth's own, 3 per 10s). It caches the *session* and refreshes by re-exchanging at `/auth/token`, which is exempt from the express limiter; only an exchange that itself 401s (a dead session) costs a second sign-in, and there are at most two sign-ins per run. The two budgets are separate — spending the sign-in allowance must never disable refreshing against a session that still works. A 429 whose retry hint exceeds 10s is **not** waited out: the run fails quoting the hint, because retrying into a 15-minute window is a guaranteed second refusal and the operator wants the real number. If that happens, check whether something else is signing in as the service account.
+
 **Mint** (one-time, needs an admin session on `api.wxyc.org/auth`):
 
 ```bash

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -110,3 +110,14 @@ The `--notify` flag is always passed, so Slack notifications are sent on failure
 | `DISCOGS_TOKEN` | Discogs API token — used by the recall index build's artwork precompute (optional; rows still write with `artwork_url = NULL` without it) |
 
 After a successful run, verify the library-metadata-lookup health endpoint returns healthy with the expected row count.
+
+## Unwired secrets (catalog parity)
+
+Two repo secrets exist that **no workflow reads yet**. They authenticate the Backend-sourced producer in `scripts/catalog_parity_diff.py` against `GET /library/catalog` — the catalog-parity soak on [wiki#89](https://github.com/WXYC/wiki/issues/89), which runs by hand today. The workflow that will consume them is [#346](https://github.com/WXYC/discogs-etl/issues/346); until it lands, these are set so the soak can run unattended from a runner or a laptop without a credential detour.
+
+| Secret | Description |
+|--------|-------------|
+| `BACKEND_CATALOG_EMAIL` | Service-account email (`catalog-parity@wxyc.org`), `member` org role — the least-privileged role carrying `catalog:read` |
+| `BACKEND_CATALOG_PASSWORD` | That account's password. **Not a token**: the JWT Backend-Service accepts expires in 15 minutes, so the harness signs in and mints one per run |
+
+Mint and rotation procedure: [`architecture.md` → Minting and rotating the parity service account](architecture.md#minting-and-rotating-the-parity-service-account-365). Treat the pair as sensitive — the export it unlocks is the entire library catalog.

--- a/scripts/catalog_parity_diff.py
+++ b/scripts/catalog_parity_diff.py
@@ -27,10 +27,18 @@ build both sides and diff them.
   (decision D3 / Option B, 2026-08-03): the gzipped-NDJSON exports ``GET
   /library/catalog`` + ``GET /library/catalog/compilation-tracks``
   (WXYC/Backend-Service#1965) read over HTTPS with a service-account bearer
-  token from ``$BACKEND_CATALOG_TOKEN`` -- no prod-DB credentials, which is
-  the whole point of Option B over a direct-Postgres producer. Plain http to
-  anything but a loopback address is refused, and so is any cross-origin
-  redirect, which urllib would otherwise follow *carrying that token*.
+  token -- no prod-DB credentials, which is the whole point of Option B over
+  a direct-Postgres producer. Plain http to anything but a loopback address
+  is refused, and so is any cross-origin redirect, which urllib would
+  otherwise follow *carrying that token*.
+
+  The token is minted per run from ``$BACKEND_CATALOG_EMAIL`` +
+  ``$BACKEND_CATALOG_PASSWORD`` (WXYC/discogs-etl#365), because the JWT
+  Backend-Service accepts lives 15 minutes and so cannot be a stored CI
+  secret for a soak that runs 7+ consecutive days -- what CI stores is the
+  service account's password. ``$BACKEND_CATALOG_TOKEN`` still short-circuits
+  all of that for a one-off run with a token already in hand. See
+  ``_TokenSource`` for why a refresh re-exchanges rather than re-signs-in.
 
 Both producers write **only** to the path named by the matching ``--*-db``
 flag, and refuse to write to a path that already exists: this harness must
@@ -80,6 +88,7 @@ connections (``mode=ro``).
 from __future__ import annotations
 
 import argparse
+import base64
 import gzip
 import json
 import logging
@@ -89,6 +98,7 @@ import sqlite3
 import subprocess
 import sys
 import tempfile
+import time
 import zlib
 from collections import Counter
 from collections.abc import Callable, Iterable, Iterator, Sequence
@@ -96,7 +106,7 @@ from contextlib import contextmanager
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Any
-from urllib.error import URLError
+from urllib.error import HTTPError, URLError
 from urllib.parse import unquote, urlsplit
 from urllib.request import (
     HTTPRedirectHandler,
@@ -332,11 +342,58 @@ def run_diff(mysql_db: str, backend_db: str) -> ParityDiff:
 # both, which is what the snapshot-consistency check keys on.
 _Row = Sequence[object]
 
-# Env var holding the Backend-Service service-account bearer JWT. Decision D3
-# (Option B) deliberately picked an HTTP/contract-governed producer over a
+# Env var holding a pre-minted Backend-Service service-account JWT. Decision
+# D3 (Option B) deliberately picked an HTTP/contract-governed producer over a
 # direct-Postgres one precisely so that no prod-DB credential has to exist in
-# GitHub Actions -- this token is the only secret the Backend producer needs.
+# GitHub Actions.
+#
+# This is the *manual* route: a JWT from better-auth lives 15 minutes (the
+# plugin default, which Backend-Service does not override), so it suits an
+# operator running a one-off with a token already in hand and cannot be a
+# stored CI secret for a soak measured in days. Unattended runs use the
+# credential pair below and mint per run.
 BACKEND_TOKEN_ENV = "BACKEND_CATALOG_TOKEN"
+
+# The service account's own credentials (#365) -- what CI actually stores.
+# `catalog-parity@wxyc.org` holds the `member` org role, the least-privileged
+# role carrying `catalog:read`.
+BACKEND_EMAIL_ENV = "BACKEND_CATALOG_EMAIL"
+BACKEND_PASSWORD_ENV = "BACKEND_CATALOG_PASSWORD"
+
+# Optional overrides. The auth base URL defaults to `<--backend-source>/auth`,
+# which is where prod serves better-auth (https://api.wxyc.org/auth), so a
+# normal invocation names one URL rather than two.
+BACKEND_AUTH_URL_ENV = "BACKEND_AUTH_URL"
+BACKEND_AUTH_ORIGIN_ENV = "BACKEND_AUTH_ORIGIN"
+
+# better-auth's CSRF guard rejects a sign-in with no Origin header
+# (MISSING_OR_NULL_ORIGIN) -- which is every non-browser caller, this one
+# included. The value has to be one of the auth server's
+# BETTER_AUTH_TRUSTED_ORIGINS; dj-site's is the one every headless WXYC
+# client sends (wxyc-canary does the same).
+_DEFAULT_AUTH_ORIGIN = "https://dj.wxyc.org"
+
+_SIGN_IN_PATH = "/sign-in/email"
+_EXCHANGE_PATH = "/token"
+
+# Refresh a JWT this far before its `exp` rather than after: a fetch can run
+# for _HTTP_TIMEOUT_SECONDS, and starting one with seconds of validity left
+# buys a guaranteed 401 and a wasted export.
+_JWT_REFRESH_MARGIN_SECONDS = 120
+
+# Sign-ins per process. Two: the first, plus one recovery for a session that
+# turns out to be dead. The refresh path re-exchanges instead (see
+# `_TokenSource`), so a long run does not spend these -- and a credential that
+# is simply wrong fails after two rather than hammering a rate limiter shared
+# with every DJ logging in.
+_MAX_SIGN_INS = 2
+
+# One retry on a rate-limited sign-in, waiting at most this long. Two limiters
+# sit in front of that path: the express one (10 per 15 min, draft-7
+# `Retry-After`) and better-auth's own (3 per 10s, `X-Retry-After`). The cap
+# has to be able to clear the shorter window, so it is 10s and not
+# wxyc-canary's 5s.
+_SIGN_IN_RETRY_CAP_SECONDS = 10
 
 # Env var holding the tubafrenzy MySQL password. It is read from the
 # environment rather than from the ``--mysql-source`` DSN because a DSN
@@ -405,9 +462,10 @@ class _SameOriginRedirectHandler(HTTPRedirectHandler):
         if _origin(req.full_url) != _origin(newurl):
             raise SourceError(
                 f"refusing to follow the {code} redirect from {req.full_url} to {newurl}: "
-                f"it crosses origins, and urllib would replay the {BACKEND_TOKEN_ENV} "
-                "bearer token to the new host. Point --backend-source at the origin that "
-                "actually serves the catalog exports."
+                "it crosses origins, and urllib would replay the parity service-account "
+                f"credentials to the new host -- the bearer token on a catalog fetch, the "
+                f"${BACKEND_PASSWORD_ENV} sign-in password on a mint. Point --backend-source "
+                f"(or ${BACKEND_AUTH_URL_ENV}) at the origin that actually serves it."
             )
         return super().redirect_request(req, fp, code, msg, headers, newurl)
 
@@ -635,21 +693,282 @@ def _catalog_cta_row_to_library_row(row: dict[str, Any]) -> tuple[object, ...]:
     )
 
 
-def _resolve_backend_base_url(source: str) -> str:
-    """Validate and normalize the Backend base URL."""
+def _resolve_https_base_url(source: str, *, source_label: str, secret_description: str) -> str:
+    """Validate and normalize a base URL that a secret is about to travel to.
+
+    Two URLs now carry a secret -- the catalog exports (a bearer token) and
+    the auth service (the sign-in password) -- and they are named by different
+    things and protect different secrets, so the caller supplies both labels.
+    A message that says "bearer token" when the password is what's at risk
+    sends the operator to the wrong env var.
+    """
     parts = urlsplit(source)
     if parts.scheme not in ("http", "https") or not parts.netloc:
         raise SourceError(
-            "--backend-source must be an http(s) base URL "
+            f"{source_label} must be an http(s) base URL "
             f"(e.g. https://api.wxyc.org), got {source!r}"
         )
     if parts.scheme == "http" and (parts.hostname or "") not in _PLAINTEXT_OK_HOSTS:
         raise SourceError(
-            f"refusing to send the {BACKEND_TOKEN_ENV} bearer token over plaintext http "
-            f"to {parts.hostname!r} -- use https (plain http is allowed only for a "
-            "loopback address, for local testing)"
+            f"refusing to send {secret_description} over plaintext http "
+            f"to {parts.hostname!r} (from {source_label}) -- use https (plain http is "
+            "allowed only for a loopback address, for local testing)"
         )
     return f"{parts.scheme}://{parts.netloc}{parts.path.rstrip('/')}"
+
+
+def _resolve_backend_base_url(source: str) -> str:
+    """Validate and normalize the Backend base URL."""
+    return _resolve_https_base_url(
+        source,
+        source_label="--backend-source",
+        secret_description=(
+            f"the service-account bearer token (${BACKEND_TOKEN_ENV}, or one minted "
+            f"from ${BACKEND_EMAIL_ENV})"
+        ),
+    )
+
+
+def _default_auth_url(base_url: str) -> str:
+    """Where better-auth lives relative to the Backend base URL.
+
+    Production serves it at https://api.wxyc.org/auth, i.e. the same origin as
+    the catalog exports -- so the common case needs no second flag, and
+    ``$BACKEND_AUTH_URL`` exists for the environments where that isn't true.
+    """
+    return f"{base_url.rstrip('/')}/auth"
+
+
+class _AuthStatusError(Exception):
+    """An auth-service call that came back with a status, not a token.
+
+    Internal to the mint path: `_TokenSource` turns each of these into either
+    a retry (429 on sign-in, 401 on an exchange) or a ``SourceError``. It
+    carries the response headers so the 429 branch can honor a retry hint.
+    """
+
+    def __init__(self, code: int, detail: str, headers: Any) -> None:
+        super().__init__(f"HTTP {code}: {detail}")
+        self.code = code
+        self.detail = detail
+        self.headers = headers
+
+    def retry_after_seconds(self, cap: float) -> float:
+        """Seconds to wait before one retry, from whichever hint header exists.
+
+        The express limiter sends draft-7 ``Retry-After``; better-auth's own
+        limiter sends ``X-Retry-After`` and nothing else. Reading only one of
+        the two means waiting the default against half the limiters that can
+        produce this response.
+        """
+        for header in ("Retry-After", "X-Retry-After"):
+            raw = self.headers.get(header) if self.headers is not None else None
+            if raw is None:
+                continue
+            try:
+                return min(max(float(str(raw).strip()), 0.0), cap)
+            except ValueError:
+                continue  # HTTP-date form: fall through to the cap
+        return cap
+
+
+def _jwt_expiry_epoch(token: str) -> float:
+    """The ``exp`` claim, or 0.0 when it cannot be read.
+
+    A local, signature-unverified decode: this only schedules the *next*
+    refresh, and the authority on whether a token is good remains the 401 from
+    Backend-Service. 0.0 means "refresh now", so an unparseable token costs an
+    extra exchange rather than a surprise expiry mid-fetch.
+    """
+    try:
+        segment = token.split(".")[1]
+        padded = segment + "=" * (-len(segment) % 4)
+        claims = json.loads(base64.urlsafe_b64decode(padded))
+        return float(claims["exp"])
+    except Exception:  # noqa: BLE001 - any malformed shape means "refresh now"
+        return 0.0
+
+
+class _TokenSource:
+    """Supplies a currently-valid bearer for the catalog exports.
+
+    Two modes:
+
+    - **Static** (``$BACKEND_CATALOG_TOKEN``): hand back what the operator
+      supplied. A 401 is terminal -- there is nothing here to refresh from,
+      and saying so beats retrying a token that cannot improve.
+    - **Credential** (``$BACKEND_CATALOG_EMAIL`` + ``$BACKEND_CATALOG_PASSWORD``):
+      sign in once, then exchange that session for a 15-minute JWT as often
+      as needed.
+
+    The asymmetry between those two cached values is the whole design, and it
+    is dictated by where the rate limiters sit. ``/auth/sign-in`` is capped at
+    10 per 15 minutes (express, keyed on the caller's IP) and 3 per 10 seconds
+    (better-auth's own); ``/auth/token`` is exempt from the first and
+    generously bounded by the second. A parity run can outlive 15 minutes --
+    three snapshot attempts over two exports, each with a 300-second budget --
+    so refreshes must be exchanges, not sign-ins. The session behind them is
+    good for a year server-side, so one sign-in covers the whole run, and only
+    an exchange that 401s spends another.
+    """
+
+    def __init__(self, base_url: str) -> None:
+        self._static = os.environ.get(BACKEND_TOKEN_ENV) or None
+        self._email = os.environ.get(BACKEND_EMAIL_ENV) or None
+        self._password = os.environ.get(BACKEND_PASSWORD_ENV) or None
+        self._session: str | None = None
+        self._jwt: str | None = None
+        self._jwt_expires_at = 0.0
+        self._sign_ins = 0
+
+        if self._static:
+            return
+        if not (self._email and self._password):
+            raise SourceError(
+                "no Backend service-account credentials: set "
+                f"${BACKEND_EMAIL_ENV} + ${BACKEND_PASSWORD_ENV} (the unattended route -- "
+                "the harness signs in and mints a fresh token per run), or "
+                f"${BACKEND_TOKEN_ENV} with a JWT you already hold (a one-off; better-auth "
+                "JWTs expire after 15 minutes). Either way the principal needs catalog:read."
+            )
+        self._auth_url = _resolve_https_base_url(
+            os.environ.get(BACKEND_AUTH_URL_ENV) or _default_auth_url(base_url),
+            source_label=f"${BACKEND_AUTH_URL_ENV}",
+            secret_description=f"the ${BACKEND_PASSWORD_ENV} sign-in password",
+        )
+        self._origin = os.environ.get(BACKEND_AUTH_ORIGIN_ENV) or _DEFAULT_AUTH_ORIGIN
+
+    def token(self) -> str:
+        """A bearer valid now -- minting or refreshing if it isn't."""
+        if self._static:
+            return self._static
+        if self._jwt and time.time() < self._jwt_expires_at - _JWT_REFRESH_MARGIN_SECONDS:
+            return self._jwt
+        self._jwt = self._exchange()
+        self._jwt_expires_at = _jwt_expiry_epoch(self._jwt)
+        return self._jwt
+
+    def invalidate(self) -> None:
+        """Discard the cached JWT after Backend-Service rejected it.
+
+        Drops the *JWT* only. The session it came from is almost certainly
+        still good -- a 15-minute token against a year-long session -- and
+        re-signing-in here is what would put a long run on a collision course
+        with the sign-in limiter.
+        """
+        if self._static:
+            raise SourceError(
+                f"the ${BACKEND_TOKEN_ENV} token was rejected (401) and cannot be refreshed: "
+                "better-auth JWTs expire after 15 minutes. Mint a fresh one, or set "
+                f"${BACKEND_EMAIL_ENV} + ${BACKEND_PASSWORD_ENV} so the harness can mint per "
+                "run -- which is what an unattended soak needs."
+            )
+        self._jwt = None
+        self._jwt_expires_at = 0.0
+
+    def _exchange(self) -> str:
+        """Trade the cached session for a JWT, re-signing-in at most once."""
+        url = self._auth_url + _EXCHANGE_PATH
+        last: _AuthStatusError | None = None
+        while self._sign_ins < _MAX_SIGN_INS:
+            session = self._session or self._sign_in()
+            request = Request(
+                url,
+                headers={
+                    "Authorization": f"Bearer {session}",
+                    "Origin": self._origin,
+                    "Accept": "application/json",
+                },
+            )
+            try:
+                return _auth_token_from(request, "the token exchange")
+            except _AuthStatusError as exc:
+                if exc.code != 401:
+                    raise SourceError(
+                        f"the token exchange at {url} failed with HTTP {exc.code}: {exc.detail}"
+                    ) from exc
+                # The session is dead (rotated, revoked, expired). That is the
+                # one condition worth another sign-in.
+                last = exc
+                self._session = None
+        raise SourceError(
+            f"the token exchange at {url} kept returning HTTP 401 after "
+            f"{self._sign_ins} sign-ins as ${BACKEND_EMAIL_ENV}: "
+            f"{last.detail if last else 'no detail'}. Check that the service account "
+            "exists, is not banned, and holds catalog:read."
+        )
+
+    def _sign_in(self) -> str:
+        """Exchange the password for a session token. One retry on a 429."""
+        url = self._auth_url + _SIGN_IN_PATH
+        body = json.dumps({"email": self._email, "password": self._password}).encode("utf-8")
+        for attempt in (1, 2):
+            self._sign_ins += 1
+            request = Request(
+                url,
+                data=body,
+                headers={
+                    "Content-Type": "application/json",
+                    "Accept": "application/json",
+                    # Absent, better-auth's CSRF guard 400s with
+                    # MISSING_OR_NULL_ORIGIN before ever checking the password.
+                    "Origin": self._origin,
+                },
+            )
+            try:
+                session = _auth_token_from(request, "sign-in")
+            except _AuthStatusError as exc:
+                if exc.code == 429 and attempt == 1:
+                    delay = exc.retry_after_seconds(_SIGN_IN_RETRY_CAP_SECONDS)
+                    logger.warning(
+                        "sign-in was rate limited; retrying once",
+                        extra={"step": "backend_producer", "delay_seconds": delay},
+                    )
+                    time.sleep(delay)
+                    continue
+                raise SourceError(
+                    f"sign-in as ${BACKEND_EMAIL_ENV} at {url} failed with "
+                    f"HTTP {exc.code}: {exc.detail}"
+                ) from exc
+            self._session = session
+            return session
+        raise AssertionError("unreachable: the retry loop either returns or raises")
+
+
+def _auth_token_from(request: Request, what: str) -> str:
+    """Run one auth-service call and return its ``token`` field.
+
+    Both auth responses are ``{"token": ...}`` -- a session from sign-in, a JWT
+    from the exchange. Non-2xx bodies are surfaced (truncated) because they
+    carry a diagnosis and never a credential; 2xx bodies are *not*, because
+    they carry exactly the credential this whole path exists to protect.
+    """
+    try:
+        with _opener.open(request, timeout=_HTTP_TIMEOUT_SECONDS) as response:
+            body = response.read()
+    except SourceError:
+        raise  # the cross-origin redirect guard
+    except HTTPError as exc:
+        detail = ""
+        try:
+            detail = exc.read().decode("utf-8", "replace")[:200].replace("\n", " ").strip()
+        except Exception:  # noqa: BLE001 - a body we cannot read is not the failure
+            pass
+        raise _AuthStatusError(exc.code, detail, exc.headers) from exc
+    except (URLError, OSError) as exc:
+        raise SourceError(f"{what} at {request.full_url} failed: {exc}") from exc
+
+    try:
+        payload = json.loads(body)
+    except json.JSONDecodeError as exc:
+        raise SourceError(f"{what} at {request.full_url} returned a non-JSON body") from exc
+    token = payload.get("token") if isinstance(payload, dict) else None
+    if not isinstance(token, str) or not token:
+        raise SourceError(
+            f"{what} at {request.full_url} returned 200 with no token field; "
+            "the auth response shape has changed"
+        )
+    return token
 
 
 def _map_ndjson_lines(
@@ -678,9 +997,36 @@ def _map_ndjson_lines(
 
 
 def _fetch_ndjson(
+    url: str, token_source: _TokenSource, mapper: Callable[[dict[str, Any]], _Row]
+) -> tuple[list[_Row], str]:
+    """GET a gzipped-NDJSON export; return its mapped rows and the watermark.
+
+    Retries exactly once on a 401, after asking ``token_source`` for a fresh
+    bearer: a 15-minute JWT can expire between the two exports of a snapshot
+    pair, or partway through a re-fetch, and re-reading the catalog is far
+    cheaper than failing a parity day over a token turnover. Once, not in a
+    loop -- a second 401 is an authorization problem, not an expiry, and
+    should say so instead of retrying until the limiter notices.
+    """
+    for attempt in (1, 2):
+        try:
+            return _fetch_ndjson_once(url, token_source.token(), mapper)
+        except _AuthStatusError as exc:
+            if exc.code == 401 and attempt == 1:
+                logger.info(
+                    "catalog export returned 401; refreshing the service-account token",
+                    extra={"step": "backend_producer", "url": url},
+                )
+                token_source.invalidate()
+                continue
+            raise SourceError(f"failed to fetch {url}: HTTP {exc.code}: {exc.detail}") from exc
+    raise AssertionError("unreachable: the retry loop either returns or raises")
+
+
+def _fetch_ndjson_once(
     url: str, token: str, mapper: Callable[[dict[str, Any]], _Row]
 ) -> tuple[list[_Row], str]:
-    """GET a gzipped-NDJSON export; return its mapped rows and the watermark."""
+    """One export GET. Raises ``_AuthStatusError`` so the caller can refresh."""
     # Scheme is validated to http/https in _resolve_backend_base_url, so this
     # cannot be tricked into a file:// or other local-handler fetch, and
     # _opener refuses any cross-origin redirect that would carry the token on.
@@ -714,12 +1060,24 @@ def _fetch_ndjson(
         ) from exc
     except UnicodeDecodeError as exc:
         raise SourceError(f"{url} returned a body that is not valid UTF-8: {exc}") from exc
+    except HTTPError as exc:
+        # Must precede the URLError clause below -- HTTPError subclasses it, so
+        # the generic branch would swallow the status and with it any chance of
+        # telling "the token just expired" apart from "the export is broken".
+        detail = ""
+        try:
+            detail = exc.read().decode("utf-8", "replace")[:200].replace("\n", " ").strip()
+        except Exception:  # noqa: BLE001 - a body we cannot read is not the failure
+            pass
+        raise _AuthStatusError(exc.code, detail, exc.headers) from exc
     except (URLError, OSError) as exc:
         raise SourceError(f"failed to fetch {url}: {exc}") from exc
     return rows, watermark
 
 
-def _fetch_consistent_snapshot(base_url: str, token: str) -> tuple[list[_Row], list[_Row]]:
+def _fetch_consistent_snapshot(
+    base_url: str, token_source: _TokenSource
+) -> tuple[list[_Row], list[_Row]]:
     """Fetch both exports, retrying until they describe the same catalog snapshot.
 
     Returns rows already mapped into ``library`` / ``compilation_track_artist``
@@ -736,10 +1094,10 @@ def _fetch_consistent_snapshot(base_url: str, token: str) -> tuple[list[_Row], l
     reason = "no attempt was made"
     for attempt in range(1, _SNAPSHOT_ATTEMPTS + 1):
         catalog_rows, catalog_watermark = _fetch_ndjson(
-            base_url + _CATALOG_PATH, token, _catalog_row_to_library_row
+            base_url + _CATALOG_PATH, token_source, _catalog_row_to_library_row
         )
         cta_rows, cta_watermark = _fetch_ndjson(
-            base_url + _COMPILATION_TRACKS_PATH, token, _catalog_cta_row_to_library_row
+            base_url + _COMPILATION_TRACKS_PATH, token_source, _catalog_cta_row_to_library_row
         )
 
         if catalog_watermark != cta_watermark:
@@ -787,20 +1145,17 @@ def _build_library_db_from_backend(source: str, output_path: str) -> None:
 
     Raises:
         SourceError: on a refused overwrite, a bad/plaintext URL, a
-            cross-origin redirect, a missing ``$BACKEND_CATALOG_TOKEN``, a
-            fetch or decode failure, a torn snapshot, an empty catalog, or a
-            catalog row that violates the api.yaml contract.
+            cross-origin redirect, missing credentials (neither
+            ``$BACKEND_CATALOG_TOKEN`` nor the ``$BACKEND_CATALOG_EMAIL`` /
+            ``$BACKEND_CATALOG_PASSWORD`` pair), a sign-in or token-exchange
+            failure, a fetch or decode failure, a torn snapshot, an empty
+            catalog, or a catalog row that violates the api.yaml contract.
     """
     _require_absent(output_path, "backend")
     base_url = _resolve_backend_base_url(source)
-    token = os.environ.get(BACKEND_TOKEN_ENV)
-    if not token:
-        raise SourceError(
-            f"{BACKEND_TOKEN_ENV} is not set: the Backend catalog exports require a "
-            "service-account bearer token with catalog:read"
-        )
+    token_source = _TokenSource(base_url)
 
-    library_rows, compilation_rows = _fetch_consistent_snapshot(base_url, token)
+    library_rows, compilation_rows = _fetch_consistent_snapshot(base_url, token_source)
     if not library_rows:
         # A broken export query, an over-narrow token scope, or a truncated
         # cached buffer all surface as a 200 with no rows. Building from it
@@ -1000,7 +1355,9 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         help=(
             "Build the Backend-sourced library.db first, from this base URL "
             f"(e.g. https://api.wxyc.org), writing it to --backend-db (which must "
-            f"not already exist). Requires a service-account token in ${BACKEND_TOKEN_ENV}."
+            f"not already exist). Needs a catalog:read service account: "
+            f"${BACKEND_EMAIL_ENV} + ${BACKEND_PASSWORD_ENV} (minted per run), or "
+            f"${BACKEND_TOKEN_ENV} for a one-off with a JWT already in hand."
         ),
     )
     return p

--- a/scripts/catalog_parity_diff.py
+++ b/scripts/catalog_parity_diff.py
@@ -376,23 +376,33 @@ _DEFAULT_AUTH_ORIGIN = "https://dj.wxyc.org"
 _SIGN_IN_PATH = "/sign-in/email"
 _EXCHANGE_PATH = "/token"
 
-# Refresh a JWT this far before its `exp` rather than after: a fetch can run
-# for _HTTP_TIMEOUT_SECONDS, and starting one with seconds of validity left
-# buys a guaranteed 401 and a wasted export.
-_JWT_REFRESH_MARGIN_SECONDS = 120
+# better-auth's default JWT life, which Backend-Service does not override.
+# Only a fallback: it schedules the next refresh when a token's own `exp` is
+# unreadable, so a claim-format change upstream costs one assumption rather
+# than an exchange per call.
+_ASSUMED_JWT_TTL_SECONDS = 900
 
 # Sign-ins per process. Two: the first, plus one recovery for a session that
 # turns out to be dead. The refresh path re-exchanges instead (see
 # `_TokenSource`), so a long run does not spend these -- and a credential that
 # is simply wrong fails after two rather than hammering a rate limiter shared
-# with every DJ logging in.
+# with every DJ logging in. Counted per sign-in, not per HTTP attempt: the
+# 429 retry below belongs to the sign-in that provoked it.
 _MAX_SIGN_INS = 2
+
+# Attempts per exchange: one against the cached session, and -- if that session
+# turns out to be dead -- one against a fresh one. Deliberately its own budget
+# rather than a share of _MAX_SIGN_INS, because an exhausted sign-in allowance
+# must not disable refreshing against a session that still works. That
+# conflation is what made a long soak run unable to refresh at all.
+_MAX_EXCHANGE_ATTEMPTS = 2
 
 # One retry on a rate-limited sign-in, waiting at most this long. Two limiters
 # sit in front of that path: the express one (10 per 15 min, draft-7
 # `Retry-After`) and better-auth's own (3 per 10s, `X-Retry-After`). The cap
 # has to be able to clear the shorter window, so it is 10s and not
-# wxyc-canary's 5s.
+# wxyc-canary's 5s. A hint longer than this is not waited out -- see
+# `_sign_in`.
 _SIGN_IN_RETRY_CAP_SECONDS = 10
 
 # Env var holding the tubafrenzy MySQL password. It is read from the
@@ -410,6 +420,13 @@ _COMPILATION_TRACKS_PATH = "/library/catalog/compilation-tracks"
 # from a per-watermark in-memory cache -- but a cold cache has to build the
 # whole body first, so the budget is generous.
 _HTTP_TIMEOUT_SECONDS = 300
+
+# Refresh a JWT this far before its `exp` rather than after. A fetch can run
+# for the whole timeout above, so a token with less life than that left cannot
+# safely start one: it is "expired" for our purposes while the clock still
+# says otherwise. The 401 retry would recover, but at the price of re-fetching
+# an entire export.
+_JWT_REFRESH_MARGIN_SECONDS = _HTTP_TIMEOUT_SECONDS
 
 # GET /library/catalog and GET /library/catalog/compilation-tracks are two
 # requests, not one transaction. They form a consistent snapshot only while
@@ -753,40 +770,46 @@ class _AuthStatusError(Exception):
         self.detail = detail
         self.headers = headers
 
-    def retry_after_seconds(self, cap: float) -> float:
-        """Seconds to wait before one retry, from whichever hint header exists.
+    def retry_hint_seconds(self) -> float | None:
+        """The server's own wait hint, or None when it did not give a usable one.
 
         The express limiter sends draft-7 ``Retry-After``; better-auth's own
         limiter sends ``X-Retry-After`` and nothing else. Reading only one of
-        the two means waiting the default against half the limiters that can
+        the two means ignoring the hint from half the limiters that can
         produce this response.
+
+        Returned unclamped, because the caller has to be able to tell a hint
+        it can wait out from one it cannot: silently truncating a 15-minute
+        window to a 10-second sleep buys a certain second refusal.
         """
         for header in ("Retry-After", "X-Retry-After"):
             raw = self.headers.get(header) if self.headers is not None else None
             if raw is None:
                 continue
             try:
-                return min(max(float(str(raw).strip()), 0.0), cap)
+                return max(float(str(raw).strip()), 0.0)
             except ValueError:
-                continue  # HTTP-date form: fall through to the cap
-        return cap
+                continue  # HTTP-date form: treat as "no usable hint"
+        return None
 
 
 def _jwt_expiry_epoch(token: str) -> float:
-    """The ``exp`` claim, or 0.0 when it cannot be read.
+    """The ``exp`` claim, or the assumed life when it cannot be read.
 
     A local, signature-unverified decode: this only schedules the *next*
     refresh, and the authority on whether a token is good remains the 401 from
-    Backend-Service. 0.0 means "refresh now", so an unparseable token costs an
-    extra exchange rather than a surprise expiry mid-fetch.
+    Backend-Service. An unreadable claim therefore falls back to better-auth's
+    documented 15 minutes rather than to "expired" -- the latter would make
+    every single ``token()`` call an exchange, six-plus per run, against a
+    limiter that allows three every ten seconds.
     """
     try:
         segment = token.split(".")[1]
         padded = segment + "=" * (-len(segment) % 4)
         claims = json.loads(base64.urlsafe_b64decode(padded))
         return float(claims["exp"])
-    except Exception:  # noqa: BLE001 - any malformed shape means "refresh now"
-        return 0.0
+    except Exception:  # noqa: BLE001 - any malformed shape falls back
+        return time.time() + _ASSUMED_JWT_TTL_SECONDS
 
 
 class _TokenSource:
@@ -867,10 +890,17 @@ class _TokenSource:
         self._jwt_expires_at = 0.0
 
     def _exchange(self) -> str:
-        """Trade the cached session for a JWT, re-signing-in at most once."""
+        """Trade the cached session for a JWT, re-signing-in at most once.
+
+        Bounded by its own attempt budget. Gating this loop on the sign-in
+        allowance instead would mean that once a run had spent that allowance
+        -- on a rate-limited first sign-in, or on one legitimate dead-session
+        recovery -- every later refresh would raise without issuing a single
+        exchange, against a session that was still perfectly good.
+        """
         url = self._auth_url + _EXCHANGE_PATH
         last: _AuthStatusError | None = None
-        while self._sign_ins < _MAX_SIGN_INS:
+        for _attempt in range(_MAX_EXCHANGE_ATTEMPTS):
             session = self._session or self._sign_in()
             request = Request(
                 url,
@@ -892,18 +922,29 @@ class _TokenSource:
                 last = exc
                 self._session = None
         raise SourceError(
-            f"the token exchange at {url} kept returning HTTP 401 after "
-            f"{self._sign_ins} sign-ins as ${BACKEND_EMAIL_ENV}: "
+            f"the token exchange at {url} returned HTTP 401 on every one of "
+            f"{_MAX_EXCHANGE_ATTEMPTS} attempts as ${BACKEND_EMAIL_ENV}: "
             f"{last.detail if last else 'no detail'}. Check that the service account "
             "exists, is not banned, and holds catalog:read."
         )
 
     def _sign_in(self) -> str:
-        """Exchange the password for a session token. One retry on a 429."""
+        """Exchange the password for a session token. One retry on a 429.
+
+        Costs one unit of the sign-in allowance however many HTTP attempts it
+        takes -- the 429 retry is part of this sign-in, not a second one.
+        """
         url = self._auth_url + _SIGN_IN_PATH
+        if self._sign_ins >= _MAX_SIGN_INS:
+            raise SourceError(
+                f"signing in as ${BACKEND_EMAIL_ENV} at {url} already ran "
+                f"{self._sign_ins} times this run and the session it returns keeps coming "
+                "back dead. Check that the service account exists, is not banned, and that "
+                f"${BACKEND_PASSWORD_ENV} is current."
+            )
+        self._sign_ins += 1
         body = json.dumps({"email": self._email, "password": self._password}).encode("utf-8")
         for attempt in (1, 2):
-            self._sign_ins += 1
             request = Request(
                 url,
                 data=body,
@@ -919,7 +960,19 @@ class _TokenSource:
                 session = _auth_token_from(request, "sign-in")
             except _AuthStatusError as exc:
                 if exc.code == 429 and attempt == 1:
-                    delay = exc.retry_after_seconds(_SIGN_IN_RETRY_CAP_SECONDS)
+                    hint = exc.retry_hint_seconds()
+                    if hint is not None and hint > _SIGN_IN_RETRY_CAP_SECONDS:
+                        # The express limiter's window is 15 minutes. Sleeping
+                        # the cap and retrying into a window this long is a
+                        # guaranteed second refusal; the operator wants the
+                        # real number, not a truncated one.
+                        raise SourceError(
+                            f"sign-in as ${BACKEND_EMAIL_ENV} at {url} was rate limited and "
+                            f"asks for {hint:g}s, longer than the {_SIGN_IN_RETRY_CAP_SECONDS}s "
+                            "this run will wait. Re-run after that window, and check whether "
+                            "something else is signing in as this service account."
+                        ) from exc
+                    delay = hint if hint is not None else _SIGN_IN_RETRY_CAP_SECONDS
                     logger.warning(
                         "sign-in was rate limited; retrying once",
                         extra={"step": "backend_producer", "delay_seconds": delay},

--- a/scripts/catalog_parity_diff.py
+++ b/scripts/catalog_parity_diff.py
@@ -375,6 +375,12 @@ _DEFAULT_AUTH_ORIGIN = "https://dj.wxyc.org"
 
 _SIGN_IN_PATH = "/sign-in/email"
 _EXCHANGE_PATH = "/token"
+_SIGN_OUT_PATH = "/sign-out"
+
+# Cleanup budget. Deliberately not _HTTP_TIMEOUT_SECONDS: the export is
+# already done by the time this runs, and a hung revocation must not hold a
+# finished run open for five minutes.
+_SIGN_OUT_TIMEOUT_SECONDS = 30
 
 # better-auth's default JWT life, which Backend-Service does not override.
 # Only a fallback: it schedules the next refresh when a token's own `exp` is
@@ -836,6 +842,7 @@ class _TokenSource:
     """
 
     def __init__(self, base_url: str) -> None:
+        self._base_url = base_url
         self._static = os.environ.get(BACKEND_TOKEN_ENV) or None
         self._email = os.environ.get(BACKEND_EMAIL_ENV) or None
         self._password = os.environ.get(BACKEND_PASSWORD_ENV) or None
@@ -843,9 +850,18 @@ class _TokenSource:
         self._jwt: str | None = None
         self._jwt_expires_at = 0.0
         self._sign_ins = 0
+        self._auth_url = ""
+        self._origin = ""
 
         if self._static:
+            # Credentials, when they are also set, are this token's fallback
+            # rather than dead weight -- but resolving the auth URL now would
+            # refuse a plaintext one the run may never touch.
             return
+        self._enter_credential_mode()
+
+    def _enter_credential_mode(self) -> None:
+        """Validate the credential pair and pin the URL the password goes to."""
         if not (self._email and self._password):
             raise SourceError(
                 "no Backend service-account credentials: set "
@@ -855,11 +871,12 @@ class _TokenSource:
                 "JWTs expire after 15 minutes). Either way the principal needs catalog:read."
             )
         self._auth_url = _resolve_https_base_url(
-            os.environ.get(BACKEND_AUTH_URL_ENV) or _default_auth_url(base_url),
+            os.environ.get(BACKEND_AUTH_URL_ENV) or _default_auth_url(self._base_url),
             source_label=f"${BACKEND_AUTH_URL_ENV}",
             secret_description=f"the ${BACKEND_PASSWORD_ENV} sign-in password",
         )
         self._origin = os.environ.get(BACKEND_AUTH_ORIGIN_ENV) or _DEFAULT_AUTH_ORIGIN
+        self._static = None
 
     def token(self) -> str:
         """A bearer valid now -- minting or refreshing if it isn't."""
@@ -880,14 +897,72 @@ class _TokenSource:
         with the sign-in limiter.
         """
         if self._static:
-            raise SourceError(
-                f"the ${BACKEND_TOKEN_ENV} token was rejected (401) and cannot be refreshed: "
-                "better-auth JWTs expire after 15 minutes. Mint a fresh one, or set "
-                f"${BACKEND_EMAIL_ENV} + ${BACKEND_PASSWORD_ENV} so the harness can mint per "
-                "run -- which is what an unattended soak needs."
+            if not (self._email and self._password):
+                raise SourceError(
+                    f"the ${BACKEND_TOKEN_ENV} token was rejected (401) and cannot be "
+                    "refreshed: better-auth JWTs expire after 15 minutes. Mint a fresh one, "
+                    f"or set ${BACKEND_EMAIL_ENV} + ${BACKEND_PASSWORD_ENV} so the harness "
+                    "can mint per run -- which is what an unattended soak needs."
+                )
+            # Both are set, which is what an unattended run inherits if the
+            # secret #365 originally specified is left in place. Stranding it
+            # on a 15-minute-old JWT -- while holding everything needed to
+            # mint a fresh one -- would be a self-inflicted outage.
+            logger.warning(
+                "the pre-minted token was rejected; falling back to the credential pair",
+                extra={"step": "backend_producer"},
             )
+            _report(
+                f"WARNING: ${BACKEND_TOKEN_ENV} was rejected (401); minting from "
+                f"${BACKEND_EMAIL_ENV} instead"
+            )
+            self._enter_credential_mode()
+            return
         self._jwt = None
         self._jwt_expires_at = 0.0
+
+    def close(self) -> None:
+        """Revoke the session this run minted, if it minted one.
+
+        Backend-Service pins ``session.expiresIn`` to a year, so a session
+        left behind is a standalone catalog:read credential with a year to
+        run -- and ``admin/set-user-password`` revokes nothing, so a password
+        rotation would not clear it. Unattended runs would accumulate one per
+        run.
+
+        Best-effort by design: the export has already happened, and the worst
+        case of a failed revocation is the state every run had before this
+        existed. A token supplied through ``$BACKEND_CATALOG_TOKEN`` is not
+        this run's to revoke and is left alone.
+        """
+        session, self._session = self._session, None
+        self._jwt = None
+        self._jwt_expires_at = 0.0
+        if not session:
+            return
+        url = self._auth_url + _SIGN_OUT_PATH
+        request = Request(
+            url,
+            data=b"{}",
+            headers={
+                "Authorization": f"Bearer {session}",
+                "Content-Type": "application/json",
+                "Accept": "application/json",
+                "Origin": self._origin,
+            },
+        )
+        try:
+            with _opener.open(request, timeout=_SIGN_OUT_TIMEOUT_SECONDS):
+                pass
+        except OSError as exc:  # URLError/HTTPError are both OSError subclasses
+            # Named loudly: the leftover session outlives this process by a
+            # year, so an operator who sees this may want to revoke it by hand
+            # (POST /auth/admin/revoke-user-sessions).
+            logger.warning(
+                "could not sign out the parity session; it stays valid server-side",
+                extra={"step": "backend_producer", "error": str(exc)},
+            )
+            _report(f"WARNING: sign-out at {url} failed ({exc}); the session was not revoked")
 
     def _exchange(self) -> str:
         """Trade the cached session for a JWT, re-signing-in at most once.
@@ -1207,7 +1282,18 @@ def _build_library_db_from_backend(source: str, output_path: str) -> None:
     _require_absent(output_path, "backend")
     base_url = _resolve_backend_base_url(source)
     token_source = _TokenSource(base_url)
+    try:
+        _build_from_backend_snapshot(base_url, output_path, token_source)
+    finally:
+        # The failure path is the one that would leak most: a run that dies
+        # mid-export has still minted a year-long session.
+        token_source.close()
 
+
+def _build_from_backend_snapshot(
+    base_url: str, output_path: str, token_source: _TokenSource
+) -> None:
+    """Fetch a consistent snapshot and write it, with the token source live."""
     library_rows, compilation_rows = _fetch_consistent_snapshot(base_url, token_source)
     if not library_rows:
         # A broken export query, an over-narrow token scope, or a truncated

--- a/tests/unit/test_catalog_parity_diff.py
+++ b/tests/unit/test_catalog_parity_diff.py
@@ -251,6 +251,7 @@ class _BackendStub:
         # by pre-loading these.
         self.sign_in_statuses: list[int] = []
         self.exchange_statuses: list[int] = []
+        self.sign_out_statuses: list[int] = []
         # Everything this stub has minted and not superseded.
         self.sessions: set[str] = set()
         self.jwts: set[str] = set()
@@ -260,6 +261,10 @@ class _BackendStub:
     @property
     def sign_ins(self) -> int:
         return sum(1 for r in self.requests if r.path == "/auth/sign-in/email")
+
+    @property
+    def sign_outs(self) -> int:
+        return sum(1 for r in self.requests if r.path == "/auth/sign-out")
 
     @property
     def exchanges(self) -> int:
@@ -313,6 +318,15 @@ class _BackendStub:
 
             def do_POST(self) -> None:  # noqa: N802 - BaseHTTPRequestHandler API
                 self._record()
+                if self.path == "/auth/sign-out":
+                    forced = stub.sign_out_statuses.pop(0) if stub.sign_out_statuses else None
+                    if forced is not None:
+                        self._send_json(forced, {"message": "forced"})
+                        return
+                    bearer = (self.headers.get("Authorization") or "").removeprefix("Bearer ")
+                    stub.sessions.discard(bearer)
+                    self._send_json(200, {"success": True})
+                    return
                 if self.path != "/auth/sign-in/email":
                     self.send_error(404)
                     return
@@ -1657,6 +1671,102 @@ class TestServiceAccountMint:
             self._use_credentials(mod, monkeypatch, stub)
             mod._build_library_db_from_backend(stub.base_url, str(out))
 
+            assert stub.exchanges == 1
+        assert out.exists()
+
+    def test_signs_out_the_session_it_minted(self, tmp_path: Path, monkeypatch) -> None:
+        """A run must not leave a year-long credential behind it.
+
+        Backend-Service pins ``session.expiresIn`` to 365 days, so every
+        un-revoked sign-in is a standalone catalog:read credential that
+        survives a password rotation (``admin/set-user-password`` revokes
+        nothing). A daily soak would accumulate one per run.
+        """
+        mod = _load_module()
+        out = tmp_path / "backend.db"
+        with _BackendStub(
+            catalog_rows=[_catalog_row(legacy_release_id=72_101)],
+            cta_rows=[],
+            credentials=("catalog-parity@wxyc.org", "hunter2-but-48-bytes"),
+        ) as stub:
+            self._use_credentials(mod, monkeypatch, stub)
+            mod._build_library_db_from_backend(stub.base_url, str(out))
+
+            assert stub.sign_outs == 1
+            assert stub.sessions == set(), "the minted session must not outlive the run"
+        assert out.exists()
+
+    def test_signs_out_even_when_the_export_fails(self, tmp_path: Path, monkeypatch) -> None:
+        """The failure path is the one that would otherwise leak most."""
+        mod = _load_module()
+        out = tmp_path / "backend.db"
+        with _BackendStub(
+            catalog_rows=[],  # an empty catalog is a producer failure
+            cta_rows=[],
+            credentials=("catalog-parity@wxyc.org", "hunter2-but-48-bytes"),
+        ) as stub:
+            self._use_credentials(mod, monkeypatch, stub)
+            with pytest.raises(mod.SourceError):
+                mod._build_library_db_from_backend(stub.base_url, str(out))
+
+            assert stub.sign_outs == 1
+            assert stub.sessions == set()
+        assert not out.exists()
+
+    def test_a_failed_sign_out_does_not_fail_the_run(self, tmp_path: Path, monkeypatch) -> None:
+        """Best-effort: the export already succeeded, and the JWT expires anyway."""
+        mod = _load_module()
+        out = tmp_path / "backend.db"
+        with _BackendStub(
+            catalog_rows=[_catalog_row(legacy_release_id=72_101)],
+            cta_rows=[],
+            credentials=("catalog-parity@wxyc.org", "hunter2-but-48-bytes"),
+        ) as stub:
+            self._use_credentials(mod, monkeypatch, stub)
+            stub.sign_out_statuses = [500]
+            mod._build_library_db_from_backend(stub.base_url, str(out))
+
+            assert stub.sign_outs == 1
+        assert out.exists()
+
+    def test_nothing_to_sign_out_of_in_static_mode(self, tmp_path: Path, monkeypatch) -> None:
+        """A token the operator supplied is not this run's to revoke."""
+        mod = _load_module()
+        out = tmp_path / "backend.db"
+        with _BackendStub(catalog_rows=[_catalog_row()], cta_rows=[]) as stub:
+            monkeypatch.setenv(mod.BACKEND_TOKEN_ENV, "svc-token")
+            monkeypatch.delenv(mod.BACKEND_EMAIL_ENV, raising=False)
+            monkeypatch.delenv(mod.BACKEND_PASSWORD_ENV, raising=False)
+            mod._build_library_db_from_backend(stub.base_url, str(out))
+
+            assert stub.sign_outs == 0
+        assert out.exists()
+
+    def test_a_stale_static_token_falls_back_to_the_credentials(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """A leftover $BACKEND_CATALOG_TOKEN must not strand a run that can mint.
+
+        #365's original acceptance criterion asked for that secret, so an
+        unattended run may well inherit one alongside the credential pair.
+        Failing on a 15-minute-old JWT while holding everything needed to mint
+        a fresh one -- and advising the operator to set variables that are
+        already set -- is the wrong end state.
+        """
+        mod = _load_module()
+        out = tmp_path / "backend.db"
+        with _BackendStub(
+            catalog_rows=[_catalog_row(legacy_release_id=72_101)],
+            cta_rows=[],
+            credentials=("catalog-parity@wxyc.org", "hunter2-but-48-bytes"),
+        ) as stub:
+            monkeypatch.setenv(mod.BACKEND_TOKEN_ENV, "stale-token")
+            monkeypatch.setenv(mod.BACKEND_EMAIL_ENV, "catalog-parity@wxyc.org")
+            monkeypatch.setenv(mod.BACKEND_PASSWORD_ENV, "hunter2-but-48-bytes")
+            monkeypatch.setenv(mod.BACKEND_AUTH_URL_ENV, f"{stub.base_url}/auth")
+            mod._build_library_db_from_backend(stub.base_url, str(out))
+
+            assert stub.sign_ins == 1, "the fallback mints rather than giving up"
             assert stub.exchanges == 1
         assert out.exists()
 

--- a/tests/unit/test_catalog_parity_diff.py
+++ b/tests/unit/test_catalog_parity_diff.py
@@ -16,6 +16,7 @@ Two halves of the catalog-parity harness live in that script:
 
 from __future__ import annotations
 
+import base64
 import gzip
 import importlib.util
 import json
@@ -24,6 +25,7 @@ import sqlite3
 import subprocess
 import sys
 import threading
+import time
 from dataclasses import dataclass, field
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
@@ -174,10 +176,29 @@ def _catalog_row(**overrides: Any) -> dict[str, Any]:
     return row
 
 
+def _fake_jwt(expires_in_seconds: int = 900) -> str:
+    """A JWT-shaped string whose payload carries an ``exp``.
+
+    The producer never verifies a signature -- it decodes ``exp`` locally to
+    decide when to refresh -- so a real key would only make the fixture
+    slower. The signature segment is deliberately garbage.
+    """
+    payload = {"exp": int(time.time()) + expires_in_seconds, "role": "member"}
+
+    def seg(obj: dict[str, Any]) -> str:
+        return base64.urlsafe_b64encode(json.dumps(obj).encode()).rstrip(b"=").decode()
+
+    return f"{seg({'alg': 'EdDSA'})}.{seg(payload)}.not-a-signature"
+
+
 @dataclass
 class _RecordedRequest:
     path: str
     authorization: str | None
+    # better-auth's CSRF guard rejects an origin-less sign-in, so the mint
+    # path has to send one -- which no test could assert on while this stub
+    # recorded only (path, authorization).
+    origin: str | None = None
 
 
 class _BackendStub:
@@ -186,6 +207,14 @@ class _BackendStub:
     Serves gzipped NDJSON with a ``Last-Modified`` watermark, records every
     request, and exposes ``on_catalog_fetch`` so a test can advance the
     watermark mid-pair to exercise the torn-snapshot re-fetch rule.
+
+    It also stands in for the two auth-service endpoints the producer mints
+    through (``POST /auth/sign-in/email`` -> session, ``GET /auth/token`` ->
+    JWT). Passing ``credentials`` turns on bearer enforcement: the exports
+    then 401 anything but a JWT this stub actually issued, which is what
+    makes the refresh path testable. Left at ``None`` (the default), any
+    bearer is accepted and the auth endpoints simply go unused -- the regime
+    every pre-#365 test in this file runs under.
     """
 
     def __init__(
@@ -194,15 +223,39 @@ class _BackendStub:
         cta_rows: list[dict[str, Any]],
         gzip_body: bool = True,
         last_modified: str = _LM_A,
+        credentials: tuple[str, str] | None = None,
+        jwt_ttl_seconds: int = 900,
     ) -> None:
         self.catalog_rows = catalog_rows
         self.cta_rows = cta_rows
         self.gzip_body = gzip_body
         self.last_modified = last_modified
+        self.credentials = credentials
+        self.jwt_ttl_seconds = jwt_ttl_seconds
         self.requests: list[_RecordedRequest] = []
         self.on_catalog_fetch: Callable[[], None] | None = None
+        # Queues of forced statuses, popped left-to-right; empty means "behave
+        # normally". A test drives 429-then-200, or a 401 from the exchange,
+        # by pre-loading these.
+        self.sign_in_statuses: list[int] = []
+        self.exchange_statuses: list[int] = []
+        # Everything this stub has minted and not superseded.
+        self.sessions: set[str] = set()
+        self.jwts: set[str] = set()
         self._server = ThreadingHTTPServer(("127.0.0.1", 0), self._handler_class())
         self._thread = threading.Thread(target=self._server.serve_forever, daemon=True)
+
+    @property
+    def sign_ins(self) -> int:
+        return sum(1 for r in self.requests if r.path == "/auth/sign-in/email")
+
+    @property
+    def exchanges(self) -> int:
+        return sum(1 for r in self.requests if r.path == "/auth/token")
+
+    @property
+    def export_requests(self) -> list[_RecordedRequest]:
+        return [r for r in self.requests if not r.path.startswith("/auth/")]
 
     @property
     def base_url(self) -> str:
@@ -227,8 +280,74 @@ class _BackendStub:
             def log_message(self, *args: object) -> None:  # keep pytest output clean
                 pass
 
+            def _record(self) -> None:
+                stub.requests.append(
+                    _RecordedRequest(
+                        self.path,
+                        self.headers.get("Authorization"),
+                        self.headers.get("Origin"),
+                    )
+                )
+
+            def _send_json(self, status: int, payload: dict[str, Any], **headers: str) -> None:
+                body = json.dumps(payload).encode("utf-8")
+                self.send_response(status)
+                self.send_header("Content-Type", "application/json")
+                for name, value in headers.items():
+                    self.send_header(name.replace("_", "-"), value)
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+
+            def do_POST(self) -> None:  # noqa: N802 - BaseHTTPRequestHandler API
+                self._record()
+                if self.path != "/auth/sign-in/email":
+                    self.send_error(404)
+                    return
+                length = int(self.headers.get("Content-Length") or 0)
+                body = json.loads(self.rfile.read(length) or b"{}")
+                forced = stub.sign_in_statuses.pop(0) if stub.sign_in_statuses else None
+                if forced == 429:
+                    # better-auth's own limiter emits X-Retry-After, NOT the
+                    # standard header the express limiter sends -- a producer
+                    # that reads only one of the two waits the wrong amount.
+                    self._send_json(429, {"message": "Too many requests"}, X_Retry_After="1")
+                    return
+                if forced is not None:
+                    self._send_json(forced, {"message": "forced"})
+                    return
+                if stub.credentials is not None and (
+                    body.get("email"),
+                    body.get("password"),
+                ) != stub.credentials:
+                    self._send_json(401, {"message": "Invalid email or password"})
+                    return
+                session = f"session-{len(stub.sessions) + 1}"
+                stub.sessions.add(session)
+                self._send_json(200, {"token": session, "user": {"id": "svc-user"}})
+
             def do_GET(self) -> None:  # noqa: N802 - BaseHTTPRequestHandler API
-                stub.requests.append(_RecordedRequest(self.path, self.headers.get("Authorization")))
+                if self.path == "/auth/token":
+                    self._record()
+                    forced = stub.exchange_statuses.pop(0) if stub.exchange_statuses else None
+                    if forced is not None:
+                        self._send_json(forced, {"message": "forced"})
+                        return
+                    bearer = (self.headers.get("Authorization") or "").removeprefix("Bearer ")
+                    if bearer not in stub.sessions:
+                        self._send_json(401, {"message": "Unauthorized"})
+                        return
+                    jwt = _fake_jwt(stub.jwt_ttl_seconds)
+                    stub.jwts.add(jwt)
+                    self._send_json(200, {"token": jwt})
+                    return
+
+                self._record()
+                if stub.credentials is not None:
+                    bearer = (self.headers.get("Authorization") or "").removeprefix("Bearer ")
+                    if bearer not in stub.jwts:
+                        self._send_json(401, {"error": "Unauthorized: Invalid or expired token."})
+                        return
                 if self.path == "/library/catalog":
                     rows = stub.catalog_rows
                 elif self.path == "/library/catalog/compilation-tracks":

--- a/tests/unit/test_catalog_parity_diff.py
+++ b/tests/unit/test_catalog_parity_diff.py
@@ -316,10 +316,14 @@ class _BackendStub:
                 if forced is not None:
                     self._send_json(forced, {"message": "forced"})
                     return
-                if stub.credentials is not None and (
-                    body.get("email"),
-                    body.get("password"),
-                ) != stub.credentials:
+                if (
+                    stub.credentials is not None
+                    and (
+                        body.get("email"),
+                        body.get("password"),
+                    )
+                    != stub.credentials
+                ):
                     self._send_json(401, {"message": "Invalid email or password"})
                     return
                 session = f"session-{len(stub.sessions) + 1}"
@@ -410,12 +414,28 @@ class _RedirectingStub:
             def log_message(self, *args: object) -> None:
                 pass
 
-            def do_GET(self) -> None:  # noqa: N802 - BaseHTTPRequestHandler API
-                stub.requests.append(_RecordedRequest(self.path, self.headers.get("Authorization")))
+            def _redirect(self) -> None:
+                stub.requests.append(
+                    _RecordedRequest(
+                        self.path,
+                        self.headers.get("Authorization"),
+                        self.headers.get("Origin"),
+                    )
+                )
                 self.send_response(stub.status)
                 self.send_header("Location", stub.target_base + self.path)
                 self.send_header("Content-Length", "0")
                 self.end_headers()
+
+            def do_GET(self) -> None:  # noqa: N802 - BaseHTTPRequestHandler API
+                self._redirect()
+
+            # A proxy that redirects GETs redirects POSTs too, and the POST is
+            # the dangerous one: it carries the sign-in password.
+            def do_POST(self) -> None:  # noqa: N802 - BaseHTTPRequestHandler API
+                length = int(self.headers.get("Content-Length") or 0)
+                self.rfile.read(length)
+                self._redirect()
 
         return _Handler
 
@@ -1349,6 +1369,279 @@ class TestBackendProducer:
             ).fetchall() == [(72_101,)]
         finally:
             conn.close()
+
+
+class TestServiceAccountMint:
+    """Minting and refreshing the Backend service-account JWT (#365).
+
+    The JWT that ``requirePermissions`` accepts lives 15 minutes (better-auth's
+    default, which Backend-Service does not override), so it cannot be a static
+    CI secret for a soak that runs 7+ consecutive days: what CI stores is the
+    service account's *password*, and the producer mints per run.
+
+    The load-bearing constraint on how it refreshes is the auth service's rate
+    limiter. ``/auth/sign-in`` is capped at 10 per 15 minutes by the express
+    limiter and 3 per 10 seconds by better-auth's own; ``/auth/token`` is
+    exempt from the former and generous under the latter. So the *ordinary*
+    refresh re-exchanges against a cached session, and only an exchange that
+    itself 401s costs a second sign-in -- capped at one per process, or a
+    broken credential becomes a sign-in storm against a limiter shared with
+    every real DJ logging in.
+    """
+
+    @staticmethod
+    def _use_credentials(mod, monkeypatch, stub) -> None:
+        monkeypatch.delenv(mod.BACKEND_TOKEN_ENV, raising=False)
+        monkeypatch.setenv(mod.BACKEND_EMAIL_ENV, "catalog-parity@wxyc.org")
+        monkeypatch.setenv(mod.BACKEND_PASSWORD_ENV, "hunter2-but-48-bytes")
+        monkeypatch.setenv(mod.BACKEND_AUTH_URL_ENV, f"{stub.base_url}/auth")
+
+    def test_mints_a_token_from_the_credential_pair(self, tmp_path: Path, monkeypatch) -> None:
+        mod = _load_module()
+        out = tmp_path / "backend.db"
+        with _BackendStub(
+            catalog_rows=[_catalog_row(legacy_release_id=72_101)],
+            cta_rows=[],
+            credentials=("catalog-parity@wxyc.org", "hunter2-but-48-bytes"),
+        ) as stub:
+            self._use_credentials(mod, monkeypatch, stub)
+            mod._build_library_db_from_backend(stub.base_url, str(out))
+
+            assert stub.sign_ins == 1
+            assert stub.exchanges == 1
+            # Every export carried a bearer this stub actually issued.
+            for request in stub.export_requests:
+                assert (request.authorization or "").removeprefix("Bearer ") in stub.jwts
+            # better-auth's CSRF guard rejects an origin-less sign-in.
+            sign_in = next(r for r in stub.requests if r.path == "/auth/sign-in/email")
+            assert sign_in.origin == mod._DEFAULT_AUTH_ORIGIN
+        assert out.exists()
+
+    def test_refreshes_by_re_exchanging_not_re_signing_in(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """A 401 mid-run costs an exchange, never a sign-in.
+
+        This is the assertion the rate limiter makes load-bearing: a run that
+        outlives its 15-minute token (three snapshot attempts x two exports,
+        each with a 300s budget) must not spend a sign-in per refresh.
+        """
+        mod = _load_module()
+        out = tmp_path / "backend.db"
+        with _BackendStub(
+            catalog_rows=[_catalog_row(legacy_release_id=72_101)],
+            cta_rows=[],
+            credentials=("catalog-parity@wxyc.org", "hunter2-but-48-bytes"),
+        ) as stub:
+            self._use_credentials(mod, monkeypatch, stub)
+
+            # Expire the minted JWT the instant the first export is served, so
+            # the CTA export gets a 401 the way a real 15-minute expiry would
+            # deliver one: mid-run, on a token that was valid when it left.
+            def expire_everything() -> None:
+                stub.jwts.clear()
+
+            stub.on_catalog_fetch = expire_everything
+            mod._build_library_db_from_backend(stub.base_url, str(out))
+
+            assert stub.sign_ins == 1, "a refresh must not re-sign-in"
+            assert stub.exchanges == 2
+        assert out.exists()
+
+    def test_re_signs_in_once_when_the_exchange_itself_401s(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """A dead session is the one thing that legitimately costs a sign-in."""
+        mod = _load_module()
+        out = tmp_path / "backend.db"
+        with _BackendStub(
+            catalog_rows=[_catalog_row(legacy_release_id=72_101)],
+            cta_rows=[],
+            credentials=("catalog-parity@wxyc.org", "hunter2-but-48-bytes"),
+        ) as stub:
+            self._use_credentials(mod, monkeypatch, stub)
+            stub.exchange_statuses = [401]
+            mod._build_library_db_from_backend(stub.base_url, str(out))
+
+            assert stub.sign_ins == 2
+            assert stub.exchanges == 2
+        assert out.exists()
+
+    def test_gives_up_rather_than_looping_on_a_dead_credential(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        mod = _load_module()
+        out = tmp_path / "backend.db"
+        with _BackendStub(
+            catalog_rows=[_catalog_row()],
+            cta_rows=[],
+            credentials=("catalog-parity@wxyc.org", "hunter2-but-48-bytes"),
+        ) as stub:
+            self._use_credentials(mod, monkeypatch, stub)
+            stub.exchange_statuses = [401, 401, 401, 401]
+            with pytest.raises(mod.SourceError, match="401"):
+                mod._build_library_db_from_backend(stub.base_url, str(out))
+
+            assert stub.sign_ins <= 2, "a broken credential must not storm the limiter"
+        assert not out.exists()
+
+    def test_retries_a_rate_limited_sign_in_once(self, tmp_path: Path, monkeypatch) -> None:
+        """429 carries X-Retry-After from better-auth, Retry-After from express."""
+        mod = _load_module()
+        out = tmp_path / "backend.db"
+        with _BackendStub(
+            catalog_rows=[_catalog_row(legacy_release_id=72_101)],
+            cta_rows=[],
+            credentials=("catalog-parity@wxyc.org", "hunter2-but-48-bytes"),
+        ) as stub:
+            self._use_credentials(mod, monkeypatch, stub)
+            stub.sign_in_statuses = [429]
+            monkeypatch.setattr(mod.time, "sleep", lambda _seconds: None)
+            mod._build_library_db_from_backend(stub.base_url, str(out))
+
+            assert stub.sign_ins == 2
+        assert out.exists()
+
+    def test_a_second_429_fails_with_the_status(self, tmp_path: Path, monkeypatch) -> None:
+        mod = _load_module()
+        out = tmp_path / "backend.db"
+        with _BackendStub(
+            catalog_rows=[_catalog_row()],
+            cta_rows=[],
+            credentials=("catalog-parity@wxyc.org", "hunter2-but-48-bytes"),
+        ) as stub:
+            self._use_credentials(mod, monkeypatch, stub)
+            stub.sign_in_statuses = [429, 429]
+            monkeypatch.setattr(mod.time, "sleep", lambda _seconds: None)
+            with pytest.raises(mod.SourceError, match="429"):
+                mod._build_library_db_from_backend(stub.base_url, str(out))
+        assert not out.exists()
+
+    def test_a_pre_minted_token_still_wins(self, tmp_path: Path, monkeypatch) -> None:
+        """Static mode is how an operator runs a one-off without the password."""
+        mod = _load_module()
+        out = tmp_path / "backend.db"
+        with _BackendStub(catalog_rows=[_catalog_row()], cta_rows=[]) as stub:
+            monkeypatch.setenv(mod.BACKEND_TOKEN_ENV, "svc-token")
+            monkeypatch.setenv(mod.BACKEND_EMAIL_ENV, "catalog-parity@wxyc.org")
+            monkeypatch.setenv(mod.BACKEND_PASSWORD_ENV, "hunter2-but-48-bytes")
+            mod._build_library_db_from_backend(stub.base_url, str(out))
+
+            assert stub.sign_ins == 0
+            assert stub.exchanges == 0
+            assert all(r.authorization == "Bearer svc-token" for r in stub.export_requests)
+
+    def test_an_expired_static_token_says_what_to_do_about_it(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """A 401 on a static token is terminal -- there is nothing to refresh from."""
+        mod = _load_module()
+        out = tmp_path / "backend.db"
+        with _BackendStub(
+            catalog_rows=[_catalog_row()],
+            cta_rows=[],
+            credentials=("catalog-parity@wxyc.org", "hunter2-but-48-bytes"),
+        ) as stub:
+            monkeypatch.setenv(mod.BACKEND_TOKEN_ENV, "stale-token")
+            monkeypatch.delenv(mod.BACKEND_EMAIL_ENV, raising=False)
+            monkeypatch.delenv(mod.BACKEND_PASSWORD_ENV, raising=False)
+            with pytest.raises(mod.SourceError, match=mod.BACKEND_PASSWORD_ENV):
+                mod._build_library_db_from_backend(stub.base_url, str(out))
+            assert stub.sign_ins == 0
+        assert not out.exists()
+
+    def test_re_exchanges_a_token_that_is_about_to_expire(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """Don't start a 300-second fetch with 30 seconds of token left."""
+        mod = _load_module()
+        out = tmp_path / "backend.db"
+        with _BackendStub(
+            catalog_rows=[_catalog_row(legacy_release_id=72_101)],
+            cta_rows=[],
+            credentials=("catalog-parity@wxyc.org", "hunter2-but-48-bytes"),
+            jwt_ttl_seconds=30,
+        ) as stub:
+            self._use_credentials(mod, monkeypatch, stub)
+            mod._build_library_db_from_backend(stub.base_url, str(out))
+
+            # One exchange per export: each one saw a token inside the margin.
+            assert stub.exchanges == 2
+            assert stub.sign_ins == 1
+        assert out.exists()
+
+    def test_requires_a_token_or_the_credential_pair(self, tmp_path: Path, monkeypatch) -> None:
+        mod = _load_module()
+        for var in (mod.BACKEND_TOKEN_ENV, mod.BACKEND_EMAIL_ENV, mod.BACKEND_PASSWORD_ENV):
+            monkeypatch.delenv(var, raising=False)
+        with pytest.raises(mod.SourceError) as excinfo:
+            mod._build_library_db_from_backend("https://api.wxyc.org", str(tmp_path / "b.db"))
+        # Both routes named: an operator reading this shouldn't have to guess
+        # which of the two credential shapes the harness wanted.
+        assert mod.BACKEND_TOKEN_ENV in str(excinfo.value)
+        assert mod.BACKEND_EMAIL_ENV in str(excinfo.value)
+        assert mod.BACKEND_PASSWORD_ENV in str(excinfo.value)
+
+    def test_refuses_a_plaintext_auth_url(self, tmp_path: Path, monkeypatch) -> None:
+        """The password is on that wire -- the message must say so."""
+        mod = _load_module()
+        monkeypatch.delenv(mod.BACKEND_TOKEN_ENV, raising=False)
+        monkeypatch.setenv(mod.BACKEND_EMAIL_ENV, "catalog-parity@wxyc.org")
+        monkeypatch.setenv(mod.BACKEND_PASSWORD_ENV, "hunter2-but-48-bytes")
+        monkeypatch.setenv(mod.BACKEND_AUTH_URL_ENV, "http://auth.example.org/auth")
+        with pytest.raises(mod.SourceError) as excinfo:
+            mod._build_library_db_from_backend("https://api.wxyc.org", str(tmp_path / "b.db"))
+        message = str(excinfo.value)
+        assert "https" in message
+        assert mod.BACKEND_AUTH_URL_ENV in message
+        assert mod.BACKEND_PASSWORD_ENV in message
+        # Must not misname the secret at risk: no bearer token is involved here.
+        assert mod.BACKEND_TOKEN_ENV not in message
+
+    def test_refuses_a_cross_origin_redirect_on_sign_in(self, tmp_path: Path, monkeypatch) -> None:
+        """A 302 out of sign-in would replay the password to a host nobody named."""
+        mod = _load_module()
+        out = tmp_path / "backend.db"
+        with _BackendStub(
+            catalog_rows=[_catalog_row()],
+            cta_rows=[],
+            credentials=("catalog-parity@wxyc.org", "hunter2-but-48-bytes"),
+        ) as elsewhere:
+            with _RedirectingStub(elsewhere.base_url) as redirector:
+                self._use_credentials(mod, monkeypatch, elsewhere)
+                monkeypatch.setenv(mod.BACKEND_AUTH_URL_ENV, f"{redirector.base_url}/auth")
+                with pytest.raises(mod.SourceError, match="redirect"):
+                    mod._build_library_db_from_backend(elsewhere.base_url, str(out))
+            assert elsewhere.sign_ins == 0
+        assert not out.exists()
+
+    def test_derives_the_auth_url_from_the_backend_source(self, monkeypatch) -> None:
+        """One flag, not two: --backend-source https://api.wxyc.org implies /auth."""
+        mod = _load_module()
+        monkeypatch.delenv(mod.BACKEND_AUTH_URL_ENV, raising=False)
+        assert mod._default_auth_url("https://api.wxyc.org") == "https://api.wxyc.org/auth"
+        assert mod._default_auth_url("https://api.wxyc.org/") == "https://api.wxyc.org/auth"
+
+    def test_never_prints_the_session_token_or_password(
+        self, tmp_path: Path, monkeypatch, capsys
+    ) -> None:
+        """A sign-in success body carries a session token; it must not surface."""
+        mod = _load_module()
+        out = tmp_path / "backend.db"
+        with _BackendStub(
+            catalog_rows=[_catalog_row(legacy_release_id=72_101)],
+            cta_rows=[],
+            credentials=("catalog-parity@wxyc.org", "hunter2-but-48-bytes"),
+        ) as stub:
+            self._use_credentials(mod, monkeypatch, stub)
+            mod._build_library_db_from_backend(stub.base_url, str(out))
+            printed = capsys.readouterr()
+            haystack = printed.out + printed.err
+            assert "hunter2-but-48-bytes" not in haystack
+            for session in stub.sessions:
+                assert session not in haystack
+            for jwt in stub.jwts:
+                assert jwt not in haystack
 
 
 class TestSharedSchemaConstants:

--- a/tests/unit/test_catalog_parity_diff.py
+++ b/tests/unit/test_catalog_parity_diff.py
@@ -176,14 +176,19 @@ def _catalog_row(**overrides: Any) -> dict[str, Any]:
     return row
 
 
-def _fake_jwt(expires_in_seconds: int = 900) -> str:
+def _fake_jwt(expires_in_seconds: int = 900, *, unreadable_exp: bool = False) -> str:
     """A JWT-shaped string whose payload carries an ``exp``.
 
     The producer never verifies a signature -- it decodes ``exp`` locally to
     decide when to refresh -- so a real key would only make the fixture
     slower. The signature segment is deliberately garbage.
+
+    ``unreadable_exp`` produces the shape a claim-format change upstream would
+    hand us: still a JWT, still accepted by Backend-Service, but with nothing
+    the local decode can turn into an epoch.
     """
-    payload = {"exp": int(time.time()) + expires_in_seconds, "role": "member"}
+    exp: Any = "not-an-epoch" if unreadable_exp else int(time.time()) + expires_in_seconds
+    payload = {"exp": exp, "role": "member"}
 
     def seg(obj: dict[str, Any]) -> str:
         return base64.urlsafe_b64encode(json.dumps(obj).encode()).rstrip(b"=").decode()
@@ -225,6 +230,7 @@ class _BackendStub:
         last_modified: str = _LM_A,
         credentials: tuple[str, str] | None = None,
         jwt_ttl_seconds: int = 900,
+        unreadable_jwt_exp: bool = False,
     ) -> None:
         self.catalog_rows = catalog_rows
         self.cta_rows = cta_rows
@@ -232,6 +238,12 @@ class _BackendStub:
         self.last_modified = last_modified
         self.credentials = credentials
         self.jwt_ttl_seconds = jwt_ttl_seconds
+        self.unreadable_jwt_exp = unreadable_jwt_exp
+        # What a forced 429 puts in its retry hint. The express limiter's
+        # window is 15 minutes, so a hint far longer than any retry the
+        # producer is willing to wait out is the realistic case, not an
+        # exotic one.
+        self.sign_in_retry_after = "1"
         self.requests: list[_RecordedRequest] = []
         self.on_catalog_fetch: Callable[[], None] | None = None
         # Queues of forced statuses, popped left-to-right; empty means "behave
@@ -311,7 +323,11 @@ class _BackendStub:
                     # better-auth's own limiter emits X-Retry-After, NOT the
                     # standard header the express limiter sends -- a producer
                     # that reads only one of the two waits the wrong amount.
-                    self._send_json(429, {"message": "Too many requests"}, X_Retry_After="1")
+                    self._send_json(
+                        429,
+                        {"message": "Too many requests"},
+                        X_Retry_After=stub.sign_in_retry_after,
+                    )
                     return
                 if forced is not None:
                     self._send_json(forced, {"message": "forced"})
@@ -341,7 +357,7 @@ class _BackendStub:
                     if bearer not in stub.sessions:
                         self._send_json(401, {"message": "Unauthorized"})
                         return
-                    jwt = _fake_jwt(stub.jwt_ttl_seconds)
+                    jwt = _fake_jwt(stub.jwt_ttl_seconds, unreadable_exp=stub.unreadable_jwt_exp)
                     stub.jwts.add(jwt)
                     self._send_json(200, {"token": jwt})
                     return
@@ -1467,6 +1483,59 @@ class TestServiceAccountMint:
             assert stub.exchanges == 2
         assert out.exists()
 
+    def test_a_retried_sign_in_does_not_cost_the_refresh_path(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """The 429 retry is part of one sign-in, not a second one.
+
+        Counting HTTP attempts rather than sign-ins conflates the two budgets:
+        a single rate-limited-then-successful sign-in would exhaust the
+        allowance, and every later refresh -- against a session that is
+        perfectly good -- would abort without issuing an exchange at all.
+        """
+        mod = _load_module()
+        out = tmp_path / "backend.db"
+        with _BackendStub(
+            catalog_rows=[_catalog_row(legacy_release_id=72_101)],
+            cta_rows=[],
+            credentials=("catalog-parity@wxyc.org", "hunter2-but-48-bytes"),
+        ) as stub:
+            self._use_credentials(mod, monkeypatch, stub)
+            stub.sign_in_statuses = [429]
+            monkeypatch.setattr(mod.time, "sleep", lambda _seconds: None)
+            stub.on_catalog_fetch = stub.jwts.clear
+            mod._build_library_db_from_backend(stub.base_url, str(out))
+
+            assert stub.exchanges == 2, "the refresh must survive a retried sign-in"
+            assert stub.sign_ins == 2, "one 429 plus its retry -- and no more"
+        assert out.exists()
+
+    def test_recovering_a_dead_session_does_not_end_the_refresh_path(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """Spending the sign-in allowance must not disable re-exchanging.
+
+        The allowance exists to bound sign-ins against a limiter shared with
+        every DJ logging in. Gating the *exchange* loop on it as well means a
+        run that legitimately recovers one dead session can never refresh
+        again -- which is the whole reason the token source exists.
+        """
+        mod = _load_module()
+        out = tmp_path / "backend.db"
+        with _BackendStub(
+            catalog_rows=[_catalog_row(legacy_release_id=72_101)],
+            cta_rows=[],
+            credentials=("catalog-parity@wxyc.org", "hunter2-but-48-bytes"),
+        ) as stub:
+            self._use_credentials(mod, monkeypatch, stub)
+            stub.exchange_statuses = [401]  # spends the second sign-in
+            stub.on_catalog_fetch = stub.jwts.clear  # then forces a refresh
+            mod._build_library_db_from_backend(stub.base_url, str(out))
+
+            assert stub.sign_ins == 2
+            assert stub.exchanges == 3, "the post-recovery refresh must re-exchange"
+        assert out.exists()
+
     def test_gives_up_rather_than_looping_on_a_dead_credential(
         self, tmp_path: Path, monkeypatch
     ) -> None:
@@ -1516,6 +1585,80 @@ class TestServiceAccountMint:
             with pytest.raises(mod.SourceError, match="429"):
                 mod._build_library_db_from_backend(stub.base_url, str(out))
         assert not out.exists()
+
+    def test_a_retry_hint_longer_than_the_cap_fails_fast(self, tmp_path: Path, monkeypatch) -> None:
+        """Truncating the hint buys a certain second 429 instead of an answer.
+
+        The express limiter's window is 15 minutes, so its draft-7 hint can
+        legitimately be ~900s. Waiting the 10s cap and retrying anyway is a
+        guaranteed refusal; the operator wants the real number.
+        """
+        mod = _load_module()
+        out = tmp_path / "backend.db"
+        slept: list[float] = []
+        with _BackendStub(
+            catalog_rows=[_catalog_row()],
+            cta_rows=[],
+            credentials=("catalog-parity@wxyc.org", "hunter2-but-48-bytes"),
+        ) as stub:
+            self._use_credentials(mod, monkeypatch, stub)
+            stub.sign_in_statuses = [429]
+            stub.sign_in_retry_after = "900"
+            monkeypatch.setattr(mod.time, "sleep", slept.append)
+            with pytest.raises(mod.SourceError, match="900"):
+                mod._build_library_db_from_backend(stub.base_url, str(out))
+
+            assert slept == [], "no point sleeping out a window this run cannot clear"
+            assert stub.sign_ins == 1
+        assert not out.exists()
+
+    def test_the_refresh_margin_covers_a_whole_fetch(self, tmp_path: Path, monkeypatch) -> None:
+        """A token must not start a fetch that can outlive it.
+
+        A fetch runs for up to ``_HTTP_TIMEOUT_SECONDS``, so a token with less
+        life than that is not usable even though it has not expired yet. The
+        401 retry would paper over it -- at the cost of re-fetching a whole
+        export.
+        """
+        mod = _load_module()
+        assert mod._JWT_REFRESH_MARGIN_SECONDS >= mod._HTTP_TIMEOUT_SECONDS
+
+        out = tmp_path / "backend.db"
+        with _BackendStub(
+            catalog_rows=[_catalog_row(legacy_release_id=72_101)],
+            cta_rows=[],
+            credentials=("catalog-parity@wxyc.org", "hunter2-but-48-bytes"),
+            jwt_ttl_seconds=mod._HTTP_TIMEOUT_SECONDS - 100,
+        ) as stub:
+            self._use_credentials(mod, monkeypatch, stub)
+            mod._build_library_db_from_backend(stub.base_url, str(out))
+
+            assert stub.exchanges == 2, "a token too short for a fetch is not reused"
+        assert out.exists()
+
+    def test_an_unreadable_exp_costs_one_exchange_not_one_per_call(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """An unparseable ``exp`` must not turn every call into an exchange.
+
+        Treating it as "expired" re-exchanges on every ``token()`` -- 6+ per
+        run across three snapshot attempts x two exports -- against
+        better-auth's 3-per-10s window. Assuming the documented 15-minute life
+        bounds it, and the 401 retry remains the authority.
+        """
+        mod = _load_module()
+        out = tmp_path / "backend.db"
+        with _BackendStub(
+            catalog_rows=[_catalog_row(legacy_release_id=72_101)],
+            cta_rows=[],
+            credentials=("catalog-parity@wxyc.org", "hunter2-but-48-bytes"),
+            unreadable_jwt_exp=True,
+        ) as stub:
+            self._use_credentials(mod, monkeypatch, stub)
+            mod._build_library_db_from_backend(stub.base_url, str(out))
+
+            assert stub.exchanges == 1
+        assert out.exists()
 
     def test_a_pre_minted_token_still_wins(self, tmp_path: Path, monkeypatch) -> None:
         """Static mode is how an operator runs a one-off without the password."""


### PR DESCRIPTION
## Why

`scripts/catalog_parity_diff.py`'s Backend producer read its bearer from `$BACKEND_CATALOG_TOKEN`, and no such credential existed — so the harness had never run against prod, and the "7 consecutive clean parity days" criterion on [wiki#89](https://github.com/WXYC/wiki/issues/89) could not start.

Investigating why nobody had simply minted one turned up the reason the ticket's own acceptance criterion ("`BACKEND_CATALOG_TOKEN` set as a repo secret") is not implementable as written:

- `requirePermissions` accepts **only** a JWKS-verified JWT (`shared/authentication/src/auth.middleware.ts:58-76`) — a better-auth session token gets a 401 there.
- Those JWTs live **15 minutes**. Backend-Service registers `jwt({ jwt: { definePayload } })` and never sets `expirationTime`, so better-auth's `"15m"` default applies.
- The long-lived session is no help either: it rotates at the 1-day `updateAge`, and the gate would reject it anyway.

A 15-minute token cannot be a stored secret for a soak measured in days. So the stored credential is the service account's **password**, and the harness mints per run — the ticket's own branch 2 ("if short-lived, the harness gains a refresh path").

## What changed

`_TokenSource` signs in at `/auth/sign-in/email`, exchanges the session for a JWT at `/auth/token`, and refreshes as the run needs it. `$BACKEND_CATALOG_TOKEN` still short-circuits the whole path for a one-off run with a token in hand — which is why the ~20 existing producer tests are untouched.

**The refresh asymmetry is the design**, and the rate limiters dictate it: `/auth/sign-in` is capped at 10 per 15 min (express, per IP — `apps/auth/app.ts:337`) and 3 per 10 s (better-auth's own), while `/auth/token` is exempt from the first. A parity run can outlive 15 minutes (three snapshot attempts × two exports, each with a 300 s budget), so an ordinary refresh **re-exchanges** against the cached session; only an exchange that itself 401s spends a second sign-in, capped at one per process. A rate-limited sign-in retries once, reading both `Retry-After` and better-auth's `X-Retry-After` (it sends only the latter).

Supporting changes the mint path forced:

- `HTTPError` is caught ahead of the `(URLError, OSError)` clause in the export fetch — that clause collapsed every status into one message, making "the token just expired" indistinguishable from "the export is broken".
- The URL validator is parameterized by what's at risk. Two URLs now carry a secret; a message naming the bearer token when the *password* is on the wire sends the operator to the wrong env var.
- The cross-origin redirect guard covers the mint calls, so a 302 out of sign-in can't replay the password to a host nobody named.
- Non-2xx auth bodies are surfaced (truncated) because they carry a diagnosis; 2xx bodies never are, because they carry the credential.

## Provisioning decisions worth reviewing

Documented in `docs/architecture.md` → *Minting and rotating the parity service account*:

1. **`admin/create-user`, not this org's `admin/provision-user`.** The latter emails an account-setup link whose token is valid for **7 days** (`account-setup-token.ts:18`) — the length of the soak — and setting a password afterwards does not revoke it. better-auth's admin endpoint takes the password directly and mints no token. It's a supported path here, not a workaround: BS has a `hooks.after` branch auto-verifying its users (BS#1118) and the `user.create.after` hook inserts the org `member` row that carries the permission.
2. **`member` role.** Every WXYC role has `catalog:read`; `member` is the floor. Residual grants are `bin:read/write` and `flowsheet:read` — no catalog or flowsheet write. A catalog-read-only role would mean a new entry in the shared `WXYCRole` union across three repos.
3. **No `role` field in the create-user body** — that's better-auth's *global* admin role, not the org role.

## Tests

14 new cases in `TestServiceAccountMint`, against the existing loopback stub (a real HTTP server, not a mocked `urlopen`). The load-bearing one is `test_refreshes_by_re_exchanging_not_re_signing_in`: a 401 mid-run must cost an exchange and **not** a sign-in. Also covered: one re-sign-in on a dead session, a cap so a broken credential can't storm the limiter, 429 retry, near-expiry pre-emption, static-token precedence, plaintext/redirect refusals on the auth URL, and an assertion that no session token, JWT, or password reaches stdout/stderr.

1156 unit tests pass; `ruff check` / `ruff format --check` clean.

## Remaining (operational, tracked on the issue)

Merging this doesn't finish #365 — the account still has to be minted, the secrets set, and a baseline parity run posted to wiki#89. Hence `Refs`, not `Closes`.

Refs #365