### PR TITLE
docs(#365): give the parity service account a permanently unroutable address

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -193,7 +193,13 @@ A run outlives its 15-minute token, so the harness refreshes — and how it refr
 
 **Mint** (one-time, needs an admin session on `api.wxyc.org/auth`):
 
-Every password below reaches `curl` on **stdin**, never in argv — same reason `LIBRARY_DB_PASSWORD` goes through `MYSQL_PWD` above. `-d "{...$PASSWORD...}"` would put it in a command line that `ps` shows to every user on the box and that `set -x` echoes into the scrollback.
+**`scripts/mint-parity-service-account.sh` does all of this**, and is the path to prefer — it reads the admin password without echo, revokes the admin session from a `trap` on the way out, and exercises the new credential (sign-in + JWT exchange) before reporting success, which is what proves the org `member` row landed:
+
+```bash
+./scripts/mint-parity-service-account.sh --admin-email you@example.org
+```
+
+The steps below are what it does, kept here because a runbook that only says "run the script" is useless the day the script is the thing that's broken. Every password reaches `curl` on **stdin**, never in argv — same reason `LIBRARY_DB_PASSWORD` goes through `MYSQL_PWD` above. `-d "{...$PASSWORD...}"` would put it in a command line that `ps` shows to every user on the box and that `set -x` echoes into the scrollback.
 
 ```bash
 # 1. Admin sign-in -> session token.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -171,7 +171,7 @@ Retiring the `wxycmusic` MySQL means moving that daily build's catalog source to
 ```bash
 PARITY_DIR=$(mktemp -d)              # fresh each run: both --*-db paths must not already exist
 export LIBRARY_DB_PASSWORD=...       # never in the DSN -- see below
-export BACKEND_CATALOG_EMAIL=catalog-parity@wxyc.org
+export BACKEND_CATALOG_EMAIL=catalog-parity@wxyc.invalid
 export BACKEND_CATALOG_PASSWORD=...  # the service account's password; the harness mints per run
 
 python scripts/catalog_parity_diff.py \
@@ -206,17 +206,17 @@ SESSION=$(jq -n --arg e "$ADMIN_EMAIL" --arg p "$ADMIN_PASSWORD" '{email:$e,pass
 #    Keep USER_ID: rotation and revocation both need it.
 PASSWORD=$(python3 -c 'import secrets; print(secrets.token_urlsafe(48))')
 USER_ID=$(jq -n --arg p "$PASSWORD" \
-    '{email:"catalog-parity@wxyc.org",name:"Catalog Parity",password:$p,data:{emailVerified:true}}' \
+    '{email:"catalog-parity@wxyc.invalid",name:"Catalog Parity",password:$p,data:{emailVerified:true}}' \
     | curl -sS -X POST https://api.wxyc.org/auth/admin/create-user \
         -H "Authorization: Bearer $SESSION" -H 'Content-Type: application/json' \
         -H 'Origin: https://dj.wxyc.org' --data-binary @- | jq -r .user.id)
 
 # 3. Store it where CI reads it.
-gh secret set BACKEND_CATALOG_EMAIL --repo WXYC/discogs-etl --body catalog-parity@wxyc.org
+gh secret set BACKEND_CATALOG_EMAIL --repo WXYC/discogs-etl --body catalog-parity@wxyc.invalid
 printf %s "$PASSWORD" | gh secret set BACKEND_CATALOG_PASSWORD --repo WXYC/discogs-etl --body-file -
 ```
 
-If `USER_ID` was not captured at mint time, recover it with `POST /auth/admin/list-users` (`{"searchField":"email","searchValue":"catalog-parity@wxyc.org"}`) rather than guessing.
+If `USER_ID` was not captured at mint time, recover it with `POST /auth/admin/list-users` (`{"searchField":"email","searchValue":"catalog-parity@wxyc.invalid"}`) rather than guessing.
 
 **Rotate**: repeat step 2 as `POST /auth/admin/set-user-password` with `{"userId":"$USER_ID","newPassword":"..."}`, then **revoke the old sessions** — `POST /auth/admin/revoke-user-sessions` with `{"userId":"$USER_ID"}` — then step 3. The revocation is not optional bookkeeping: `set-user-password` revokes nothing, and Backend-Service pins `session.expiresIn` to **365 days** (`shared/authentication/src/auth.definition.ts`), so a rotation without it orphans the stored secret while leaving every previously-minted session able to keep exchanging for `catalog:read` JWTs for a year. The harness signs out the session it mints (`_TokenSource.close`, in a `finally`), so in the normal case there is nothing left to revoke — this covers the runs that died before they could.
 
@@ -227,6 +227,7 @@ Three things about that procedure are load-bearing:
 - **`admin/create-user`, not `admin/provision-user`.** The org's own wrapper refuses a caller-supplied password and emails an account-setup link whose token is valid for **7 days** (`shared/authentication/src/account-setup-token.ts`) — the length of the soak. Setting the password afterwards does not revoke it, so anyone who could read that mailbox could reset the account mid-soak. better-auth's admin endpoint takes the password directly and mints no token. Backend-Service handles this path explicitly: a `hooks.after` branch auto-verifies the email (BS#1118) and the `user.create.after` hook inserts the org `member` row, which is where the `catalog:read` permission actually comes from.
 - **`member` is the least-privileged role that carries `catalog:read`.** Every WXYC role has it; `member` is the floor. The residual grants are `bin:read/write` (its own DJ bin) and `flowsheet:read` — no catalog write, no flowsheet write. A truly catalog-read-only role would need a new entry in the shared `WXYCRole` union across three repos.
 - **No `role` field in the create-user body.** That field is better-auth's *global* admin role (`user.role`), not the org role — leaving it at the default keeps the account outside the admin plugin entirely.
+- **`@wxyc.invalid`, deliberately not `@wxyc.org`.** The address is an identifier, not a mailbox: `.invalid` is reserved by [RFC 2606](https://www.rfc-editor.org/rfc/rfc2606#section-2) and can never be delegated in the global DNS, so no mail can reach it *and no future change can make it reachable*. That last clause is the point — an `@wxyc.org` address needs no mailbox today, but anyone who later adds a catch-all silently hands whoever reads it the ability to run `forget-password` against an account holding the whole catalog. Nothing in the mint path sends mail (`admin/create-user` mints no token and the body sets `emailVerified`), and rotation is admin-driven, so the account never needs to receive anything. One consequence to know: a `forget-password` submitted for this address makes SES attempt delivery to a domain that cannot resolve, which is a hard bounce against the org's sender reputation. Rotate through `admin/set-user-password`; never through the reset flow.
 
 If the account ever needs revoking: rotate the password **and** revoke the sessions (both above — the password alone leaves year-long sessions live), and ban the user if the compromise is active. The JWT payload carries `banned` and `requirePermissions` 403s on it, so a ban takes effect within one 15-minute token turnover; it is the only one of the three that also invalidates a JWT already in flight.
 

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -117,7 +117,7 @@ Two repo secrets exist that **no workflow reads yet**. They authenticate the Bac
 
 | Secret | Description |
 |--------|-------------|
-| `BACKEND_CATALOG_EMAIL` | Service-account email (`catalog-parity@wxyc.org`), `member` org role — the least-privileged role carrying `catalog:read` |
+| `BACKEND_CATALOG_EMAIL` | Service-account email (`catalog-parity@wxyc.invalid`), `member` org role — the least-privileged role carrying `catalog:read` |
 | `BACKEND_CATALOG_PASSWORD` | That account's password. **Not a token**: the JWT Backend-Service accepts expires in 15 minutes, so the harness signs in and mints one per run |
 
 Mint and rotation procedure: [`architecture.md` → Minting and rotating the parity service account](architecture.md#minting-and-rotating-the-parity-service-account-365). Treat the pair as sensitive — the export it unlocks is the entire library catalog.

--- a/scripts/catalog_parity_diff.py
+++ b/scripts/catalog_parity_diff.py
@@ -355,7 +355,7 @@ _Row = Sequence[object]
 BACKEND_TOKEN_ENV = "BACKEND_CATALOG_TOKEN"
 
 # The service account's own credentials (#365) -- what CI actually stores.
-# `catalog-parity@wxyc.org` holds the `member` org role, the least-privileged
+# `catalog-parity@wxyc.invalid` holds the `member` org role, the least-privileged
 # role carrying `catalog:read`.
 BACKEND_EMAIL_ENV = "BACKEND_CATALOG_EMAIL"
 BACKEND_PASSWORD_ENV = "BACKEND_CATALOG_PASSWORD"

--- a/scripts/mint-parity-service-account.sh
+++ b/scripts/mint-parity-service-account.sh
@@ -209,6 +209,25 @@ if [[ "$USE_SUPPLIED_SESSION" == true ]]; then
     IFS= read -r -s -p 'Admin session token: ' SESSION
     echo >&2
     [[ -n "$SESSION" ]] || die "no session token given"
+    # A JWT pasted here would authenticate as nobody: the admin endpoints
+    # resolve their caller through getSessionFromCtx, which the bearer plugin
+    # feeds from a *session* token. Browsers see both -- as `set-auth-jwt` and
+    # `set-auth-token` -- and confusing them produces another opaque 401, so
+    # tell them apart locally instead.
+    if python3 -c '
+import base64, json, sys
+parts = sys.argv[1].split(".")
+if len(parts) != 3:
+    sys.exit(1)
+seg = parts[0]
+try:
+    header = json.loads(base64.urlsafe_b64decode(seg + "=" * (-len(seg) % 4)))
+except Exception:
+    sys.exit(1)
+sys.exit(0 if isinstance(header, dict) and "alg" in header else 1)
+' "$SESSION"; then
+        die "that is a JWT (set-auth-jwt), not a session token. The admin API needs the session: copy set-auth-token, or the token field from the /auth/sign-in response body."
+    fi
     SESSION_IS_OURS=false
     log "using the session token you supplied (it will not be revoked)"
 else

--- a/scripts/mint-parity-service-account.sh
+++ b/scripts/mint-parity-service-account.sh
@@ -48,6 +48,7 @@ SERVICE_NAME="Catalog Parity"
 ORIGIN="${BACKEND_AUTH_ORIGIN:-https://dj.wxyc.org}"
 ADMIN_EMAIL=""
 ADMIN_USERNAME=""
+USE_SUPPLIED_SESSION=false
 OUT_DIR=""
 
 usage() {
@@ -60,6 +61,9 @@ Usage: mint-parity-service-account.sh [options]
                         looks like an email). One of the two is required.
   --auth-url URL        Auth service base (default: https://api.wxyc.org/auth)
   --service-email EMAIL Service account to create (default: catalog-parity@wxyc.invalid)
+  --admin-session       Use a session token you already hold instead of a
+                        password (prompted for, never in argv). For accounts
+                        that sign in by one-time code and have no password.
   --origin ORIGIN       Origin header (default: https://dj.wxyc.org)
   --out-dir DIR         Where to write svc.password / svc.user_id (default: mktemp -d)
   -h, --help            This message
@@ -73,6 +77,7 @@ while [[ $# -gt 0 ]]; do
     case "$1" in
         --admin-email) ADMIN_EMAIL="$2"; shift 2 ;;
         --admin-username) ADMIN_USERNAME="$2"; shift 2 ;;
+        --admin-session) USE_SUPPLIED_SESSION=true; shift ;;
         --auth-url) AUTH_URL="$2"; shift 2 ;;
         --service-email) SERVICE_EMAIL="$2"; shift 2 ;;
         --origin) ORIGIN="$2"; shift 2 ;;
@@ -101,7 +106,19 @@ AUTH_URL="${AUTH_URL%/}"
 if [[ -n "$ADMIN_EMAIL" && -n "$ADMIN_USERNAME" ]]; then
     die "pass --admin-email or --admin-username, not both"
 fi
-if [[ -z "$ADMIN_EMAIL" && -z "$ADMIN_USERNAME" ]]; then
+# Catch the confusable pair locally. better-auth 422s an "@" as
+# INVALID_USERNAME, and learning that from production is a slow way to find
+# out which flag you wanted.
+if [[ -n "$ADMIN_USERNAME" && "$ADMIN_USERNAME" == *@* ]]; then
+    die "--admin-username takes a username; '${ADMIN_USERNAME}' is an address, so use --admin-email"
+fi
+if [[ -n "$ADMIN_EMAIL" && "$ADMIN_EMAIL" != *@* ]]; then
+    die "--admin-email takes an address; '${ADMIN_EMAIL}' has no '@', so use --admin-username"
+fi
+if [[ "$USE_SUPPLIED_SESSION" == true && ( -n "$ADMIN_EMAIL" || -n "$ADMIN_USERNAME" ) ]]; then
+    die "--admin-session signs in for you; drop --admin-email/--admin-username"
+fi
+if [[ "$USE_SUPPLIED_SESSION" == false && -z "$ADMIN_EMAIL" && -z "$ADMIN_USERNAME" ]]; then
     IFS= read -r -p 'Admin email or username: ' ADMIN_IDENTIFIER
     if [[ "$ADMIN_IDENTIFIER" == *@* ]]; then
         ADMIN_EMAIL="$ADMIN_IDENTIFIER"
@@ -115,7 +132,12 @@ fi
 # routes to /sign-in/username whenever the identifier has no "@". An
 # account that signs in by username has no working email path, and the
 # refusal is the same INVALID_EMAIL_OR_PASSWORD either way.
-if [[ -n "$ADMIN_USERNAME" ]]; then
+ADMIN_IDENTIFIER=""
+SIGN_IN_PATH=""
+SIGN_IN_FIELD=""
+if [[ "$USE_SUPPLIED_SESSION" == true ]]; then
+    :
+elif [[ -n "$ADMIN_USERNAME" ]]; then
     ADMIN_IDENTIFIER="$ADMIN_USERNAME"
     SIGN_IN_PATH="/sign-in/username"
     SIGN_IN_FIELD="username"
@@ -134,8 +156,16 @@ fi
 mkdir -p "$OUT_DIR"
 
 SESSION=""
+# Only ever revoke what this script minted. A session the operator handed us
+# is their dj-site login; signing it out would log them off mid-task. Same
+# rule the harness applies to $BACKEND_CATALOG_TOKEN.
+SESSION_IS_OURS=false
 cleanup() {
     local status=$?
+    if [[ -n "$SESSION" && "$SESSION_IS_OURS" == false ]]; then
+        log "leaving the session you supplied alone; this script revokes only what it mints"
+        SESSION=""
+    fi
     # Revoke on every exit path, including a failure between sign-in and
     # create-user: the session is good for a year either way.
     if [[ -n "$SESSION" ]]; then
@@ -172,38 +202,47 @@ call_auth() {
     RESPONSE="${raw%$'\n'*}"
 }
 
-# 1. Admin sign-in. The password is read without echo and piped straight into
+# 1. Get an admin session, either by signing in or by taking one the operator
+#    already holds. The password is read without echo and goes straight into
 #    the JSON body -- it exists only in this process's memory.
-# IFS= so a password with a leading or trailing space survives intact: a
-# bare `read` splits on IFS and would silently hand the server a different
-# string than the one that was typed.
-IFS= read -r -s -p "Password for ${ADMIN_IDENTIFIER}: " ADMIN_PASSWORD
-echo >&2
-[[ -n "$ADMIN_PASSWORD" ]] || die "an admin password is required"
+if [[ "$USE_SUPPLIED_SESSION" == true ]]; then
+    IFS= read -r -s -p 'Admin session token: ' SESSION
+    echo >&2
+    [[ -n "$SESSION" ]] || die "no session token given"
+    SESSION_IS_OURS=false
+    log "using the session token you supplied (it will not be revoked)"
+else
+    IFS= read -r -s -p "Password for ${ADMIN_IDENTIFIER}: " ADMIN_PASSWORD
+    echo >&2
+    [[ -n "$ADMIN_PASSWORD" ]] || die "an admin password is required"
 
-call_auth "$SIGN_IN_PATH" "" \
-    < <(jq -n --arg f "$SIGN_IN_FIELD" --arg i "$ADMIN_IDENTIFIER" --arg p "$ADMIN_PASSWORD" \
-        '{($f): $i, password: $p}')
-unset ADMIN_PASSWORD
-if [[ "$HTTP_STATUS" == "401" ]]; then
-    # better-auth answers "no such user" and "wrong password" identically, by
-    # design. Say which two things to check, because the operator staring at a
-    # password they know is correct cannot tell those apart.
-    log "ERROR: ${SIGN_IN_PATH} rejected ${ADMIN_IDENTIFIER} (HTTP 401): ${RESPONSE}"
-    log "       better-auth returns this for an unknown ${SIGN_IN_FIELD} AND for a wrong password."
-    if [[ "$SIGN_IN_FIELD" == "email" ]]; then
-        log "       If you sign in to dj.wxyc.org with a username rather than that address,"
-        log "       re-run with --admin-username <name>: they are separate endpoints."
-    else
-        log "       If you sign in to dj.wxyc.org with an email address, re-run with"
-        log "       --admin-email <address>: they are separate endpoints."
+    call_auth "$SIGN_IN_PATH" "" \
+        < <(jq -n --arg f "$SIGN_IN_FIELD" --arg i "$ADMIN_IDENTIFIER" --arg p "$ADMIN_PASSWORD" \
+            '{($f): $i, password: $p}')
+    unset ADMIN_PASSWORD
+    if [[ "$HTTP_STATUS" == "401" ]]; then
+        # better-auth answers "no such user" and "wrong password" identically,
+        # by design. Say which things to check, because the operator staring at
+        # a password they know is correct cannot tell those apart.
+        log "ERROR: ${SIGN_IN_PATH} rejected ${ADMIN_IDENTIFIER} (HTTP 401): ${RESPONSE}"
+        log "       better-auth returns this for an unknown ${SIGN_IN_FIELD} AND for a wrong password."
+        if [[ "$SIGN_IN_FIELD" == "email" ]]; then
+            log "       If you sign in to dj.wxyc.org with a username rather than that address,"
+            log "       re-run with --admin-username <name>: they are separate endpoints."
+        else
+            log "       If you sign in to dj.wxyc.org with an email address, re-run with"
+            log "       --admin-email <address>: they are separate endpoints."
+        fi
+        log "       If you sign in with a one-time code and have no password, re-run with"
+        log "       --admin-session and paste a session token from a signed-in browser."
+        exit 1
     fi
-    exit 1
+    [[ "$HTTP_STATUS" == "200" ]] || die "admin sign-in failed with HTTP ${HTTP_STATUS}: ${RESPONSE}"
+    SESSION="$(jq -r '.token // empty' <<<"$RESPONSE")"
+    [[ -n "$SESSION" ]] || die "admin sign-in returned no session token"
+    SESSION_IS_OURS=true
+    log "signed in as ${ADMIN_IDENTIFIER}"
 fi
-[[ "$HTTP_STATUS" == "200" ]] || die "admin sign-in failed with HTTP ${HTTP_STATUS}: ${RESPONSE}"
-SESSION="$(jq -r '.token // empty' <<<"$RESPONSE")"
-[[ -n "$SESSION" ]] || die "admin sign-in returned no session token"
-log "signed in as ${ADMIN_IDENTIFIER}"
 
 # 2. Create the principal. No `role` field: that one is better-auth's global
 #    admin role, not the org role. The org `member` row -- which is where

--- a/scripts/mint-parity-service-account.sh
+++ b/scripts/mint-parity-service-account.sh
@@ -47,13 +47,17 @@ SERVICE_NAME="Catalog Parity"
 # MISSING_OR_NULL_ORIGIN. This must be one of BETTER_AUTH_TRUSTED_ORIGINS.
 ORIGIN="${BACKEND_AUTH_ORIGIN:-https://dj.wxyc.org}"
 ADMIN_EMAIL=""
+ADMIN_USERNAME=""
 OUT_DIR=""
 
 usage() {
     cat <<'USAGE'
 Usage: mint-parity-service-account.sh [options]
 
-  --admin-email EMAIL   Admin to sign in as (prompted if omitted)
+  --admin-email EMAIL   Admin to sign in as, by email
+  --admin-username NAME Admin to sign in as, by username (WXYC accounts may
+                        have either; dj-site picks by whether the identifier
+                        looks like an email). One of the two is required.
   --auth-url URL        Auth service base (default: https://api.wxyc.org/auth)
   --service-email EMAIL Service account to create (default: catalog-parity@wxyc.invalid)
   --origin ORIGIN       Origin header (default: https://dj.wxyc.org)
@@ -68,6 +72,7 @@ USAGE
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --admin-email) ADMIN_EMAIL="$2"; shift 2 ;;
+        --admin-username) ADMIN_USERNAME="$2"; shift 2 ;;
         --auth-url) AUTH_URL="$2"; shift 2 ;;
         --service-email) SERVICE_EMAIL="$2"; shift 2 ;;
         --origin) ORIGIN="$2"; shift 2 ;;
@@ -93,10 +98,32 @@ case "$AUTH_URL" in
 esac
 AUTH_URL="${AUTH_URL%/}"
 
-if [[ -z "$ADMIN_EMAIL" ]]; then
-    read -r -p 'Admin email: ' ADMIN_EMAIL
+if [[ -n "$ADMIN_EMAIL" && -n "$ADMIN_USERNAME" ]]; then
+    die "pass --admin-email or --admin-username, not both"
 fi
-[[ -n "$ADMIN_EMAIL" ]] || die "an admin email is required"
+if [[ -z "$ADMIN_EMAIL" && -z "$ADMIN_USERNAME" ]]; then
+    IFS= read -r -p 'Admin email or username: ' ADMIN_IDENTIFIER
+    if [[ "$ADMIN_IDENTIFIER" == *@* ]]; then
+        ADMIN_EMAIL="$ADMIN_IDENTIFIER"
+    else
+        ADMIN_USERNAME="$ADMIN_IDENTIFIER"
+    fi
+fi
+
+# better-auth exposes the two as separate endpoints with separate body
+# fields; the username plugin is enabled on this deployment, and dj-site
+# routes to /sign-in/username whenever the identifier has no "@". An
+# account that signs in by username has no working email path, and the
+# refusal is the same INVALID_EMAIL_OR_PASSWORD either way.
+if [[ -n "$ADMIN_USERNAME" ]]; then
+    ADMIN_IDENTIFIER="$ADMIN_USERNAME"
+    SIGN_IN_PATH="/sign-in/username"
+    SIGN_IN_FIELD="username"
+else
+    ADMIN_IDENTIFIER="$ADMIN_EMAIL"
+    SIGN_IN_PATH="/sign-in/email"
+    SIGN_IN_FIELD="email"
+fi
 
 # Secrets land here; keep them off other users' terminals from the start
 # rather than chmod-ing after the write.
@@ -147,17 +174,36 @@ call_auth() {
 
 # 1. Admin sign-in. The password is read without echo and piped straight into
 #    the JSON body -- it exists only in this process's memory.
-read -r -s -p "Password for ${ADMIN_EMAIL}: " ADMIN_PASSWORD
+# IFS= so a password with a leading or trailing space survives intact: a
+# bare `read` splits on IFS and would silently hand the server a different
+# string than the one that was typed.
+IFS= read -r -s -p "Password for ${ADMIN_IDENTIFIER}: " ADMIN_PASSWORD
 echo >&2
 [[ -n "$ADMIN_PASSWORD" ]] || die "an admin password is required"
 
-call_auth "/sign-in/email" "" \
-    < <(jq -n --arg e "$ADMIN_EMAIL" --arg p "$ADMIN_PASSWORD" '{email:$e,password:$p}')
+call_auth "$SIGN_IN_PATH" "" \
+    < <(jq -n --arg f "$SIGN_IN_FIELD" --arg i "$ADMIN_IDENTIFIER" --arg p "$ADMIN_PASSWORD" \
+        '{($f): $i, password: $p}')
 unset ADMIN_PASSWORD
+if [[ "$HTTP_STATUS" == "401" ]]; then
+    # better-auth answers "no such user" and "wrong password" identically, by
+    # design. Say which two things to check, because the operator staring at a
+    # password they know is correct cannot tell those apart.
+    log "ERROR: ${SIGN_IN_PATH} rejected ${ADMIN_IDENTIFIER} (HTTP 401): ${RESPONSE}"
+    log "       better-auth returns this for an unknown ${SIGN_IN_FIELD} AND for a wrong password."
+    if [[ "$SIGN_IN_FIELD" == "email" ]]; then
+        log "       If you sign in to dj.wxyc.org with a username rather than that address,"
+        log "       re-run with --admin-username <name>: they are separate endpoints."
+    else
+        log "       If you sign in to dj.wxyc.org with an email address, re-run with"
+        log "       --admin-email <address>: they are separate endpoints."
+    fi
+    exit 1
+fi
 [[ "$HTTP_STATUS" == "200" ]] || die "admin sign-in failed with HTTP ${HTTP_STATUS}: ${RESPONSE}"
 SESSION="$(jq -r '.token // empty' <<<"$RESPONSE")"
 [[ -n "$SESSION" ]] || die "admin sign-in returned no session token"
-log "signed in as ${ADMIN_EMAIL}"
+log "signed in as ${ADMIN_IDENTIFIER}"
 
 # 2. Create the principal. No `role` field: that one is better-auth's global
 #    admin role, not the org role. The org `member` row -- which is where

--- a/scripts/mint-parity-service-account.sh
+++ b/scripts/mint-parity-service-account.sh
@@ -1,0 +1,219 @@
+#!/usr/bin/env bash
+#
+# Mint the catalog:read service account the parity harness signs in as (#365).
+#
+# Run this once, by hand, from your own terminal. It holds an admin credential
+# against production, so it is deliberately not wired into any workflow.
+#
+#   ./scripts/mint-parity-service-account.sh --admin-email you@example.org
+#
+# On success it writes two files into --out-dir (default: a fresh mktemp -d):
+#
+#   svc.password   the generated service-account password
+#   svc.user_id    the new user's id, needed to rotate or revoke later
+#
+# and prints where they landed. Feed them to `gh secret set` (the command is
+# printed at the end) and delete the directory.
+#
+# Design notes, each of which has a guard in
+# tests/unit/test_mint_parity_service_account.py:
+#
+#   * No secret ever reaches a command line. argv is readable by any `ps` and
+#     is echoed by `set -x`; every request body goes to curl on stdin. This is
+#     the same argument docs/architecture.md makes for LIBRARY_DB_PASSWORD and
+#     MYSQL_PWD.
+#   * admin/create-user, never the org's admin/provision-user wrapper. The
+#     latter emails an account-setup link whose token lives 7 days -- the
+#     length of the parity soak -- and setting the password afterwards does
+#     not revoke it.
+#   * The admin session is revoked on the way out, from a trap, because
+#     better-auth pins session.expiresIn to a year. An admin session left
+#     behind is a year-long admin credential.
+#   * The credential is exercised before it is reported: signing in as the new
+#     account and exchanging for a JWT proves the org `member` row landed,
+#     which is where catalog:read actually comes from.
+#
+# See docs/architecture.md, "Minting and rotating the parity service account".
+
+set -euo pipefail
+
+AUTH_URL="${BACKEND_AUTH_URL:-https://api.wxyc.org/auth}"
+# Non-routing by construction: `.invalid` is reserved by RFC 2606 and can
+# never be delegated, so no future catch-all on wxyc.org can turn this into a
+# mailbox that could run forget-password against the account.
+SERVICE_EMAIL="catalog-parity@wxyc.invalid"
+SERVICE_NAME="Catalog Parity"
+# better-auth's CSRF guard 400s an origin-less sign-in with
+# MISSING_OR_NULL_ORIGIN. This must be one of BETTER_AUTH_TRUSTED_ORIGINS.
+ORIGIN="${BACKEND_AUTH_ORIGIN:-https://dj.wxyc.org}"
+ADMIN_EMAIL=""
+OUT_DIR=""
+
+usage() {
+    cat <<'USAGE'
+Usage: mint-parity-service-account.sh [options]
+
+  --admin-email EMAIL   Admin to sign in as (prompted if omitted)
+  --auth-url URL        Auth service base (default: https://api.wxyc.org/auth)
+  --service-email EMAIL Service account to create (default: catalog-parity@wxyc.invalid)
+  --origin ORIGIN       Origin header (default: https://dj.wxyc.org)
+  --out-dir DIR         Where to write svc.password / svc.user_id (default: mktemp -d)
+  -h, --help            This message
+
+The admin password is read from the terminal without echo. It is never passed
+as an argument, written to disk, or logged.
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --admin-email) ADMIN_EMAIL="$2"; shift 2 ;;
+        --auth-url) AUTH_URL="$2"; shift 2 ;;
+        --service-email) SERVICE_EMAIL="$2"; shift 2 ;;
+        --origin) ORIGIN="$2"; shift 2 ;;
+        --out-dir) OUT_DIR="$2"; shift 2 ;;
+        -h|--help) usage; exit 0 ;;
+        *) echo "Unknown option: $1" >&2; usage >&2; exit 2 ;;
+    esac
+done
+
+log() { echo "$(date '+%Y-%m-%d %H:%M:%S') $*" >&2; }
+die() { log "ERROR: $*"; exit 1; }
+
+for tool in curl jq python3; do
+    command -v "$tool" >/dev/null 2>&1 || die "$tool is required but not on PATH"
+done
+
+# Refuse to put an admin password on a plaintext wire. Loopback is exempt so
+# this can be rehearsed against a local auth service.
+case "$AUTH_URL" in
+    https://*) ;;
+    http://127.0.0.1[:/]*|http://localhost[:/]*|http://\[::1\][:/]*) log "WARNING: plaintext loopback auth URL" ;;
+    *) die "auth URL must be https (or loopback): $AUTH_URL" ;;
+esac
+AUTH_URL="${AUTH_URL%/}"
+
+if [[ -z "$ADMIN_EMAIL" ]]; then
+    read -r -p 'Admin email: ' ADMIN_EMAIL
+fi
+[[ -n "$ADMIN_EMAIL" ]] || die "an admin email is required"
+
+# Secrets land here; keep them off other users' terminals from the start
+# rather than chmod-ing after the write.
+umask 077
+if [[ -z "$OUT_DIR" ]]; then
+    OUT_DIR="$(mktemp -d)"
+fi
+mkdir -p "$OUT_DIR"
+
+SESSION=""
+cleanup() {
+    local status=$?
+    # Revoke on every exit path, including a failure between sign-in and
+    # create-user: the session is good for a year either way.
+    if [[ -n "$SESSION" ]]; then
+        if printf '{}' | curl -sS -o /dev/null -X POST "${AUTH_URL}/sign-out" \
+            -H "Authorization: Bearer ${SESSION}" \
+            -H 'Content-Type: application/json' -H "Origin: ${ORIGIN}" \
+            --data-binary @- 2>/dev/null; then
+            log "revoked the admin session"
+        else
+            log "WARNING: could not revoke the admin session; it stays valid for a year."
+            log "         Revoke it by hand: POST ${AUTH_URL}/admin/revoke-user-sessions"
+        fi
+        SESSION=""
+    fi
+    exit "$status"
+}
+trap cleanup EXIT INT TERM
+
+# One auth call. Body on stdin, status separated from the payload so a 4xx is
+# a failure rather than a payload that happens to lack the field we wanted.
+HTTP_STATUS=""
+RESPONSE=""
+call_auth() {
+    local path="$1" bearer="${2:-}"
+    local -a args=(-sS -X POST "${AUTH_URL}${path}"
+        -H 'Content-Type: application/json' -H 'Accept: application/json'
+        -H "Origin: ${ORIGIN}" --data-binary @- -w $'\n%{http_code}')
+    if [[ -n "$bearer" ]]; then
+        args+=(-H "Authorization: Bearer ${bearer}")
+    fi
+    local raw
+    raw="$(curl "${args[@]}")" || die "${path} could not be reached"
+    HTTP_STATUS="${raw##*$'\n'}"
+    RESPONSE="${raw%$'\n'*}"
+}
+
+# 1. Admin sign-in. The password is read without echo and piped straight into
+#    the JSON body -- it exists only in this process's memory.
+read -r -s -p "Password for ${ADMIN_EMAIL}: " ADMIN_PASSWORD
+echo >&2
+[[ -n "$ADMIN_PASSWORD" ]] || die "an admin password is required"
+
+call_auth "/sign-in/email" "" \
+    < <(jq -n --arg e "$ADMIN_EMAIL" --arg p "$ADMIN_PASSWORD" '{email:$e,password:$p}')
+unset ADMIN_PASSWORD
+[[ "$HTTP_STATUS" == "200" ]] || die "admin sign-in failed with HTTP ${HTTP_STATUS}: ${RESPONSE}"
+SESSION="$(jq -r '.token // empty' <<<"$RESPONSE")"
+[[ -n "$SESSION" ]] || die "admin sign-in returned no session token"
+log "signed in as ${ADMIN_EMAIL}"
+
+# 2. Create the principal. No `role` field: that one is better-auth's global
+#    admin role, not the org role. The org `member` row -- which is where
+#    catalog:read comes from -- is inserted by a user.create.after hook, and a
+#    hooks.after branch auto-verifies the address (BS#1118).
+SERVICE_PASSWORD="$(python3 -c 'import secrets; print(secrets.token_urlsafe(48))')"
+call_auth "/admin/create-user" "$SESSION" \
+    < <(jq -n --arg e "$SERVICE_EMAIL" --arg n "$SERVICE_NAME" --arg p "$SERVICE_PASSWORD" \
+        '{email:$e,name:$n,password:$p,data:{emailVerified:true}}')
+if [[ "$HTTP_STATUS" != "200" ]]; then
+    die "create-user failed with HTTP ${HTTP_STATUS}: ${RESPONSE}"
+fi
+USER_ID="$(jq -r '.user.id // empty' <<<"$RESPONSE")"
+[[ -n "$USER_ID" ]] || die "create-user returned no user id: ${RESPONSE}"
+log "created ${SERVICE_EMAIL} (${USER_ID})"
+
+# 3. Store the credential before verifying it. A verification failure still
+#    leaves an account that exists, and an account whose password was thrown
+#    away is worse than one that needs a second look.
+printf '%s' "$SERVICE_PASSWORD" >"${OUT_DIR}/svc.password"
+printf '%s\n' "$USER_ID" >"${OUT_DIR}/svc.user_id"
+
+# 4. Exercise it. Signing in as the new account and exchanging for a JWT is
+#    the cheapest proof that the member row landed and the password is what we
+#    think it is -- the two failures that would otherwise surface as a broken
+#    soak days later.
+call_auth "/sign-in/email" "" \
+    < <(jq -n --arg e "$SERVICE_EMAIL" --arg p "$SERVICE_PASSWORD" '{email:$e,password:$p}')
+[[ "$HTTP_STATUS" == "200" ]] \
+    || die "the new account could not sign in (HTTP ${HTTP_STATUS}); its password is in ${OUT_DIR}/svc.password"
+SERVICE_SESSION="$(jq -r '.token // empty' <<<"$RESPONSE")"
+[[ -n "$SERVICE_SESSION" ]] || die "the new account signed in but returned no token"
+
+JWT_STATUS="$(curl -sS -o /dev/null -w '%{http_code}' "${AUTH_URL}/token" \
+    -H "Authorization: Bearer ${SERVICE_SESSION}" -H "Origin: ${ORIGIN}" \
+    -H 'Accept: application/json')"
+[[ "$JWT_STATUS" == "200" ]] \
+    || die "the new account could not exchange for a JWT (HTTP ${JWT_STATUS}); check that the org member row was created"
+
+# Don't leave the verification's own year-long session behind either.
+printf '{}' | curl -sS -o /dev/null -X POST "${AUTH_URL}/sign-out" \
+    -H "Authorization: Bearer ${SERVICE_SESSION}" \
+    -H 'Content-Type: application/json' -H "Origin: ${ORIGIN}" --data-binary @- \
+    || log "WARNING: could not sign out the verification session"
+unset SERVICE_PASSWORD SERVICE_SESSION
+
+log "verified: the account can sign in and mint a catalog:read JWT"
+cat >&2 <<EOF
+
+Done. Credentials are in ${OUT_DIR}:
+
+  gh secret set BACKEND_CATALOG_EMAIL --repo WXYC/discogs-etl --body ${SERVICE_EMAIL}
+  gh secret set BACKEND_CATALOG_PASSWORD --repo WXYC/discogs-etl --body-file ${OUT_DIR}/svc.password
+
+Keep svc.user_id somewhere durable -- rotation (admin/set-user-password) and
+revocation (admin/revoke-user-sessions) both need it. Then:
+
+  rm -rf ${OUT_DIR}
+EOF

--- a/scripts/mint-parity-service-account.sh
+++ b/scripts/mint-parity-service-account.sh
@@ -64,6 +64,15 @@ Usage: mint-parity-service-account.sh [options]
   --admin-session       Use a session token you already hold instead of a
                         password (prompted for, never in argv). For accounts
                         that sign in by one-time code and have no password.
+                        Get one from a signed-in browser: DevTools > Storage >
+                        Cookies > dj.wxyc.org, the cookie whose name ends in
+                        `better-auth.session_token`. Copy the whole value,
+                        including the `.` and everything after it -- that is
+                        the signature, and the bearer plugin verifies it. The
+                        cookie is httpOnly, so `document.cookie` will not show
+                        it. Do NOT copy `set-auth-jwt` or the body of an
+                        /auth/token response: those are JWTs, and the admin
+                        API authenticates by session.
   --origin ORIGIN       Origin header (default: https://dj.wxyc.org)
   --out-dir DIR         Where to write svc.password / svc.user_id (default: mktemp -d)
   -h, --help            This message
@@ -206,7 +215,7 @@ call_auth() {
 #    already holds. The password is read without echo and goes straight into
 #    the JSON body -- it exists only in this process's memory.
 if [[ "$USE_SUPPLIED_SESSION" == true ]]; then
-    IFS= read -r -s -p 'Admin session token: ' SESSION
+    IFS= read -r -s -p 'Admin session token (the better-auth.session_token cookie value): ' SESSION
     echo >&2
     [[ -n "$SESSION" ]] || die "no session token given"
     # A JWT pasted here would authenticate as nobody: the admin endpoints

--- a/tests/unit/test_catalog_parity_diff.py
+++ b/tests/unit/test_catalog_parity_diff.py
@@ -1433,7 +1433,7 @@ class TestServiceAccountMint:
     @staticmethod
     def _use_credentials(mod, monkeypatch, stub) -> None:
         monkeypatch.delenv(mod.BACKEND_TOKEN_ENV, raising=False)
-        monkeypatch.setenv(mod.BACKEND_EMAIL_ENV, "catalog-parity@wxyc.org")
+        monkeypatch.setenv(mod.BACKEND_EMAIL_ENV, "catalog-parity@wxyc.invalid")
         monkeypatch.setenv(mod.BACKEND_PASSWORD_ENV, "hunter2-but-48-bytes")
         monkeypatch.setenv(mod.BACKEND_AUTH_URL_ENV, f"{stub.base_url}/auth")
 
@@ -1443,7 +1443,7 @@ class TestServiceAccountMint:
         with _BackendStub(
             catalog_rows=[_catalog_row(legacy_release_id=72_101)],
             cta_rows=[],
-            credentials=("catalog-parity@wxyc.org", "hunter2-but-48-bytes"),
+            credentials=("catalog-parity@wxyc.invalid", "hunter2-but-48-bytes"),
         ) as stub:
             self._use_credentials(mod, monkeypatch, stub)
             mod._build_library_db_from_backend(stub.base_url, str(out))
@@ -1472,7 +1472,7 @@ class TestServiceAccountMint:
         with _BackendStub(
             catalog_rows=[_catalog_row(legacy_release_id=72_101)],
             cta_rows=[],
-            credentials=("catalog-parity@wxyc.org", "hunter2-but-48-bytes"),
+            credentials=("catalog-parity@wxyc.invalid", "hunter2-but-48-bytes"),
         ) as stub:
             self._use_credentials(mod, monkeypatch, stub)
 
@@ -1498,7 +1498,7 @@ class TestServiceAccountMint:
         with _BackendStub(
             catalog_rows=[_catalog_row(legacy_release_id=72_101)],
             cta_rows=[],
-            credentials=("catalog-parity@wxyc.org", "hunter2-but-48-bytes"),
+            credentials=("catalog-parity@wxyc.invalid", "hunter2-but-48-bytes"),
         ) as stub:
             self._use_credentials(mod, monkeypatch, stub)
             stub.exchange_statuses = [401]
@@ -1523,7 +1523,7 @@ class TestServiceAccountMint:
         with _BackendStub(
             catalog_rows=[_catalog_row(legacy_release_id=72_101)],
             cta_rows=[],
-            credentials=("catalog-parity@wxyc.org", "hunter2-but-48-bytes"),
+            credentials=("catalog-parity@wxyc.invalid", "hunter2-but-48-bytes"),
         ) as stub:
             self._use_credentials(mod, monkeypatch, stub)
             stub.sign_in_statuses = [429]
@@ -1550,7 +1550,7 @@ class TestServiceAccountMint:
         with _BackendStub(
             catalog_rows=[_catalog_row(legacy_release_id=72_101)],
             cta_rows=[],
-            credentials=("catalog-parity@wxyc.org", "hunter2-but-48-bytes"),
+            credentials=("catalog-parity@wxyc.invalid", "hunter2-but-48-bytes"),
         ) as stub:
             self._use_credentials(mod, monkeypatch, stub)
             stub.exchange_statuses = [401]  # spends the second sign-in
@@ -1569,7 +1569,7 @@ class TestServiceAccountMint:
         with _BackendStub(
             catalog_rows=[_catalog_row()],
             cta_rows=[],
-            credentials=("catalog-parity@wxyc.org", "hunter2-but-48-bytes"),
+            credentials=("catalog-parity@wxyc.invalid", "hunter2-but-48-bytes"),
         ) as stub:
             self._use_credentials(mod, monkeypatch, stub)
             stub.exchange_statuses = [401, 401, 401, 401]
@@ -1586,7 +1586,7 @@ class TestServiceAccountMint:
         with _BackendStub(
             catalog_rows=[_catalog_row(legacy_release_id=72_101)],
             cta_rows=[],
-            credentials=("catalog-parity@wxyc.org", "hunter2-but-48-bytes"),
+            credentials=("catalog-parity@wxyc.invalid", "hunter2-but-48-bytes"),
         ) as stub:
             self._use_credentials(mod, monkeypatch, stub)
             stub.sign_in_statuses = [429]
@@ -1602,7 +1602,7 @@ class TestServiceAccountMint:
         with _BackendStub(
             catalog_rows=[_catalog_row()],
             cta_rows=[],
-            credentials=("catalog-parity@wxyc.org", "hunter2-but-48-bytes"),
+            credentials=("catalog-parity@wxyc.invalid", "hunter2-but-48-bytes"),
         ) as stub:
             self._use_credentials(mod, monkeypatch, stub)
             stub.sign_in_statuses = [429, 429]
@@ -1624,7 +1624,7 @@ class TestServiceAccountMint:
         with _BackendStub(
             catalog_rows=[_catalog_row()],
             cta_rows=[],
-            credentials=("catalog-parity@wxyc.org", "hunter2-but-48-bytes"),
+            credentials=("catalog-parity@wxyc.invalid", "hunter2-but-48-bytes"),
         ) as stub:
             self._use_credentials(mod, monkeypatch, stub)
             stub.sign_in_statuses = [429]
@@ -1652,7 +1652,7 @@ class TestServiceAccountMint:
         with _BackendStub(
             catalog_rows=[_catalog_row(legacy_release_id=72_101)],
             cta_rows=[],
-            credentials=("catalog-parity@wxyc.org", "hunter2-but-48-bytes"),
+            credentials=("catalog-parity@wxyc.invalid", "hunter2-but-48-bytes"),
             jwt_ttl_seconds=mod._HTTP_TIMEOUT_SECONDS - 100,
         ) as stub:
             self._use_credentials(mod, monkeypatch, stub)
@@ -1676,7 +1676,7 @@ class TestServiceAccountMint:
         with _BackendStub(
             catalog_rows=[_catalog_row(legacy_release_id=72_101)],
             cta_rows=[],
-            credentials=("catalog-parity@wxyc.org", "hunter2-but-48-bytes"),
+            credentials=("catalog-parity@wxyc.invalid", "hunter2-but-48-bytes"),
             unreadable_jwt_exp=True,
         ) as stub:
             self._use_credentials(mod, monkeypatch, stub)
@@ -1698,7 +1698,7 @@ class TestServiceAccountMint:
         with _BackendStub(
             catalog_rows=[_catalog_row(legacy_release_id=72_101)],
             cta_rows=[],
-            credentials=("catalog-parity@wxyc.org", "hunter2-but-48-bytes"),
+            credentials=("catalog-parity@wxyc.invalid", "hunter2-but-48-bytes"),
         ) as stub:
             self._use_credentials(mod, monkeypatch, stub)
             mod._build_library_db_from_backend(stub.base_url, str(out))
@@ -1714,7 +1714,7 @@ class TestServiceAccountMint:
         with _BackendStub(
             catalog_rows=[],  # an empty catalog is a producer failure
             cta_rows=[],
-            credentials=("catalog-parity@wxyc.org", "hunter2-but-48-bytes"),
+            credentials=("catalog-parity@wxyc.invalid", "hunter2-but-48-bytes"),
         ) as stub:
             self._use_credentials(mod, monkeypatch, stub)
             with pytest.raises(mod.SourceError):
@@ -1731,7 +1731,7 @@ class TestServiceAccountMint:
         with _BackendStub(
             catalog_rows=[_catalog_row(legacy_release_id=72_101)],
             cta_rows=[],
-            credentials=("catalog-parity@wxyc.org", "hunter2-but-48-bytes"),
+            credentials=("catalog-parity@wxyc.invalid", "hunter2-but-48-bytes"),
         ) as stub:
             self._use_credentials(mod, monkeypatch, stub)
             stub.sign_out_statuses = [500]
@@ -1754,7 +1754,7 @@ class TestServiceAccountMint:
         with _BackendStub(
             catalog_rows=[_catalog_row(legacy_release_id=72_101)],
             cta_rows=[],
-            credentials=("catalog-parity@wxyc.org", "hunter2-but-48-bytes"),
+            credentials=("catalog-parity@wxyc.invalid", "hunter2-but-48-bytes"),
         ) as stub:
             self._use_credentials(mod, monkeypatch, stub)
             stub.sign_out_statuses = [302]
@@ -1774,7 +1774,7 @@ class TestServiceAccountMint:
         with _BackendStub(
             catalog_rows=[],  # the real failure: a producer that read nothing
             cta_rows=[],
-            credentials=("catalog-parity@wxyc.org", "hunter2-but-48-bytes"),
+            credentials=("catalog-parity@wxyc.invalid", "hunter2-but-48-bytes"),
         ) as stub:
             self._use_credentials(mod, monkeypatch, stub)
             stub.sign_out_statuses = [302]
@@ -1796,7 +1796,7 @@ class TestServiceAccountMint:
         with _BackendStub(
             catalog_rows=[_catalog_row()],
             cta_rows=[],
-            credentials=("catalog-parity@wxyc.org", "hunter2-but-48-bytes"),
+            credentials=("catalog-parity@wxyc.invalid", "hunter2-but-48-bytes"),
         ) as stub:
             self._use_credentials(mod, monkeypatch, stub)
             stub.sign_in_statuses = [429]
@@ -1817,7 +1817,7 @@ class TestServiceAccountMint:
         with _BackendStub(
             catalog_rows=[_catalog_row(legacy_release_id=72_101)],
             cta_rows=[],
-            credentials=("catalog-parity@wxyc.org", "hunter2-but-48-bytes"),
+            credentials=("catalog-parity@wxyc.invalid", "hunter2-but-48-bytes"),
         ) as stub:
             self._use_credentials(mod, monkeypatch, stub)
             stub.sign_in_statuses = [429]
@@ -1857,10 +1857,10 @@ class TestServiceAccountMint:
         with _BackendStub(
             catalog_rows=[_catalog_row(legacy_release_id=72_101)],
             cta_rows=[],
-            credentials=("catalog-parity@wxyc.org", "hunter2-but-48-bytes"),
+            credentials=("catalog-parity@wxyc.invalid", "hunter2-but-48-bytes"),
         ) as stub:
             monkeypatch.setenv(mod.BACKEND_TOKEN_ENV, "stale-token")
-            monkeypatch.setenv(mod.BACKEND_EMAIL_ENV, "catalog-parity@wxyc.org")
+            monkeypatch.setenv(mod.BACKEND_EMAIL_ENV, "catalog-parity@wxyc.invalid")
             monkeypatch.setenv(mod.BACKEND_PASSWORD_ENV, "hunter2-but-48-bytes")
             monkeypatch.setenv(mod.BACKEND_AUTH_URL_ENV, f"{stub.base_url}/auth")
             mod._build_library_db_from_backend(stub.base_url, str(out))
@@ -1875,7 +1875,7 @@ class TestServiceAccountMint:
         out = tmp_path / "backend.db"
         with _BackendStub(catalog_rows=[_catalog_row()], cta_rows=[]) as stub:
             monkeypatch.setenv(mod.BACKEND_TOKEN_ENV, "svc-token")
-            monkeypatch.setenv(mod.BACKEND_EMAIL_ENV, "catalog-parity@wxyc.org")
+            monkeypatch.setenv(mod.BACKEND_EMAIL_ENV, "catalog-parity@wxyc.invalid")
             monkeypatch.setenv(mod.BACKEND_PASSWORD_ENV, "hunter2-but-48-bytes")
             mod._build_library_db_from_backend(stub.base_url, str(out))
 
@@ -1892,7 +1892,7 @@ class TestServiceAccountMint:
         with _BackendStub(
             catalog_rows=[_catalog_row()],
             cta_rows=[],
-            credentials=("catalog-parity@wxyc.org", "hunter2-but-48-bytes"),
+            credentials=("catalog-parity@wxyc.invalid", "hunter2-but-48-bytes"),
         ) as stub:
             monkeypatch.setenv(mod.BACKEND_TOKEN_ENV, "stale-token")
             monkeypatch.delenv(mod.BACKEND_EMAIL_ENV, raising=False)
@@ -1911,7 +1911,7 @@ class TestServiceAccountMint:
         with _BackendStub(
             catalog_rows=[_catalog_row(legacy_release_id=72_101)],
             cta_rows=[],
-            credentials=("catalog-parity@wxyc.org", "hunter2-but-48-bytes"),
+            credentials=("catalog-parity@wxyc.invalid", "hunter2-but-48-bytes"),
             jwt_ttl_seconds=30,
         ) as stub:
             self._use_credentials(mod, monkeypatch, stub)
@@ -1938,7 +1938,7 @@ class TestServiceAccountMint:
         """The password is on that wire -- the message must say so."""
         mod = _load_module()
         monkeypatch.delenv(mod.BACKEND_TOKEN_ENV, raising=False)
-        monkeypatch.setenv(mod.BACKEND_EMAIL_ENV, "catalog-parity@wxyc.org")
+        monkeypatch.setenv(mod.BACKEND_EMAIL_ENV, "catalog-parity@wxyc.invalid")
         monkeypatch.setenv(mod.BACKEND_PASSWORD_ENV, "hunter2-but-48-bytes")
         monkeypatch.setenv(mod.BACKEND_AUTH_URL_ENV, "http://auth.example.org/auth")
         with pytest.raises(mod.SourceError) as excinfo:
@@ -1957,7 +1957,7 @@ class TestServiceAccountMint:
         with _BackendStub(
             catalog_rows=[_catalog_row()],
             cta_rows=[],
-            credentials=("catalog-parity@wxyc.org", "hunter2-but-48-bytes"),
+            credentials=("catalog-parity@wxyc.invalid", "hunter2-but-48-bytes"),
         ) as elsewhere:
             with _RedirectingStub(elsewhere.base_url) as redirector:
                 self._use_credentials(mod, monkeypatch, elsewhere)
@@ -1983,7 +1983,7 @@ class TestServiceAccountMint:
         with _BackendStub(
             catalog_rows=[_catalog_row(legacy_release_id=72_101)],
             cta_rows=[],
-            credentials=("catalog-parity@wxyc.org", "hunter2-but-48-bytes"),
+            credentials=("catalog-parity@wxyc.invalid", "hunter2-but-48-bytes"),
         ) as stub:
             self._use_credentials(mod, monkeypatch, stub)
             mod._build_library_db_from_backend(stub.base_url, str(out))

--- a/tests/unit/test_mint_parity_service_account.py
+++ b/tests/unit/test_mint_parity_service_account.py
@@ -111,6 +111,34 @@ class TestMintScript:
         assert "/sign-in/username" in script
         assert "--admin-username" in script
 
+    def test_an_email_passed_as_a_username_is_caught_locally(self, script: str) -> None:
+        """better-auth 422s an `@` as INVALID_USERNAME -- catch it before the wire.
+
+        The two flags are easy to confuse precisely because the account has
+        both kinds of identifier, and a round trip to production to learn you
+        typed the wrong flag is a worse teacher than a local message.
+        """
+        code = "\n".join(line for line in script.splitlines() if not line.strip().startswith("#"))
+        assert re.search(r'ADMIN_USERNAME"?\s*==\s*\*@\*', code)
+
+    def test_it_accepts_a_session_the_operator_already_has(self, script: str) -> None:
+        """Not every admin can reach a password.
+
+        This deployment enables emailOTP, so an account may sign in by
+        one-time code and have no usable password at all. Handing the script a
+        session obtained however dj-site obtains one keeps that operator
+        unblocked without inventing a credential for them.
+        """
+        assert "--admin-session" in script
+
+    def test_a_supplied_session_is_not_revoked(self, script: str) -> None:
+        """Revoking it would sign the operator out of dj-site.
+
+        Same rule the harness applies to $BACKEND_CATALOG_TOKEN: this script
+        revokes what it minted, and nothing else.
+        """
+        assert "SESSION_IS_OURS" in script
+
     def test_the_sign_in_failure_is_actionable(self, script: str) -> None:
         """better-auth cannot say which half was wrong, so the script must.
 

--- a/tests/unit/test_mint_parity_service_account.py
+++ b/tests/unit/test_mint_parity_service_account.py
@@ -131,6 +131,18 @@ class TestMintScript:
         """
         assert "--admin-session" in script
 
+    def test_it_rejects_a_jwt_pasted_where_the_session_belongs(self, script: str) -> None:
+        """`set-auth-jwt` and `set-auth-token` are one letter apart in practice.
+
+        The admin endpoints resolve their caller through `getSessionFromCtx`,
+        so a JWT pasted here authenticates as nobody and returns another
+        opaque 401. The shapes are distinguishable locally: a JWT is three
+        base64url segments whose first decodes to a JOSE header.
+        """
+        assert "set-auth-token" in script
+        code = "\n".join(line for line in script.splitlines() if not line.strip().startswith("#"))
+        assert "alg" in code, "the JWT-shape check must inspect the JOSE header"
+
     def test_a_supplied_session_is_not_revoked(self, script: str) -> None:
         """Revoking it would sign the operator out of dj-site.
 

--- a/tests/unit/test_mint_parity_service_account.py
+++ b/tests/unit/test_mint_parity_service_account.py
@@ -1,0 +1,175 @@
+"""Guards on the parity service-account mint script (#365).
+
+The script runs once, by hand, holding the highest-privilege credential in
+the org, against production. That combination means the usual safety net --
+"run it and see" -- does not exist: there is no staging rehearsal that would
+catch a password leaked into ``ps`` output, and no second chance to un-email
+an account-setup token. So the properties that make the procedure safe are
+asserted here against the script's text rather than its behavior.
+
+This mirrors the drift guard on ``sync-library.sh`` in
+``test_catalog_parity_diff.py``: the shell is the artifact an operator runs,
+so the shell is what gets checked.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import stat
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "mint-parity-service-account.sh"
+ARCHITECTURE_DOC = REPO_ROOT / "docs" / "architecture.md"
+
+# The address the harness signs in as. Non-routing by construction: `.invalid`
+# is reserved by RFC 2606 and can never be delegated, so no future catch-all
+# on wxyc.org can turn it into a mailbox that could run `forget-password`
+# against an account holding the whole catalog.
+SERVICE_ACCOUNT_EMAIL = "catalog-parity@wxyc.invalid"
+
+
+@pytest.fixture(scope="module")
+def script() -> str:
+    return SCRIPT_PATH.read_text(encoding="utf-8")
+
+
+class TestMintScript:
+    """Properties an operator cannot verify by reading the output."""
+
+    def test_the_script_exists_and_is_executable(self) -> None:
+        assert SCRIPT_PATH.exists(), f"missing {SCRIPT_PATH}"
+        mode = SCRIPT_PATH.stat().st_mode
+        assert mode & stat.S_IXUSR, "an operator runbook step must be runnable"
+
+    def test_it_fails_loudly(self, script: str) -> None:
+        """No unset variable, no ignored error, no swallowed pipe failure.
+
+        A mint that half-succeeds is worse than one that fails: it can leave a
+        live account whose password was never stored.
+        """
+        assert "set -euo pipefail" in script
+
+    def test_no_secret_ever_reaches_a_command_line(self, script: str) -> None:
+        """argv is world-readable through `ps`, and `set -x` echoes it.
+
+        This is the same argument `docs/architecture.md` makes for routing
+        LIBRARY_DB_PASSWORD through MYSQL_PWD. Bodies go to curl on stdin.
+        """
+        secrets = ("ADMIN_PASSWORD", "SERVICE_PASSWORD", "SESSION")
+        for line in script.splitlines():
+            stripped = line.strip()
+            if stripped.startswith("#") or "curl" not in stripped:
+                continue
+            for name in secrets:
+                assert f'-d "${name}' not in stripped
+                assert f'--data "${name}' not in stripped
+        # Every request body is piped in, never passed as an argument.
+        assert "--data-binary @-" in script
+        assert not re.search(r"--data(-binary|-raw)?\s+['\"]?\{", script), (
+            "a literal JSON body on the command line is one edit away from "
+            "carrying a password there too"
+        )
+
+    def test_the_auth_helper_is_never_run_in_a_pipeline(self, script: str) -> None:
+        """`jq ... | call_auth` runs the function in a subshell.
+
+        Its assignments to HTTP_STATUS/RESPONSE are then lost to the parent,
+        which reads them as empty and reports "sign-in failed with HTTP :"
+        for a request that in fact succeeded -- after the server has already
+        minted a year-long session the script no longer knows how to revoke.
+        Bodies go in through process substitution instead.
+        """
+        assert "| call_auth" not in script
+        assert "< <(jq" in script
+
+    def test_the_admin_password_is_never_echoed(self, script: str) -> None:
+        """Read silently, so it stays out of the terminal and out of history."""
+        assert re.search(r"read\b[^\n]*-[a-z]*s[a-z]*\b[^\n]*ADMIN_PASSWORD", script)
+
+    def test_it_mints_the_documented_principal(self, script: str) -> None:
+        """Drift guard: the script and the runbook must name one account.
+
+        Two spellings of the address means the secret CI holds signs in as an
+        account nobody documented -- and the documented one lingers unused
+        with a password nobody rotates.
+        """
+        assert SERVICE_ACCOUNT_EMAIL in script
+        assert SERVICE_ACCOUNT_EMAIL in ARCHITECTURE_DOC.read_text(encoding="utf-8")
+
+    def test_it_uses_create_user_not_provision_user(self, script: str) -> None:
+        """provision-user emails a 7-day reset token -- the length of the soak.
+
+        Setting the password afterwards does not revoke it, so that path
+        leaves a live takeover link for anyone who can read the mailbox.
+        """
+        assert "admin/create-user" in script
+        # Checked over executable lines only: the script is expected to
+        # *explain* why it avoids provision-user, just never to call it.
+        code = "\n".join(line for line in script.splitlines() if not line.strip().startswith("#"))
+        assert "provision-user" not in code
+
+    def test_it_does_not_send_a_global_admin_role(self, script: str) -> None:
+        """`role` in this body is better-auth's admin plugin, not the org role.
+
+        The org `member` row -- where catalog:read actually comes from -- is
+        inserted by a database hook. Setting `role` here would instead enroll
+        the service account in the admin plugin.
+        """
+        assert '"role"' not in script
+        assert "role:" not in script
+
+    def test_it_revokes_the_admin_session_it_mints(self, script: str) -> None:
+        """better-auth pins session.expiresIn to a year.
+
+        An admin session left behind is a year-long admin credential -- the
+        same defect the harness's own `_TokenSource.close` exists to avoid,
+        one privilege level up.
+        """
+        assert "/sign-out" in script
+        assert "trap " in script, "revocation must survive a mid-script failure"
+
+    def test_the_stored_password_is_not_world_readable(self, script: str) -> None:
+        assert "umask 077" in script or "chmod 600" in script
+
+    def test_the_password_is_generated_not_chosen(self, script: str) -> None:
+        """48 bytes from `secrets`, so no human ever picks or retypes it."""
+        assert "token_urlsafe(48)" in script
+
+    def test_it_refuses_to_put_the_password_on_a_plaintext_wire(self, script: str) -> None:
+        """The same guard the harness applies to its own auth URL."""
+        assert "https://" in script
+        assert re.search(r"https\b", script)
+        assert "must be https" in script or "refusing" in script.lower()
+
+    def test_it_verifies_the_credential_before_reporting_success(self, script: str) -> None:
+        """A password stored but never exercised is a soak that fails on day 1.
+
+        Signing in as the new account and exchanging for a JWT also proves the
+        org `member` row landed -- the hook that grants catalog:read.
+        """
+        assert "/sign-in/email" in script
+        assert "/token" in script
+
+
+class TestRunbookAgreement:
+    """The script and the prose must not describe different procedures."""
+
+    def test_the_runbook_points_at_the_script(self) -> None:
+        doc = ARCHITECTURE_DOC.read_text(encoding="utf-8")
+        assert "mint-parity-service-account.sh" in doc
+
+    def test_the_secret_names_agree(self, script: str) -> None:
+        doc = ARCHITECTURE_DOC.read_text(encoding="utf-8")
+        for name in ("BACKEND_CATALOG_EMAIL", "BACKEND_CATALOG_PASSWORD"):
+            assert name in script
+            assert name in doc
+
+
+def test_the_scratchpad_default_is_not_a_repo_path(script: str) -> None:
+    """A generated password must never land where `git add -A` can reach it."""
+    assert not re.search(r"OUT_DIR=\$\{?\w*:?-?\.?/?(scripts|docs|tests)/", script)
+    assert os.sep in script  # sanity: the script does write files somewhere

--- a/tests/unit/test_mint_parity_service_account.py
+++ b/tests/unit/test_mint_parity_service_account.py
@@ -90,6 +90,38 @@ class TestMintScript:
         """Read silently, so it stays out of the terminal and out of history."""
         assert re.search(r"read\b[^\n]*-[a-z]*s[a-z]*\b[^\n]*ADMIN_PASSWORD", script)
 
+    def test_the_password_read_does_not_strip_whitespace(self, script: str) -> None:
+        """A bare `read` splits on IFS and eats leading/trailing spaces.
+
+        A password that legitimately starts or ends with a space would be
+        silently mangled into one that fails -- and the operator, who can see
+        that their password is correct, has no way to tell that apart from a
+        genuinely rejected credential.
+        """
+        assert re.search(r"IFS=\s+read\b[^\n]*ADMIN_PASSWORD", script)
+
+    def test_it_can_sign_in_by_username(self, script: str) -> None:
+        """WXYC accounts authenticate by username or by email.
+
+        dj-site branches on whether the identifier looks like an email and
+        calls `signIn.username` when it does not, so an operator whose account
+        is username-based cannot mint at all through an email-only path. What
+        they see is an indistinguishable INVALID_EMAIL_OR_PASSWORD.
+        """
+        assert "/sign-in/username" in script
+        assert "--admin-username" in script
+
+    def test_the_sign_in_failure_is_actionable(self, script: str) -> None:
+        """better-auth cannot say which half was wrong, so the script must.
+
+        A 401 here means the identifier did not match a user OR the password
+        did not match that user -- and for an admin staring at a password they
+        know is right, "which one?" is the whole question.
+        """
+        code = "\n".join(line for line in script.splitlines() if not line.strip().startswith("#"))
+        assert "INVALID_EMAIL_OR_PASSWORD" in code or "--admin-username" in code
+        assert re.search(r"401", code), "the 401 branch must explain itself"
+
     def test_it_mints_the_documented_principal(self, script: str) -> None:
         """Drift guard: the script and the runbook must name one account.
 


### PR DESCRIPTION
The parity service account is `catalog-parity@wxyc.invalid`, not `@wxyc.org`. The address is an identifier, not a mailbox.

## Why a reserved TLD rather than an unused `@wxyc.org` local part

The property that matters is not "has no mailbox today" but **"cannot acquire one"**. An `@wxyc.org` address needs no mailbox now, yet anyone who later adds a catch-all — or creates the mailbox for an unrelated reason — silently hands whoever reads that mail the ability to run `forget-password` against an account that holds read access to the entire catalog. [RFC 2606 §2](https://www.rfc-editor.org/rfc/rfc2606#section-2) reserves `.invalid` and guarantees it is never delegated in the global DNS, so the address closes that path off permanently rather than by convention.

Nothing in the mint path needs delivery: `admin/create-user` mints no token and the body sets `emailVerified`, and rotation goes through `admin/set-user-password`. The account never has to receive anything.

## One consequence, documented

A `forget-password` submitted for this address makes SES attempt delivery to a domain that cannot resolve — a hard bounce against the org's sender reputation. The runbook now says plainly that the reset flow is not the rotation path.

## Compatibility

better-auth types the email field as a bare `z.string()` (`node_modules/better-auth/dist/plugins/admin/routes.mjs:109`, `api/routes/sign-in.mjs:220`) with no format validation, so the reserved TLD passes sign-in and create-user unchanged.

Docs, fixtures, and the module comment all move together; 1170 unit tests pass, `ruff check` and `ruff format --check` clean.

Refs #365.
