### PR TITLE
Drop the "expected to FALL" claim the CTA baseline note contradicts (#370)

### DIFF
--- a/parity-residue-pin.txt
+++ b/parity-residue-pin.txt
@@ -64,8 +64,9 @@
 #     from apps/backend/services/catalog-export.service.ts:360-377).
 #     140,617 mysql rows / 2,586 releases vs 144,778 backend rows / 2,576.
 #
-#     These are a CEILING, not a target (the `clean` term is `<=`), and both
-#     numbers are expected to FALL. What they currently hold:
+#     These are a CEILING, not a target (the `clean` term is `<=`). Which
+#     direction each number moves as the residue is repaired is NOT obvious
+#     -- see the note below the decomposition. What they currently hold:
 #
 #       cta_missing 2701 = 869 rows in 10 mysql-only releases, every one of
 #         them a collapsed_mysql_ids id below (so they are already this

--- a/tests/unit/test_parity_residue_pin.py
+++ b/tests/unit/test_parity_residue_pin.py
@@ -76,9 +76,13 @@ def test_ledger_cta_baselines_are_populated() -> None:
     back to the ``EMPTY_BASELINES`` shape.
 
     Deliberately asserts only shape and sign, never the literal numbers: the
-    pair is a **ceiling**, expected to fall as the residue behind it is
-    repaired (see the pin's CTA-baseline note), and a test that froze today's
-    values would redden on exactly the improvement the gate wants.
+    pair is a **ceiling**, and repairing the residue behind it moves the two
+    numbers in directions that are not obvious -- clearing the mojibake
+    duplicates from Backend alone would convert that class from ``cta_extra``
+    to ``cta_missing`` rather than removing it (see the pin's CTA-baseline
+    note). A test that froze today's values would redden on a legitimate
+    re-measurement in either direction, including the improvement the gate
+    exists to wait for.
     """
     baselines = json.loads(LEDGER_JSON.read_text(encoding="utf-8"))["baselines"]
     assert baselines["measured_date"] is not None, (


### PR DESCRIPTION
Follow-up to #376. Comments only — no behavior change.

`parity-residue-pin.txt` shipped saying two incompatible things about the one number that gates the soak:

> These are a CEILING, not a target (the `clean` term is `<=`), and both numbers are **expected to FALL**.

and then, 25 lines later:

> Which way this resolves changes the number, so **do not assume it only falls**. Backend's mysql-matching copies are the CORRUPTED ones, so the 4,879 extra are its clean rows: deleting Backend's corrupted duplicates alone would convert them to `cta_missing` rather than removing the drift.

The second passage is the correct one. The first was written before the id-ordering evidence came in — the finding that the mojibake rows are the *later* inserts, so Backend's clean rows are what report as drift — and it survived the rewrite of the paragraph that falsifies it.

Replaced with a pointer to the note that does the reasoning, rather than restating the direction argument twice and inviting exactly this drift again.

`test_ledger_cta_baselines_are_populated`'s docstring used the same claim as its justification for asserting shape and sign only. That conclusion is right and unchanged — the actual reason is that a frozen literal reddens on a legitimate re-measurement in **either** direction, not that the numbers only go down.

Why it matters beyond tidiness: a reader who takes "expected to FALL" at face value would read a *rise* in `cta_missing` after a partial Backend-side cleanup as a regression, when it is the predicted outcome of fixing only one side. The pin is the artifact that tells the next operator whether a red soak day is real.

The pin's own prose is not covered by either SHA it records (`ledger_json_sha256` / `residue_ledger_md_sha256` hash the two vendored files), so no hash moves.

## Verification

`ruff check` clean · `ruff format --check` 153 files · `tests/unit/test_parity_residue_pin.py` 4 passed.