### PR TITLE
docs: point the unwired-secrets note at the filed soak workflow (#378)

### DIFF
--- a/docs/automation.md
+++ b/docs/automation.md
@@ -113,7 +113,12 @@ After a successful run, verify the library-metadata-lookup health endpoint retur
 
 ## Unwired secrets (catalog parity)
 
-Two repo secrets exist that **no workflow reads yet**. They authenticate the Backend-sourced producer in `scripts/catalog_parity_diff.py` against `GET /library/catalog` — the catalog-parity soak on [wiki#89](https://github.com/WXYC/wiki/issues/89), which runs by hand today. [#370](https://github.com/WXYC/discogs-etl/issues/370) gave the harness a `clean` verdict and a `--fail-on-drift` exit code (4) for exactly this purpose, but that flag still has no consumer: a scheduled workflow needs the Kattare SSH tunnel and the MariaDB client (`sync-library.yml` is the shape to copy), which is real scope and was deliberately not folded into #370. Until that follow-up workflow is filed and lands, these secrets are set so the soak can run unattended from a runner or a laptop without a credential detour, and the seven-consecutive-clean-days streak stays a hand-run invocation.
+Two repo secrets exist that **no workflow reads yet**. They authenticate the Backend-sourced producer in `scripts/catalog_parity_diff.py` against `GET /library/catalog` — the catalog-parity soak on [wiki#89](https://github.com/WXYC/wiki/issues/89), which runs by hand today. [#370](https://github.com/WXYC/discogs-etl/issues/370) gave the harness a `clean` verdict and a `--fail-on-drift` exit code (4) for exactly this purpose, but that flag still has no consumer: a scheduled workflow needs the Kattare SSH tunnel and the MariaDB client (`sync-library.yml` is the shape to copy), which is real scope and was deliberately not folded into #370. That workflow is now filed as **[#378](https://github.com/WXYC/discogs-etl/issues/378)**, which #346 is blocked by; until it lands, these secrets are set so the soak can run unattended from a runner or a laptop without a credential detour, and the seven-consecutive-clean-days streak stays a hand-run invocation.
+
+Two things that cost time on the first live run ([#346's step-8a measurement](https://github.com/WXYC/discogs-etl/issues/346#issuecomment-5287728924)) and that #378 has to carry, so they are recorded here rather than only in that comment:
+
+- **The MySQL producer needs a MariaDB client.** The Homebrew MySQL 9.7 client **segfaults (exit 139)** against tubafrenzy's MySQL 5.1.56. `sync-library.yml` installs `mariadb-client` for exactly this reason.
+- **`--default-character-set=utf8` is load-bearing.** Without it the connection negotiates latin1 and the dump is not valid UTF-8, which fails `parse_library_tsv` outright rather than showing up as drift. `scripts/sync-library.sh` passes it on both SELECTs.
 
 | Secret | Description |
 |--------|-------------|


### PR DESCRIPTION
Plan step 8 (`plans/346-parity-clean-definition.md`) is "a comment, not a commit" — with one exception the plan names itself: Part 4 said `docs/automation.md`'s unwired-secrets note should "point at that ticket rather than at #346 generally". The ticket only existed once step 8 ran, so this is the one line that could not land with step 7.

## What changed

`docs/automation.md`'s "Unwired secrets (catalog parity)" section now names [#378](https://github.com/WXYC/discogs-etl/issues/378) — the scheduled soak workflow, filed today — and records that [#346](https://github.com/WXYC/discogs-etl/issues/346) is marked blocked by it in the issue graph.

It also picks up the two things that cost real time on the first live run of the harness against the prod pair, both of which are constraints #378's workflow has to satisfy:

- **A MariaDB client is required.** The Homebrew MySQL 9.7 client segfaults (exit 139) against tubafrenzy's MySQL 5.1.56. `sync-library.yml` already installs `mariadb-client`; anyone copying that shape needs to know why it is there.
- **`--default-character-set=utf8` is load-bearing.** Without it the connection negotiates latin1 and the dump is not valid UTF-8, so `parse_library_tsv` fails outright instead of reporting drift — a failure mode that looks like a broken harness rather than a missing flag.

Both were previously only in an issue comment. They belong in the doc the workflow author will actually open.

## Verification

Docs-only, no code paths touched. `ruff check` clean, `ruff format --check` 153 files, full unit suite 1374 passed / 3 deselected / 1 xfailed run from this worktree (`tests/unit/test_sync_library_derive_wiring.py` asserts over `docs/automation.md`, so this is not a no-op check).

Context: the step-8a prod measurement is [on #346](https://github.com/WXYC/discogs-etl/issues/346#issuecomment-5287728924).
