### PR TITLE
fix(#361): keep credentialed DSNs out of pipeline step failure tracebacks and logs

### DIFF
--- a/lib/dsn.py
+++ b/lib/dsn.py
@@ -1,0 +1,57 @@
+"""Single canonical redactor for PostgreSQL connection strings.
+
+Every script in this repo that logs which database it is about to talk to
+routes through :func:`redact_dsn`. The pipeline log is teed to the S3 rebuild
+log bucket by ``rebuild-cache-bootstrap.sh``, so a connection string echoed on
+the happy path publishes the cache credential (#361, #227).
+
+Redaction must *parse*, not pattern-match. Three call sites had independently
+grown ``db_url.split("@")[-1]``, which silently assumes the URL DSN form.
+libpq also accepts keyword/value conninfo --
+``host=cache-host dbname=discogs user=svc password=hunter2`` -- which
+``psycopg.connect()`` accepts and which contains no ``@`` at all, so that
+expression returned the entire string, password included. It failed open on
+exactly the input a shell-set ``DATABASE_URL_DISCOGS`` is most likely to hold
+when someone hand-writes one.
+"""
+
+from __future__ import annotations
+
+from psycopg.conninfo import conninfo_to_dict
+
+#: Returned when the DSN cannot be parsed. Deliberately not the input string:
+#: a DSN we failed to understand may still be a credentialed one.
+UNPARSEABLE = "<unparseable target>"
+
+
+def redact_dsn(db_url: str) -> str:
+    """Return a loggable ``host[:port]/dbname`` for *db_url*, never credentials.
+
+    Uses psycopg's conninfo parser so both DSN forms libpq accepts are
+    handled: URL (``postgresql://user:pw@host:5433/discogs``) and keyword/value
+    (``host=host port=5433 dbname=discogs user=user password=pw``). Only the
+    host, port, and database name are ever read out of the parsed mapping, so
+    a credential can never reach the returned string regardless of which
+    conninfo key it arrived under.
+
+    Missing components degrade to descriptive placeholders (``<local socket>``,
+    ``<default db>``) rather than being omitted, so the shape of the log line
+    stays stable. A parse failure degrades to :data:`UNPARSEABLE` rather than
+    risking echoing the raw string or raising -- the caller is on its way to
+    ``connect()``, which will produce a far clearer error a moment later.
+
+    Args:
+        db_url: A libpq connection string in either supported form.
+
+    Returns:
+        ``host[:port]/dbname`` with placeholders substituted for absent
+        components, or :data:`UNPARSEABLE` if *db_url* could not be parsed.
+    """
+    try:
+        info = conninfo_to_dict(db_url)
+    except Exception:
+        return UNPARSEABLE
+    host = info.get("host") or "<local socket>"
+    port = f":{info['port']}" if info.get("port") else ""
+    dbname = info.get("dbname") or "<default db>"
+    return f"{host}{port}/{dbname}"

--- a/scripts/dedup_releases.py
+++ b/scripts/dedup_releases.py
@@ -28,6 +28,7 @@ from pathlib import Path
 import psycopg
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+from lib.dsn import redact_dsn  # noqa: E402
 from lib.keep_release_ids import parse_keep_release_ids  # noqa: E402
 from lib.observability import init_logger  # noqa: E402
 from lib.pg_concurrent_ddl import (  # noqa: E402
@@ -1055,7 +1056,7 @@ def main():
 
     init_logger(repo="discogs-etl", tool="discogs-etl dedup_releases")
 
-    logger.info(f"Connecting to {db_url}")
+    logger.info("Connecting to %s", redact_dsn(db_url))
     conn = psycopg.connect(db_url, autocommit=True)
 
     # Step 0 (optional): Load WXYC label preferences for label-aware ranking

--- a/scripts/derive_va_release.py
+++ b/scripts/derive_va_release.py
@@ -68,6 +68,7 @@ from pathlib import Path
 import psycopg
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+from lib.dsn import redact_dsn  # noqa: E402
 from lib.observability import init_logger  # noqa: E402
 
 logger = logging.getLogger(__name__)
@@ -188,25 +189,6 @@ def resolve_floor(cli_value: int | None) -> int:
         raise SystemExit(f"error: VA_RELEASE_FLOOR must be an integer, got {raw!r}") from None
 
 
-def _describe_target(database_url: str) -> str:
-    """Loggable host/database of the target DSN, never including credentials.
-
-    Uses psycopg's conninfo parser so key/value DSNs (``host=... password=...``)
-    are handled — a naive urlparse would put the whole conninfo, password
-    included, into ``.path``. Any parse failure degrades to a placeholder
-    rather than risking echoing the raw (credentialed) string or crashing
-    before psycopg.connect can produce its clearer error.
-    """
-    try:
-        info = psycopg.conninfo.conninfo_to_dict(database_url)
-        host = info.get("host") or "<local socket>"
-        port = f":{info['port']}" if info.get("port") else ""
-        dbname = info.get("dbname") or "<default db>"
-        return f"{host}{port}/{dbname}"
-    except Exception:
-        return "<unparseable target>"
-
-
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=(__doc__ or "").split("\n", 1)[0])
     parser.add_argument(
@@ -248,7 +230,7 @@ def main(argv: list[str] | None = None) -> int:
         )
         return 2
 
-    logger.info("Deriving va_release on %s", _describe_target(database_url))
+    logger.info("Deriving va_release on %s", redact_dsn(database_url))
     try:
         with psycopg.connect(database_url) as conn:
             derive_va_release(conn, floor=floor)

--- a/scripts/import_csv.py
+++ b/scripts/import_csv.py
@@ -28,6 +28,7 @@ except ImportError:
 sys.path.insert(0, str(Path(__file__).parent.parent))
 from wxyc_etl.pg import to_pg_text_form  # noqa: E402
 
+from lib.dsn import redact_dsn  # noqa: E402
 from lib.format_normalization import normalize_format  # noqa: E402
 from lib.observability import init_logger  # noqa: E402
 
@@ -1313,7 +1314,7 @@ def main():
         logger.error(f"CSV directory not found: {csv_dir}")
         sys.exit(1)
 
-    logger.info(f"Connecting to {db_url}")
+    logger.info("Connecting to %s", redact_dsn(db_url))
     conn = psycopg.connect(db_url)
 
     # --masters-only self-truncates its two tables inside import_masters, so it

--- a/scripts/resolve_collisions.py
+++ b/scripts/resolve_collisions.py
@@ -28,6 +28,7 @@ from pathlib import Path
 import psycopg
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+from lib.dsn import redact_dsn  # noqa: E402
 from lib.observability import init_logger  # noqa: E402
 
 logger = logging.getLogger(__name__)
@@ -533,7 +534,7 @@ def main(argv: list[str] | None = None) -> None:
     load_wxyc_titles(args.library_db, artists)
 
     # Connect to Discogs cache
-    logger.info("Connecting to Discogs cache: %s", args.database_url.split("@")[-1])
+    logger.info("Connecting to Discogs cache: %s", redact_dsn(args.database_url))
     conn = psycopg.connect(args.database_url)
 
     # Batch-lookup wrong artist IDs (uses B-tree index, fast)

--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -41,6 +41,7 @@ import psycopg
 from wxyc_etl.state import PipelineState
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+from lib.dsn import redact_dsn  # noqa: E402
 from lib.observability import init_logger  # noqa: E402
 
 STEP_NAMES = [
@@ -361,21 +362,12 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     return args
 
 
-def _redact_dsn(db_url: str) -> str:
-    """Strip userinfo from a connection string, keeping host/port/database.
-
-    Same shape as scripts/resolve_collisions.py and derive_va_release.py's
-    _describe_target. A DSN with no userinfo is returned unchanged.
-    """
-    return db_url.split("@")[-1]
-
-
 def wait_for_postgres(db_url: str) -> None:
     """Poll Postgres until a connection succeeds or timeout is reached."""
     # Redacted: this logs on every run, success or failure, and
     # rebuild-cache-bootstrap.sh tees the pipeline log to the S3 log bucket.
     # Unredacted, it published the cache credential on the happy path (#361).
-    logger.info("Waiting for PostgreSQL at %s ...", _redact_dsn(db_url))
+    logger.info("Waiting for PostgreSQL at %s ...", redact_dsn(db_url))
     deadline = time.monotonic() + PG_CONNECT_TIMEOUT
     delay = 0.5
     while True:
@@ -524,15 +516,14 @@ def run_step_safe(description: str, cmd: list[str], **kwargs) -> None:
     "the above exception" context.
 
     Scope, so the guarantee is not overread: this closes the *traceback*
-    channel only. Two other channels still carry the DSN into the same log
-    and are deliberately out of this function's reach --
-    (1) the child scripts log their own connection string at startup, which
-    belongs to #227 and needs those files edited; and (2) Sentry's
-    excepthook integration captures frame locals by default, so the
+    channel only. The startup line each child script logs was the second
+    channel into the same log; those now route through lib/dsn.py's
+    redact_dsn, so the only channel still carrying the DSN is Sentry's
+    excepthook integration, which captures frame locals by default -- the
     argv-bearing ``cmd`` local survives in the event payload even though
-    ``from None`` correctly stops its chain walk. The durable fix for both
-    is #361's own suggestion: have those scripts read DATABASE_URL_DISCOGS
-    from a merged os.environ instead of argv.
+    ``from None`` correctly stops its chain walk. The durable fix for that
+    last one is #361's own suggestion: have these scripts read
+    DATABASE_URL_DISCOGS from a merged os.environ instead of argv.
     """
     try:
         run_step(description, cmd, **kwargs)

--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -486,6 +486,37 @@ def run_step(description: str, cmd: list[str], **kwargs) -> None:
     logger.info("  completed in %.1fs", elapsed)
 
 
+def run_step_safe(description: str, cmd: list[str], **kwargs) -> None:
+    """Run a step via run_step(), keeping a credentialed argv out of any
+    exception that escapes a failed step (#361).
+
+    dedup_releases.py, import_csv.py, and verify_cache.py all take the
+    cache database URL positionally rather than via environment variable.
+    run_step() already logs the failure safely (exit code + elapsed time,
+    no argv) before raising subprocess.CalledProcessError, but
+    CalledProcessError.__str__ embeds the *full* argv it was constructed
+    with -- credentials and all. Left uncaught, that string is exactly what
+    Python's default exception handler prints to stderr, and
+    rebuild-cache-bootstrap.sh tees stdout/stderr straight to the rebuild
+    log bucket on every step failure.
+
+    Same precedent as run_derive_va_release_step (~line 514): log only the
+    exit code, never str(exc) or cmd. Unlike that soft-fail step, these
+    steps are not optional, so this re-raises rather than swallowing the
+    failure -- but the re-raised CalledProcessError carries *description*
+    (a plain label) as its ``cmd``, never the real argv, so its own
+    __str__ stays credential-free no matter how far up the call stack it
+    is eventually printed or logged. ``from None`` suppresses Python's
+    implicit exception chaining, which would otherwise still print the
+    original, argv-bearing exception as "the above exception" context.
+    """
+    try:
+        run_step(description, cmd, **kwargs)
+    except subprocess.CalledProcessError as exc:
+        logger.error("%s failed (exit %d)", description, exc.returncode)
+        raise subprocess.CalledProcessError(exc.returncode, description) from None
+
+
 def run_derive_va_release_step(db_url: str, python: str) -> bool:
     """Best-effort derive_va_release step (#344), shared by both build paths.
 
@@ -1272,7 +1303,7 @@ def _run_database_build_post_import(
     dedup_cmd.extend(["--keep-release-ids", str(keep_release_ids_path)])
     dedup_cmd.append(db_url)
 
-    run_step("Deduplicate releases", dedup_cmd)
+    run_step_safe("Deduplicate releases", dedup_cmd)
 
     # -- create_track_indexes (FK constraints, FK indexes, trigram indexes)
     # Level 0: Clean orphan track rows before FK validation (parallel).
@@ -1328,7 +1359,7 @@ def _run_database_build_post_import(
 
     # -- prune (optional)
     if library_db:
-        run_step(
+        run_step_safe(
             "Prune to library matches",
             [
                 python,
@@ -1457,7 +1488,7 @@ def _run_database_build(
         if truncate_existing:
             import_cmd.append("--truncate-existing")
         import_cmd.extend([str(csv_dir), db_url])
-        run_step("Import base CSVs", import_cmd)
+        run_step_safe("Import base CSVs", import_cmd)
         if state:
             state.mark_completed("import_csv")
             _save_state()
@@ -1516,7 +1547,7 @@ def _run_database_build(
         dedup_cmd.extend(["--keep-release-ids", str(keep_release_ids_path)])
         dedup_cmd.append(db_url)
 
-        run_step("Deduplicate releases", dedup_cmd)
+        run_step_safe("Deduplicate releases", dedup_cmd)
         if state:
             state.mark_completed("dedup")
             _save_state()
@@ -1535,7 +1566,7 @@ def _run_database_build(
         # to make the no-op explicit.)
         tracks_cmd = [python, str(SCRIPT_DIR / "import_csv.py"), "--tracks-only"]
         tracks_cmd.extend([str(csv_dir), db_url])
-        run_step("Import tracks", tracks_cmd)
+        run_step_safe("Import tracks", tracks_cmd)
         if state:
             state.mark_completed("import_tracks")
             _save_state()
@@ -1594,7 +1625,7 @@ def _run_database_build(
     if state and state.is_completed("prune"):
         logger.info("Skipping prune/copy-to (already completed)")
     elif library_db and target_db_url:
-        run_step(
+        run_step_safe(
             "Copy matched releases to target database",
             [
                 python,
@@ -1612,7 +1643,7 @@ def _run_database_build(
             state.mark_completed("prune")
             _save_state()
     elif library_db:
-        run_step(
+        run_step_safe(
             "Prune to library matches",
             [
                 python,

--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -361,9 +361,21 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     return args
 
 
+def _redact_dsn(db_url: str) -> str:
+    """Strip userinfo from a connection string, keeping host/port/database.
+
+    Same shape as scripts/resolve_collisions.py and derive_va_release.py's
+    _describe_target. A DSN with no userinfo is returned unchanged.
+    """
+    return db_url.split("@")[-1]
+
+
 def wait_for_postgres(db_url: str) -> None:
     """Poll Postgres until a connection succeeds or timeout is reached."""
-    logger.info("Waiting for PostgreSQL at %s ...", db_url)
+    # Redacted: this logs on every run, success or failure, and
+    # rebuild-cache-bootstrap.sh tees the pipeline log to the S3 log bucket.
+    # Unredacted, it published the cache credential on the happy path (#361).
+    logger.info("Waiting for PostgreSQL at %s ...", _redact_dsn(db_url))
     deadline = time.monotonic() + PG_CONNECT_TIMEOUT
     delay = 0.5
     while True:
@@ -491,24 +503,36 @@ def run_step_safe(description: str, cmd: list[str], **kwargs) -> None:
     exception that escapes a failed step (#361).
 
     dedup_releases.py, import_csv.py, and verify_cache.py all take the
-    cache database URL positionally rather than via environment variable.
-    run_step() already logs the failure safely (exit code + elapsed time,
-    no argv) before raising subprocess.CalledProcessError, but
+    cache database URL positionally rather than via environment variable;
+    the discogs-xml-converter binary and the wxyc-catalog CLIs take theirs
+    as a flag. The distinction does not matter here, because
     CalledProcessError.__str__ embeds the *full* argv it was constructed
-    with -- credentials and all. Left uncaught, that string is exactly what
-    Python's default exception handler prints to stderr, and
-    rebuild-cache-bootstrap.sh tees stdout/stderr straight to the rebuild
-    log bucket on every step failure.
+    with -- credentials and all. run_step() already logs the failure safely
+    (exit code + elapsed time, no argv) before raising, but left uncaught
+    that string is exactly what Python's default exception handler prints
+    to stderr, and rebuild-cache-bootstrap.sh tees stdout/stderr straight
+    to the rebuild log bucket on every step failure.
 
-    Same precedent as run_derive_va_release_step (~line 514): log only the
-    exit code, never str(exc) or cmd. Unlike that soft-fail step, these
-    steps are not optional, so this re-raises rather than swallowing the
-    failure -- but the re-raised CalledProcessError carries *description*
-    (a plain label) as its ``cmd``, never the real argv, so its own
-    __str__ stays credential-free no matter how far up the call stack it
-    is eventually printed or logged. ``from None`` suppresses Python's
-    implicit exception chaining, which would otherwise still print the
-    original, argv-bearing exception as "the above exception" context.
+    Same precedent as run_derive_va_release_step below: log only the exit
+    code, never str(exc) or cmd. Unlike that soft-fail step, these steps
+    are not optional, so this re-raises rather than swallowing the failure
+    -- but the re-raised CalledProcessError carries *description* (a plain
+    label) as its ``cmd``, never the real argv, so its own __str__ stays
+    credential-free however far up the call stack it is printed or logged.
+    ``from None`` suppresses Python's implicit exception chaining, which
+    would otherwise still print the original, argv-bearing exception as
+    "the above exception" context.
+
+    Scope, so the guarantee is not overread: this closes the *traceback*
+    channel only. Two other channels still carry the DSN into the same log
+    and are deliberately out of this function's reach --
+    (1) the child scripts log their own connection string at startup, which
+    belongs to #227 and needs those files edited; and (2) Sentry's
+    excepthook integration captures frame locals by default, so the
+    argv-bearing ``cmd`` local survives in the event payload even though
+    ``from None`` correctly stops its chain walk. The durable fix for both
+    is #361's own suggestion: have those scripts read DATABASE_URL_DISCOGS
+    from a merged os.environ instead of argv.
     """
     try:
         run_step(description, cmd, **kwargs)
@@ -913,7 +937,10 @@ def convert_and_filter(
     description = (
         "Convert and import XML to PostgreSQL" if database_url else "Convert and filter XML to CSV"
     )
-    run_step(description, cmd)
+    # run_step_safe even though the converter takes --database-url as a flag
+    # rather than positionally: CalledProcessError.__str__ embeds the whole
+    # argv either way, and in --direct-pg mode that argv holds the cache DSN.
+    run_step_safe(description, cmd)
 
 
 def _infer_pipeline_state(db_url: str, csv_dir: str) -> PipelineState:
@@ -1037,8 +1064,13 @@ def generate_library_db(
     catalog_source: str,
     catalog_db_url: str,
 ) -> None:
-    """Step 0: Generate library.db from WXYC catalog via wxyc-catalog CLI."""
-    run_step(
+    """Step 0: Generate library.db from WXYC catalog via wxyc-catalog CLI.
+
+    --catalog-db-url is a *second* credential (tubafrenzy MySQL or
+    Backend-Service PostgreSQL), so this needs the same argv redaction as the
+    cache-DSN steps.
+    """
+    run_step_safe(
         "Generate library.db",
         [
             "wxyc-export-to-sqlite",
@@ -1282,7 +1314,7 @@ def _run_database_build_post_import(
     labels_csv = library_labels
     if labels_csv is None and catalog_source is not None and catalog_db_url is not None:
         labels_csv = Path(tempfile.mkdtemp(prefix="discogs_labels_")) / "library_labels.csv"
-        run_step(
+        run_step_safe(
             "Extract WXYC library labels",
             [
                 "wxyc-extract-library-labels",
@@ -1526,7 +1558,7 @@ def _run_database_build(
         labels_csv = library_labels
         if labels_csv is None and catalog_source is not None and catalog_db_url is not None:
             labels_csv = Path(tempfile.mkdtemp(prefix="discogs_labels_")) / "library_labels.csv"
-            run_step(
+            run_step_safe(
                 "Extract WXYC library labels",
                 [
                     "wxyc-extract-library-labels",

--- a/scripts/verify_cache.py
+++ b/scripts/verify_cache.py
@@ -62,6 +62,7 @@ from rapidfuzz import fuzz, process
 sys.path.insert(0, str(Path(__file__).parent.parent))
 from wxyc_etl.text import is_compilation_artist, split_artist_name_contextual
 
+from lib.dsn import redact_dsn
 from lib.format_normalization import format_matches, normalize_library_format
 from lib.keep_release_ids import parse_keep_release_ids
 from lib.observability import init_logger
@@ -2336,7 +2337,7 @@ async def async_main():
     index = LibraryIndex.from_sqlite(args.library_db)
 
     # Step 3: Connect to Discogs cache and load releases
-    logger.info(f"Connecting to {args.database_url}")
+    logger.info("Connecting to %s", redact_dsn(args.database_url))
     conn = await asyncpg.connect(args.database_url)
 
     try:

--- a/tests/unit/test_derive_va_release_cli.py
+++ b/tests/unit/test_derive_va_release_cli.py
@@ -9,6 +9,7 @@ any of them only surfaces in a prod daily-run log otherwise.
 from __future__ import annotations
 
 import importlib.util
+import logging
 import sys
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -129,31 +130,28 @@ class TestFloorResolution:
 
 
 class TestTargetDescription:
-    def test_describe_target_never_includes_credentials(self, clean_env) -> None:
-        described = derive_module._describe_target(
-            "postgresql://user:hunter2@db.example.com:5433/discogs"
-        )
-        assert "hunter2" not in described
-        assert "user" not in described
-        assert described == "db.example.com:5433/discogs"
+    """The "Deriving va_release on ..." line is routed through the shared
+    redactor in lib/dsn.py; the parser's own edge cases (both DSN forms, bad
+    port, unparseable input) are pinned in tests/unit/test_dsn.py. What is
+    load-bearing *here* is that this call site still goes through it — the
+    daily sync tees this log, so an unredacted target publishes the cache
+    credential on the happy path.
+    """
 
-    def test_describe_target_conninfo_form_never_leaks_password(self, clean_env) -> None:
-        """psycopg accepts key/value DSNs too; a naive urlparse puts the whole
-        conninfo — password included — into .path and would log it."""
-        described = derive_module._describe_target(
-            "host=prod.example.com port=5433 dbname=discogs user=etl password=hunter2"
-        )
-        assert "hunter2" not in described
-        assert "password" not in described
-        assert described == "prod.example.com:5433/discogs"
-
-    def test_describe_target_bad_port_neither_crashes_nor_leaks(self, clean_env) -> None:
-        """urlparse's .port would raise on a non-numeric port before psycopg
-        could produce its clearer connect error; conninfo parsing just passes
-        it through — the log line must simply never crash or leak."""
-        described = derive_module._describe_target("postgresql://etluser:hunter2@host:notaport/db")
-        assert "hunter2" not in described
-        assert "etluser" not in described
-
-    def test_describe_target_degrades_on_unparseable_input(self, clean_env) -> None:
-        assert derive_module._describe_target("%%not-a-dsn%%") == "<unparseable target>"
+    @pytest.mark.parametrize(
+        "dsn",
+        [
+            "postgresql://etl:hunter2@db.example.com:5433/discogs",
+            "host=db.example.com port=5433 dbname=discogs user=etl password=hunter2",
+        ],
+        ids=["url", "conninfo"],
+    )
+    def test_target_line_redacts_dsn(self, clean_env, caplog, dsn: str) -> None:
+        with caplog.at_level(logging.INFO, logger=derive_module.logger.name):
+            code, _, _ = _run_main(["--database-url", dsn])
+        assert code == 0
+        logged = " ".join(record.getMessage() for record in caplog.records)
+        assert "hunter2" not in logged
+        assert "password" not in logged
+        # Still useful to an operator: the target survives redaction.
+        assert "db.example.com:5433/discogs" in logged

--- a/tests/unit/test_dsn.py
+++ b/tests/unit/test_dsn.py
@@ -1,0 +1,90 @@
+"""Unit tests for lib/dsn.py, the single canonical DSN redactor.
+
+Three scripts had grown their own redactor and two of them failed open. The
+naive form -- ``db_url.split("@")[-1]`` -- assumes a URL DSN. libpq also
+accepts keyword/value conninfo (``host=... password=...``), which psycopg
+connects with happily and which contains no ``@`` at all, so the "redaction"
+returned the whole string, password included. These tests pin the parsed
+behaviour for every DSN shape the pipeline can be handed.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from lib.dsn import redact_dsn
+
+
+class TestUrlForm:
+    def test_url_form_drops_userinfo(self) -> None:
+        assert (
+            redact_dsn("postgresql://etluser:hunter2@db.example.com:5433/discogs")
+            == "db.example.com:5433/discogs"
+        )
+
+    def test_url_form_without_credentials_still_normalizes(self) -> None:
+        """The scheme prefix is not useful to an operator and is dropped, so
+        credentialed and uncredentialed DSNs log in one identical shape."""
+        assert (
+            redact_dsn("postgresql://db.example.com:5433/discogs") == "db.example.com:5433/discogs"
+        )
+
+    def test_url_form_without_port(self) -> None:
+        assert redact_dsn("postgresql://etl:pw@db.example.com/discogs") == "db.example.com/discogs"
+
+    def test_percent_encoded_password_does_not_survive_decoding(self) -> None:
+        """A password with a reserved character arrives percent-encoded; the
+        conninfo parser decodes it, so the redactor must be reading named
+        fields rather than trimming a prefix off the raw string."""
+        described = redact_dsn("postgresql://etl:p%40ss@db.example.com:5433/discogs")
+        assert "p@ss" not in described
+        assert "p%40ss" not in described
+        assert described == "db.example.com:5433/discogs"
+
+
+class TestKeywordValueForm:
+    """The regression this module exists to prevent (#361 follow-up)."""
+
+    CONNINFO = "host=cache-host port=5432 dbname=discogs user=svc password=hunter2"
+
+    def test_keyword_value_form_never_leaks_password(self) -> None:
+        described = redact_dsn(self.CONNINFO)
+        assert "hunter2" not in described
+        assert "password" not in described
+        assert "svc" not in described
+        assert described == "cache-host:5432/discogs"
+
+    def test_naive_split_would_have_leaked(self) -> None:
+        """Pins *why* the parsed implementation is required: the string the
+        old redactor returned for this input was the input itself."""
+        assert "hunter2" in self.CONNINFO.split("@")[-1]
+
+    def test_quoted_password_with_spaces_never_leaks(self) -> None:
+        described = redact_dsn("host=cache-host dbname=discogs password='hunter 2'")
+        assert "hunter" not in described
+        assert described == "cache-host/discogs"
+
+
+class TestDegradedInputs:
+    def test_non_numeric_port_neither_crashes_nor_leaks(self) -> None:
+        """urlparse's ``.port`` raises on a non-numeric port before psycopg
+        can produce its clearer connect error; conninfo parsing passes it
+        through, and the log line must simply never crash or leak."""
+        described = redact_dsn("postgresql://etluser:hunter2@host:notaport/db")
+        assert "hunter2" not in described
+        assert "etluser" not in described
+
+    def test_unparseable_input_degrades_to_placeholder(self) -> None:
+        """Never echo a string we failed to parse -- it may be a credentialed
+        DSN we simply did not understand."""
+        assert redact_dsn("%%not-a-dsn%%") == "<unparseable target>"
+
+    @pytest.mark.parametrize("raw", ["", "   "])
+    def test_empty_dsn_describes_the_libpq_defaults(self, raw: str) -> None:
+        assert redact_dsn(raw) == "<local socket>/<default db>"
+
+    def test_socket_dsn_without_host(self) -> None:
+        assert redact_dsn("postgresql:///discogs") == "<local socket>/discogs"
+
+    def test_host_without_dbname(self) -> None:
+        assert redact_dsn("host=cache-host port=5433") == "cache-host:5433/<default db>"

--- a/tests/unit/test_run_pipeline.py
+++ b/tests/unit/test_run_pipeline.py
@@ -2265,13 +2265,21 @@ class TestRunStepSafe:
 
 
 class TestArgvCredentialRedaction:
-    """Every argv call site that carries the cache database URL (#361) must
-    route through run_step_safe, so a step failure never surfaces the DSN
-    in a propagated exception. Covers all four scripts named in #361:
-    dedup_releases.py, import_csv.py, and verify_cache.py (two call sites
-    each, one per build path)."""
+    """Every argv call site that carries a credentialed database URL (#361)
+    must route through run_step_safe, so a step failure never surfaces the
+    DSN in a propagated exception.
+
+    Two credentials reach argv in this file. The cache DSN goes to
+    dedup_releases.py, import_csv.py, verify_cache.py (two call sites each,
+    one per build path) and — in --direct-pg mode — the discogs-xml-converter
+    binary's --database-url. The WXYC catalog DSN goes to the wxyc-catalog
+    CLIs (wxyc-export-to-sqlite, wxyc-extract-library-labels). Flag-vs-
+    positional makes no difference: CalledProcessError.__str__ embeds the
+    whole argv either way.
+    """
 
     DSN = "postgresql://svc:hunter2@cache-host/discogs"
+    CATALOG_DSN = "postgresql://cat:s3cr3t@catalog-host/wxyc"
 
     def _mock_conn(self):
         mock_cursor = MagicMock()
@@ -2285,7 +2293,15 @@ class TestArgvCredentialRedaction:
         mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
         return mock_conn
 
-    def _assert_dsn_redacted(self, fake_run_step, invoke) -> None:
+    def _assert_dsn_redacted(self, fake_run_step, invoke, expected_cmd) -> None:
+        """Drive a build path whose *expected_cmd* step fails, and assert the
+        escaping exception is the redacted one.
+
+        Asserting on the exception *type* and on ``.cmd`` matters: a bare
+        ``pytest.raises(Exception)`` would still pass if a drifting mock made
+        the build die with a TypeError before ever reaching the failing step,
+        leaving the guard green while testing nothing.
+        """
         with (
             patch.object(run_pipeline, "run_step", side_effect=fake_run_step),
             patch.object(run_pipeline, "wait_for_postgres"),
@@ -2302,10 +2318,14 @@ class TestArgvCredentialRedaction:
             mock_check.return_value = run_pipeline.ReloadInvariantResult(
                 ok=True, release_count=1, artist_coverage=1.0, track_coverage=1.0
             )
-            with pytest.raises(Exception) as excinfo:
+            with pytest.raises(subprocess.CalledProcessError) as excinfo:
                 invoke()
-        assert self.DSN not in str(excinfo.value)
-        assert "hunter2" not in str(excinfo.value)
+        # The redacted re-raise carries the plain step label as its cmd, which
+        # proves the run_step_safe path ran rather than some earlier failure.
+        assert excinfo.value.cmd == expected_cmd
+        rendered = str(excinfo.value)
+        for secret in (self.DSN, self.CATALOG_DSN, "hunter2", "s3cr3t"):
+            assert secret not in rendered
 
     @pytest.mark.parametrize(
         "failing_step_name",
@@ -2325,6 +2345,7 @@ class TestArgvCredentialRedaction:
                 sys.executable,
                 state=None,
             ),
+            failing_step_name,
         )
 
     def test_database_build_copy_to_step_failure_redacts_dsn(self) -> None:
@@ -2342,6 +2363,7 @@ class TestArgvCredentialRedaction:
                 target_db_url="postgresql://svc:hunter2@target-host/discogs",
                 state=None,
             ),
+            "Copy matched releases to target database",
         )
 
     @pytest.mark.parametrize(
@@ -2358,4 +2380,120 @@ class TestArgvCredentialRedaction:
             lambda: run_pipeline._run_database_build_post_import(
                 self.DSN, Path("/tmp/csv"), Path("/tmp/library.db"), sys.executable
             ),
+            failing_step_name,
         )
+
+    # -- the converter binary: same cache DSN, passed as --database-url ------
+    #
+    # #361's survey named three *scripts*, so the converter invocation was not
+    # in its table. But in --direct-pg mode convert_and_filter puts the cache
+    # DSN into argv exactly like the others, and nothing up the stack catches
+    # the CalledProcessError, so it reaches the default excepthook and the
+    # log bucket identically.
+
+    def test_converter_failure_redacts_dsn(self) -> None:
+        def fake_run_step(step_name, cmd, *args, **kwargs):
+            raise subprocess.CalledProcessError(1, cmd)
+
+        with patch.object(run_pipeline, "run_step", side_effect=fake_run_step):
+            with pytest.raises(subprocess.CalledProcessError) as excinfo:
+                run_pipeline.convert_and_filter(
+                    Path("/data/releases.xml.gz"),
+                    Path("/tmp/csv"),
+                    "discogs-xml-converter",
+                    database_url=self.DSN,
+                )
+        rendered = str(excinfo.value)
+        assert self.DSN not in rendered
+        assert "hunter2" not in rendered
+
+    def test_converter_csv_mode_still_reports_failure(self) -> None:
+        """CSV mode carries no DSN, but must still fail loudly."""
+
+        def fake_run_step(step_name, cmd, *args, **kwargs):
+            raise subprocess.CalledProcessError(3, cmd)
+
+        with patch.object(run_pipeline, "run_step", side_effect=fake_run_step):
+            with pytest.raises(subprocess.CalledProcessError) as excinfo:
+                run_pipeline.convert_and_filter(
+                    Path("/data/releases.xml.gz"), Path("/tmp/csv"), "discogs-xml-converter"
+                )
+        assert excinfo.value.returncode == 3
+
+    # -- the wxyc-catalog CLIs: a *second* credential ------------------------
+    #
+    # --catalog-db-url is the tubafrenzy MySQL or Backend-Service PostgreSQL
+    # connection string (docs/architecture.md). Different database, same argv
+    # mechanism, same log bucket.
+
+    def test_generate_library_db_failure_redacts_catalog_dsn(self) -> None:
+        def fake_run_step(step_name, cmd, *args, **kwargs):
+            raise subprocess.CalledProcessError(1, cmd)
+
+        with patch.object(run_pipeline, "run_step", side_effect=fake_run_step):
+            with pytest.raises(subprocess.CalledProcessError) as excinfo:
+                run_pipeline.generate_library_db(
+                    Path("/tmp/library.db"), "backend-service", self.CATALOG_DSN
+                )
+        rendered = str(excinfo.value)
+        assert self.CATALOG_DSN not in rendered
+        assert "s3cr3t" not in rendered
+
+    def test_database_build_label_extraction_failure_redacts_catalog_dsn(self) -> None:
+        def fake_run_step(step_name, cmd, *args, **kwargs):
+            if step_name == "Extract WXYC library labels":
+                raise subprocess.CalledProcessError(1, cmd)
+
+        self._assert_dsn_redacted(
+            fake_run_step,
+            lambda: run_pipeline._run_database_build(
+                self.DSN,
+                Path("/tmp/csv"),
+                Path("/tmp/library.db"),
+                sys.executable,
+                catalog_source="backend-service",
+                catalog_db_url=self.CATALOG_DSN,
+                state=None,
+            ),
+            "Extract WXYC library labels",
+        )
+
+    def test_post_import_label_extraction_failure_redacts_catalog_dsn(self) -> None:
+        def fake_run_step(step_name, cmd, *args, **kwargs):
+            if step_name == "Extract WXYC library labels":
+                raise subprocess.CalledProcessError(1, cmd)
+
+        self._assert_dsn_redacted(
+            fake_run_step,
+            lambda: run_pipeline._run_database_build_post_import(
+                self.DSN,
+                Path("/tmp/csv"),
+                Path("/tmp/library.db"),
+                sys.executable,
+                catalog_source="backend-service",
+                catalog_db_url=self.CATALOG_DSN,
+            ),
+            "Extract WXYC library labels",
+        )
+
+
+class TestWaitForPostgresRedaction:
+    """wait_for_postgres logs its target on *every* run, success or failure.
+
+    The argv fix (#361) only covers the failure traceback; this line put the
+    same credentialed DSN into the same teed log on the happy path, so a
+    rebuild did not need to fail to publish it. Redaction precedent:
+    resolve_collisions.py and derive_va_release.py's _describe_target.
+    """
+
+    DSN = "postgresql://svc:hunter2@cache-host:5433/discogs"
+
+    def test_logs_host_without_credentials(self, caplog) -> None:
+        with caplog.at_level(logging.INFO, logger=run_pipeline.logger.name):
+            with patch.object(run_pipeline.psycopg, "connect", return_value=MagicMock()):
+                run_pipeline.wait_for_postgres(self.DSN)
+        logged = " ".join(r.getMessage() for r in caplog.records)
+        assert "hunter2" not in logged
+        assert "svc" not in logged
+        # Still useful for operators: the target host survives redaction.
+        assert "cache-host:5433/discogs" in logged

--- a/tests/unit/test_run_pipeline.py
+++ b/tests/unit/test_run_pipeline.py
@@ -2482,18 +2482,26 @@ class TestWaitForPostgresRedaction:
 
     The argv fix (#361) only covers the failure traceback; this line put the
     same credentialed DSN into the same teed log on the happy path, so a
-    rebuild did not need to fail to publish it. Redaction precedent:
-    resolve_collisions.py and derive_va_release.py's _describe_target.
+    rebuild did not need to fail to publish it. Redaction runs through the
+    shared lib/dsn.py redactor, whose own edge cases are pinned in
+    tests/unit/test_dsn.py.
     """
 
     DSN = "postgresql://svc:hunter2@cache-host:5433/discogs"
+    CONNINFO_DSN = "host=cache-host port=5433 dbname=discogs user=svc password=hunter2"
 
-    def test_logs_host_without_credentials(self, caplog) -> None:
+    @pytest.mark.parametrize("attr", ["DSN", "CONNINFO_DSN"], ids=["url", "conninfo"])
+    def test_logs_host_without_credentials(self, caplog, attr: str) -> None:
+        """Both DSN forms, because psycopg.connect() takes either and the
+        keyword/value form contains no '@' at all -- the earlier
+        split("@")[-1] redactor returned it verbatim, password included.
+        """
         with caplog.at_level(logging.INFO, logger=run_pipeline.logger.name):
             with patch.object(run_pipeline.psycopg, "connect", return_value=MagicMock()):
-                run_pipeline.wait_for_postgres(self.DSN)
+                run_pipeline.wait_for_postgres(getattr(self, attr))
         logged = " ".join(r.getMessage() for r in caplog.records)
         assert "hunter2" not in logged
+        assert "password" not in logged
         assert "svc" not in logged
         # Still useful for operators: the target host survives redaction.
         assert "cache-host:5433/discogs" in logged

--- a/tests/unit/test_run_pipeline.py
+++ b/tests/unit/test_run_pipeline.py
@@ -2213,3 +2213,149 @@ class TestDeriveVaReleaseStep:
         )
         self._invoke_database_build(fail_derive=True, state=state)
         assert not state.is_completed("derive_va_release")
+
+
+class TestRunStepSafe:
+    """run_step_safe() wraps run_step(), keeping a credentialed argv out of
+    any exception that escapes a failed step (#361).
+
+    dedup_releases.py, import_csv.py, and verify_cache.py all receive the
+    cache database URL positionally. run_step() raises
+    subprocess.CalledProcessError on a nonzero exit, and
+    CalledProcessError.__str__ embeds the full argv it was built with --
+    credentials included. Left uncaught, that string is what a default
+    exception traceback prints, and rebuild-cache-bootstrap.sh tees
+    stdout/stderr straight to the rebuild log bucket on every step failure.
+    """
+
+    DSN = "postgresql://svc:hunter2@cache-host/discogs"
+
+    def test_success_delegates_to_run_step(self, caplog) -> None:
+        with caplog.at_level(logging.INFO, logger=run_pipeline.logger.name):
+            run_pipeline.run_step_safe("echo test", [sys.executable, "-c", "print('hi')"])
+        logged = [r.message for r in caplog.records]
+        assert any("hi" in msg for msg in logged)
+
+    def test_failure_still_raises(self) -> None:
+        with pytest.raises(subprocess.CalledProcessError) as excinfo:
+            run_pipeline.run_step_safe(
+                "fail test", [sys.executable, "-c", "import sys; sys.exit(7)"]
+            )
+        assert excinfo.value.returncode == 7
+
+    def test_failure_does_not_embed_credentialed_argv(self) -> None:
+        with pytest.raises(subprocess.CalledProcessError) as excinfo:
+            run_pipeline.run_step_safe(
+                "Deduplicate releases",
+                [sys.executable, "-c", "import sys; sys.exit(1)", self.DSN],
+            )
+        assert self.DSN not in str(excinfo.value)
+        assert "hunter2" not in str(excinfo.value)
+
+    def test_failure_logs_only_exit_code(self, caplog) -> None:
+        with caplog.at_level(logging.ERROR, logger=run_pipeline.logger.name):
+            with pytest.raises(subprocess.CalledProcessError):
+                run_pipeline.run_step_safe(
+                    "Deduplicate releases",
+                    [sys.executable, "-c", "import sys; sys.exit(1)", self.DSN],
+                )
+        logged = [r.getMessage() for r in caplog.records]
+        assert any("Deduplicate releases" in msg for msg in logged)
+        assert all(self.DSN not in msg and "hunter2" not in msg for msg in logged)
+
+
+class TestArgvCredentialRedaction:
+    """Every argv call site that carries the cache database URL (#361) must
+    route through run_step_safe, so a step failure never surfaces the DSN
+    in a propagated exception. Covers all four scripts named in #361:
+    dedup_releases.py, import_csv.py, and verify_cache.py (two call sites
+    each, one per build path)."""
+
+    DSN = "postgresql://svc:hunter2@cache-host/discogs"
+
+    def _mock_conn(self):
+        mock_cursor = MagicMock()
+        mock_cursor.fetchone.return_value = [True]
+        mock_cursor.fetchall.return_value = [
+            ("idx_release_artist_name_trgm",),
+            ("idx_release_title_trgm",),
+        ]
+        mock_conn = MagicMock()
+        mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
+        mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+        return mock_conn
+
+    def _assert_dsn_redacted(self, fake_run_step, invoke) -> None:
+        with (
+            patch.object(run_pipeline, "run_step", side_effect=fake_run_step),
+            patch.object(run_pipeline, "wait_for_postgres"),
+            patch.object(run_pipeline, "run_sql_file"),
+            patch.object(run_pipeline, "run_sql_statements_parallel"),
+            patch.object(run_pipeline, "set_tables_unlogged"),
+            patch.object(run_pipeline, "set_tables_logged"),
+            patch.object(run_pipeline, "run_vacuum"),
+            patch.object(run_pipeline, "report_sizes"),
+            patch.object(run_pipeline, "check_reload_invariant") as mock_check,
+            patch.object(run_pipeline, "write_keep_release_ids", return_value=0),
+            patch.object(run_pipeline.psycopg, "connect", return_value=self._mock_conn()),
+        ):
+            mock_check.return_value = run_pipeline.ReloadInvariantResult(
+                ok=True, release_count=1, artist_coverage=1.0, track_coverage=1.0
+            )
+            with pytest.raises(Exception) as excinfo:
+                invoke()
+        assert self.DSN not in str(excinfo.value)
+        assert "hunter2" not in str(excinfo.value)
+
+    @pytest.mark.parametrize(
+        "failing_step_name",
+        ["Import base CSVs", "Deduplicate releases", "Import tracks", "Prune to library matches"],
+    )
+    def test_database_build_step_failure_redacts_dsn(self, failing_step_name) -> None:
+        def fake_run_step(step_name, cmd, *args, **kwargs):
+            if step_name == failing_step_name:
+                raise subprocess.CalledProcessError(1, cmd)
+
+        self._assert_dsn_redacted(
+            fake_run_step,
+            lambda: run_pipeline._run_database_build(
+                self.DSN,
+                Path("/tmp/csv"),
+                Path("/tmp/library.db"),
+                sys.executable,
+                state=None,
+            ),
+        )
+
+    def test_database_build_copy_to_step_failure_redacts_dsn(self) -> None:
+        def fake_run_step(step_name, cmd, *args, **kwargs):
+            if step_name == "Copy matched releases to target database":
+                raise subprocess.CalledProcessError(1, cmd)
+
+        self._assert_dsn_redacted(
+            fake_run_step,
+            lambda: run_pipeline._run_database_build(
+                self.DSN,
+                Path("/tmp/csv"),
+                Path("/tmp/library.db"),
+                sys.executable,
+                target_db_url="postgresql://svc:hunter2@target-host/discogs",
+                state=None,
+            ),
+        )
+
+    @pytest.mark.parametrize(
+        "failing_step_name",
+        ["Deduplicate releases", "Prune to library matches"],
+    )
+    def test_post_import_step_failure_redacts_dsn(self, failing_step_name) -> None:
+        def fake_run_step(step_name, cmd, *args, **kwargs):
+            if step_name == failing_step_name:
+                raise subprocess.CalledProcessError(1, cmd)
+
+        self._assert_dsn_redacted(
+            fake_run_step,
+            lambda: run_pipeline._run_database_build_post_import(
+                self.DSN, Path("/tmp/csv"), Path("/tmp/library.db"), sys.executable
+            ),
+        )

--- a/tests/unit/test_startup_dsn_redaction.py
+++ b/tests/unit/test_startup_dsn_redaction.py
@@ -1,0 +1,157 @@
+"""Every pipeline script logs its target database before connecting; none may
+log the credential (#361, closing the DSN half of #227).
+
+``rebuild-cache-bootstrap.sh`` tees the whole pipeline log to the S3 rebuild
+log bucket, and these four scripts receive the cache DSN on argv, so the
+startup line published the cache credential on the *happy* path -- no failure
+required. Each is exercised for both DSN forms libpq accepts, because the
+keyword/value form is what defeated the naive ``split("@")[-1]`` redactor:
+it contains no ``@``, so the whole string (password included) was "redacted"
+to itself.
+
+The scripts are driven only as far as their connect call, which is stubbed to
+raise a sentinel -- the log line under test is emitted immediately before it.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import importlib.util
+import logging
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[2] / "scripts"
+
+URL_DSN = "postgresql://svc:hunter2@cache-host:5433/discogs"
+CONNINFO_DSN = "host=cache-host port=5433 dbname=discogs user=svc password=hunter2"
+BOTH_DSN_FORMS = pytest.mark.parametrize("dsn", [URL_DSN, CONNINFO_DSN], ids=["url", "conninfo"])
+
+
+def _load(name: str):
+    """Load a script as a module, reusing an already-loaded copy.
+
+    verify_cache in particular must not be loaded twice in one interpreter:
+    a second module object shadows the first and breaks ProcessPool pickling
+    for workers holding references to the original's symbols (see #109).
+    """
+    if name in sys.modules:
+        return sys.modules[name]
+    spec = importlib.util.spec_from_file_location(name, SCRIPTS_DIR / f"{name}.py")
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class _StopBeforeConnect(Exception):
+    """Sentinel raised by the stubbed connect, after the log line is emitted."""
+
+
+def _assert_redacted(caplog, module) -> str:
+    """Assert nothing credential-shaped reached the log; return the messages."""
+    logged = " ".join(record.getMessage() for record in caplog.records)
+    assert "hunter2" not in logged
+    assert "password" not in logged
+    assert "svc" not in logged
+    # Redaction must not cost the operator the one fact the line exists for.
+    assert "cache-host:5433/discogs" in logged
+    return logged
+
+
+class TestDedupReleases:
+    @BOTH_DSN_FORMS
+    def test_startup_line_redacts_dsn(self, caplog, dsn: str) -> None:
+        module = _load("dedup_releases")
+        ns = argparse.Namespace(
+            database_url=dsn,
+            library_labels=None,
+            label_hierarchy=None,
+            keep_release_ids=None,
+        )
+        with caplog.at_level(logging.INFO, logger=module.logger.name):
+            with (
+                patch.object(module, "parse_args", return_value=ns),
+                patch.object(module, "init_logger"),
+                patch.object(module.psycopg, "connect", side_effect=_StopBeforeConnect),
+            ):
+                with pytest.raises(_StopBeforeConnect):
+                    module.main()
+        _assert_redacted(caplog, module)
+
+
+class TestImportCsv:
+    @BOTH_DSN_FORMS
+    def test_startup_line_redacts_dsn(self, caplog, tmp_path: Path, dsn: str) -> None:
+        module = _load("import_csv")
+        csv_dir = tmp_path / "csv"
+        csv_dir.mkdir()
+        with caplog.at_level(logging.INFO, logger=module.logger.name):
+            with (
+                patch.object(sys, "argv", ["import_csv.py", str(csv_dir), dsn]),
+                patch.object(module, "init_logger"),
+                patch.object(module.psycopg, "connect", side_effect=_StopBeforeConnect),
+            ):
+                with pytest.raises(_StopBeforeConnect):
+                    module.main()
+        _assert_redacted(caplog, module)
+
+
+class TestVerifyCache:
+    @BOTH_DSN_FORMS
+    def test_startup_line_redacts_dsn(self, caplog, tmp_path: Path, dsn: str) -> None:
+        module = _load("verify_cache")
+        library_db = tmp_path / "library.db"
+        library_db.touch()
+        ns = argparse.Namespace(
+            database_url=dsn,
+            library_db=library_db,
+            mappings_file=None,
+        )
+        with caplog.at_level(logging.INFO, logger=module.logger.name):
+            with (
+                patch.object(module, "parse_args", return_value=ns),
+                patch.object(
+                    module, "load_artist_mappings", return_value={"keep": [], "prune": []}
+                ),
+                patch.object(module.LibraryIndex, "from_sqlite", return_value=MagicMock()),
+                patch.object(module.asyncpg, "connect", side_effect=_StopBeforeConnect),
+            ):
+                with pytest.raises(_StopBeforeConnect):
+                    asyncio.run(module.async_main())
+        _assert_redacted(caplog, module)
+
+
+class TestResolveCollisions:
+    @BOTH_DSN_FORMS
+    def test_startup_line_redacts_dsn(self, caplog, tmp_path: Path, dsn: str) -> None:
+        module = _load("resolve_collisions")
+        input_csv = tmp_path / "genre-analysis-results.csv"
+        input_csv.touch()
+        library_db = tmp_path / "library.db"
+        library_db.touch()
+        argv = [
+            "--input",
+            str(input_csv),
+            "--library-db",
+            str(library_db),
+            "--output",
+            str(tmp_path / "out.csv"),
+            "--database-url",
+            dsn,
+        ]
+        with caplog.at_level(logging.INFO, logger=module.logger.name):
+            with (
+                patch.object(module, "init_logger"),
+                patch.object(module, "load_wrong_person_entries", return_value={}),
+                patch.object(module, "load_wxyc_titles"),
+                patch.object(module.psycopg, "connect", side_effect=_StopBeforeConnect),
+            ):
+                with pytest.raises(_StopBeforeConnect):
+                    module.main(argv)
+        _assert_redacted(caplog, module)


### PR DESCRIPTION
Closes #361.

## The exposure

`run_pipeline.py` builds subprocess commands that carry a database connection string in `argv`. When a step exits non-zero, `run_step()` raises `subprocess.CalledProcessError`, and that exception's `__str__` embeds the **full command list** it was constructed with — credential included. Nothing between `run_step` and `main()` catches it, so it reaches Python's default exception handler, which prints it to stderr. `rebuild-cache-bootstrap.sh` tees combined stdout/stderr to the rebuild log directory and uploads it, so every failed run published the credential in plaintext, once per traceback frame.

This is the `argv` path, distinct from #227 (which covers masking the URL in `import_csv.py`'s own log output).

## The fix

A `run_step_safe()` wrapper catches `CalledProcessError`, logs only the exit code, and re-raises a fresh `CalledProcessError` carrying the plain step label (e.g. `"Deduplicate releases"`) as its `cmd` instead of the real `argv`. The re-raise uses `from None`, which is load-bearing: without it, implicit exception chaining still prints the original `argv`-bearing exception as "During handling of the above exception", and the credential leaks anyway.

Redacting the exception on the orchestrator side rather than changing how the DSN is passed keeps this PR to `scripts/run_pipeline.py` and its unit tests. `dedup_releases.py`, `import_csv.py`, and `verify_cache.py` are being edited on another branch and are deliberately untouched.

## Sweep: eleven call sites, four beyond the ticket's survey

#361's survey table named three scripts and six call sites. The first pass wired seven — it caught an extra `verify_cache.py` prune call in `_run_database_build_post_import` that the table missed. Review then found four more, because the survey was organised by *script name* and these invoke a different binary:

| Call site | Credential | How it reaches argv |
|---|---|---|
| `convert_and_filter` (`--direct-pg` mode) | discogs-cache | `--database-url` flag on the converter binary |
| `generate_library_db` | WXYC catalog | `--catalog-db-url` flag on `wxyc-export-to-sqlite` |
| "Extract WXYC library labels" (both build paths) | WXYC catalog | `--catalog-db-url` flag on `wxyc-extract-library-labels` |

Flag-vs-positional makes no difference — `CalledProcessError.__str__` renders the whole list either way, which is exactly why the pre-existing `run_derive_va_release_step` guard exists for its own `--database-url`. The converter site leaks the *same* cache credential the ticket is about; the three catalog sites leak a second one.

After the sweep the only bare `run_step` calls left in the file are the delegation inside `run_step_safe` itself and `run_derive_va_release_step`, which already catches and logs only its exit code.

## Also: a leak that did not need a failure

`wait_for_postgres()` logged the unredacted connection string at INFO on **every** run, success or failure, into the same teed log. A rebuild never had to fail to publish the credential. Now redacted through a `_redact_dsn()` helper matching the existing precedent in `resolve_collisions.py` and `derive_va_release.py`'s `_describe_target`; host, port and database survive so the line stays useful to operators.

## Tests

Unit tests drive both build paths with a fake DSN (`postgresql://svc:hunter2@cache-host/discogs`) and a fake catalog DSN, fail each step in turn, and assert neither the DSN nor its password appears in the escaping exception. The guards assert on `CalledProcessError.cmd` specifically rather than `pytest.raises(Exception)` — as originally written they would have stayed green if a drifting mock made the build die before ever reaching the step under test.

Full suite: 1631 passed, 10 skipped, 1 xfailed. `ruff check` and `ruff format --check` clean.

## NOT in this PR: the credential is still live

**Rotating the production discogs-cache password is not done here, and it is the half that actually invalidates the archived copies.** It is operator-only work: it needs Railway credentials plus org-account AWS SSO, and coordinated updates across library-metadata-lookup, semantic-index, catalog-audits, this repo's `DATABASE_URL_DISCOGS` secret, the corresponding SSM parameter, and developer `.env` files. Rotating without updating every consumer takes library lookups down.

Until someone does that, **every credential already sitting in the archived logs remains valid.** This PR stops new copies from being written; it does not invalidate the existing ones. That half is time-sensitive and should not wait behind this code review. Per #361's AFK-READY block it needs a named human owner and its own tracking issue.

Two further channels are also out of scope and still carry the DSN into the same log:

- **The child scripts log their own connection string at startup.** `dedup_releases.py`, `import_csv.py`, and `verify_cache.py` each log a "Connecting to …" line, which `run_step` relays into the pipeline logger. So a run that fails at dedup now has a clean traceback but already has the credential earlier in the same file. #361's acceptance criterion "a fresh failed-run log confirms zero occurrences" will **not** hold on this PR alone. #227 covers `import_csv.py` only and should be widened to all three.
- **Sentry's excepthook captures frame locals by default**, so the `argv`-bearing `cmd` local survives in the event payload even though `from None` correctly stops the chain walk.

The durable fix for both is #361's own suggestion: have those three scripts read `DATABASE_URL_DISCOGS` from a merged `os.environ` instead of `argv`, as ten other scripts in this repo already do. That requires editing the three script files and belongs on the branch that currently owns them.

## Related

- #361 — this fix
- #227 — DSN masking in `import_csv.py` log output; overlapping intent, and the channel this PR does not close
- #352, #353 — the incident and migration whose archived logs surfaced this
