### PR TITLE
fix(#373): open TSV parsers with newline="\n" so a bare CR cannot terminate a line

### DIFF
--- a/lib/library_db.py
+++ b/lib/library_db.py
@@ -310,23 +310,45 @@ def parse_library_tsv(tsv_path: str) -> Iterable[Sequence[object]]:
     *comparable* -- both holding true bytes -- so do not read it as
     load-bearing for this parser.
 
-    **Carriage return is outside the escape vocabulary, and this parser does
-    not handle it.** ``mysql``'s ``safe_put_field`` escapes exactly NUL, TAB,
-    NL and backslash, never CR, while this ``open()`` runs in universal-
-    newline mode -- so a raw CR in source data is read as a line terminator.
-    Mid-row it splits the line and both fragments fail the field-count check
-    (dropped, with a WARNING); in the **final** column the first fragment
-    still has the right field count and is accepted with the value silently
-    truncated at the CR. Unlike the four escapes above this class leaves no
-    trace in the built artifact -- a ``char(13)`` probe against ``library.db``
-    cannot see a row that was dropped or truncated on the way in -- so it has
-    to be measured against MySQL (``INSTR(TITLE, CHAR(13))``). Deliberately
-    left unfixed here: correcting it changes which rows are ingested, which
-    needs that measurement first. See WXYC/discogs-etl#370.
+    **Carriage return is outside the escape vocabulary, so this parser reads
+    with** ``newline="\n"`` **to keep a bare CR from acting as a line
+    terminator.** ``mysql``'s ``safe_put_field`` escapes exactly NUL, TAB, NL
+    and backslash, never CR. Left in Python's default universal-newline
+    mode, ``open()`` would treat a raw CR in source data as a line
+    terminator: mid-row it would split the line and both fragments would
+    fail the field-count check (dropped, with a WARNING); in the **final**
+    column the first fragment would still have the right field count and be
+    accepted with the value silently truncated at the CR -- no error, and a
+    served title or artist name quietly missing its tail. ``newline=""``
+    does *not* fix this: it only suppresses newline *translation*, and
+    universal-newline splitting stays on, so a bare CR still terminates a
+    line. Only ``newline="\n"`` disables that splitting, so a bare CR
+    survives as data within whichever field contains it. See
+    WXYC/discogs-etl#373.
+
+    Measured against tubafrenzy MySQL 2026-08-14, byte-exact via
+    ``LOCATE(CHAR(13), BINARY col)`` (not ``INSTR(col, CHAR(13))``, which
+    compares collation weights rather than bytes on this server and
+    spuriously matches non-ASCII/mojibake content -- see WXYC/discogs-etl#373
+    for the false-positive counts that trap produced): every free-text column
+    behind *both* parsers returns zero CR-bearing rows -- the seven in
+    ``LIBRARY_SELECT_SQL`` and, for ``parse_compilation_track_tsv``,
+    ``COMPILATION_TRACK_ARTIST.ARTIST_NAME`` and ``TRACK_TITLE``. The class is
+    real and reachable but currently latent -- this fix changes no row's
+    ingestion outcome today, for either parser. See WXYC/discogs-etl#370.
+
+    The flip side of ``newline="\n"`` is that it requires an **LF-terminated**
+    file, which is what the Linux ``mysql -B -N`` producer emits. Fed a
+    CRLF-terminated TSV, both parsers would now leave a trailing CR on each
+    row's final column rather than absorbing it, and would do so silently.
+    That is unreachable from this repo's producers, and it is not fixable in
+    the parser regardless: a CRLF terminator and a data CR at the end of the
+    last field are the same two bytes, and resolving that ambiguity in favour
+    of data is the whole point of this change.
 
     A generator, so warnings interleave with the inserts they describe.
     """
-    with open(tsv_path, encoding="utf-8") as f:
+    with open(tsv_path, encoding="utf-8", newline="\n") as f:
         for line in f:
             fields = line.rstrip("\n").split("\t")
             if len(fields) != len(LIBRARY_INSERT_COLUMNS):
@@ -356,9 +378,10 @@ def parse_compilation_track_tsv(tsv_path: str) -> Iterable[Sequence[object]]:
     sees it. Every surviving field is then unescaped back to the real
     bytes, same as ``parse_library_tsv`` -- this parser is **not** safe to
     reuse unchanged; see that function's docstring for the ``--raw``
-    fragility both parsers share.
+    fragility and the bare-CR handling (``newline="\n"``, WXYC/discogs-etl#373)
+    that both parsers share.
     """
-    with open(tsv_path, encoding="utf-8") as f:
+    with open(tsv_path, encoding="utf-8", newline="\n") as f:
         for line in f:
             fields = line.rstrip("\n").split("\t")
             if len(fields) != 3:

--- a/tests/unit/test_tsv_to_sqlite.py
+++ b/tests/unit/test_tsv_to_sqlite.py
@@ -764,6 +764,109 @@ class TestTsvToSqlite:
         assert title == "\\N"
         assert title is not None
 
+    def test_cr_in_final_column_survives_intact(self, tmp_path: Path) -> None:
+        r"""A bare CR in the final column (cross_reference_names) must survive
+        intact rather than being read as a line terminator and silently
+        truncating the value (WXYC/discogs-etl#373).
+
+        Red before the ``newline="\n"`` fix: the default universal-newline
+        ``open()`` treats the bare CR as a line terminator, so the first
+        fragment still carries all 11 fields and is accepted with the value
+        truncated at ``Cross``, while the orphaned tail (``Ref``) is dropped
+        as malformed. The dropped tail does emit a WARNING, but it identifies
+        neither the truncated row nor the truncation -- the corrupted value
+        lands with no diagnostic attached to it, which is what makes this the
+        dangerous half of the defect.
+        """
+        tsv = (
+            "1\tAluminum Tunes\tStereolab\tST\t100\t1\tRock\tCD\t\\N\t\\N\tCross\rRef\n"
+            "2\tDOGA\tJuana Molina\tMO\t200\t2\tRock\tCD\t\\N\t\\N\t\\N\n"
+        )
+        tsv_file = tmp_path / "input.tsv"
+        tsv_file.write_text(tsv, encoding="utf-8")
+        db_path = tmp_path / "library.db"
+
+        tsv_to_sqlite(str(tsv_file), str(db_path))
+
+        conn = sqlite3.connect(str(db_path))
+        rows = conn.execute("SELECT id, cross_reference_names FROM library ORDER BY id").fetchall()
+        conn.close()
+
+        # Both rows land intact -- the CR-bearing final column is not
+        # truncated, and the row following the bare CR is not mistaken for a
+        # continuation of the first.
+        assert rows == [(1, "Cross\rRef"), (2, None)]
+
+    def test_cr_mid_row_no_longer_splits_row(self, tmp_path: Path) -> None:
+        r"""A bare CR in a non-final column no longer terminates the line.
+
+        Pre-fix this was the loud, already-handled case: both fragments fail
+        the field-count check and the row is dropped with a WARNING. Post-fix
+        the row is accepted whole, with the CR preserved inside the field
+        (WXYC/discogs-etl#373) -- this is the intended behavior change noted
+        in the ticket, not a regression.
+        """
+        tsv = "1\tAluminum Tunes\tStereo\rlab\tST\t100\t1\tRock\tCD\t\\N\t\\N\t\\N\n"
+        tsv_file = tmp_path / "input.tsv"
+        tsv_file.write_text(tsv, encoding="utf-8")
+        db_path = tmp_path / "library.db"
+
+        tsv_to_sqlite(str(tsv_file), str(db_path))
+
+        conn = sqlite3.connect(str(db_path))
+        row = conn.execute("SELECT id, artist FROM library WHERE id = 1").fetchone()
+        conn.close()
+
+        assert row == (1, "Stereo\rlab")
+
+    def test_crlf_in_field_value_round_trips(self, tmp_path: Path) -> None:
+        r"""A Windows-entered line break survives as a real CRLF *inside* the
+        field, pinning the interaction between the ``newline="\n"`` fix and
+        ``_unescape_mysql_field`` (WXYC/discogs-etl#373).
+
+        This is the likeliest real origin of a CR in this data, and on the
+        wire it is a two-part shape: ``mysql -B -N`` escapes the LF to the two
+        characters backslash-``n`` but leaves the CR as a bare byte, so the
+        field arrives as ``Cross`` + CR + ``\n`` + ``Ref``. Both halves have
+        to be handled by different mechanisms for the value to reassemble --
+        ``newline="\n"`` keeps the bare CR from ending the line, and the
+        unescape turns the two-char sequence back into a real LF. Covered
+        once here rather than twice: the unescape half lives in
+        ``_parse_nullable_field``, which both parsers share.
+        """
+        tsv = "1\tAluminum Tunes\tStereolab\tST\t100\t1\tRock\tCD\t\\N\t\\N\tCross\r\\nRef\n"
+        tsv_file = tmp_path / "input.tsv"
+        tsv_file.write_text(tsv, encoding="utf-8")
+        db_path = tmp_path / "library.db"
+
+        tsv_to_sqlite(str(tsv_file), str(db_path))
+
+        conn = sqlite3.connect(str(db_path))
+        value = conn.execute("SELECT cross_reference_names FROM library WHERE id = 1").fetchone()[0]
+        conn.close()
+
+        # A real CRLF pair, not the escaped spelling and not a truncation.
+        assert value == "Cross\r\nRef"
+
+    def test_multiple_rows_still_parse_after_newline_fix(self, tmp_path: Path) -> None:
+        r"""A normal, CR-free multi-row TSV parses unchanged under
+        ``newline="\n"`` -- regression guard for WXYC/discogs-etl#373."""
+        tsv = (
+            "1\tAluminum Tunes\tStereolab\tST\t100\t1\tRock\tCD\t\\N\t\\N\t\\N\n"
+            "2\tDOGA\tJuana Molina\tMO\t200\t2\tRock\tCD\t\\N\t\\N\t\\N\n"
+        )
+        tsv_file = tmp_path / "input.tsv"
+        tsv_file.write_text(tsv, encoding="utf-8")
+        db_path = tmp_path / "library.db"
+
+        tsv_to_sqlite(str(tsv_file), str(db_path))
+
+        conn = sqlite3.connect(str(db_path))
+        rows = conn.execute("SELECT id, title, artist FROM library ORDER BY id").fetchall()
+        conn.close()
+
+        assert rows == [(1, "Aluminum Tunes", "Stereolab"), (2, "DOGA", "Juana Molina")]
+
 
 class TestCtaEscaping:
     """Escaping tests for parse_compilation_track_tsv (WXYC/discogs-etl#370).
@@ -934,3 +1037,83 @@ class TestCtaEscaping:
         conn.close()
 
         assert track_title is None
+
+    def test_cta_cr_in_final_column_survives_intact(self, tmp_path: Path) -> None:
+        r"""A bare CR in the final column (track_title) must survive intact
+        rather than being read as a line terminator and silently truncating
+        the value (WXYC/discogs-etl#373).
+
+        Red before the ``newline="\n"`` fix: the default universal-newline
+        ``open()`` treats the bare CR as a line terminator, so the first
+        fragment is accepted with ``track_title`` truncated at ``Track`` and
+        the trailing fragment (``Title``) is dropped as malformed.
+        """
+        library_tsv = self._library_tsv(tmp_path)
+        cta_tsv = self._cta_tsv(
+            tmp_path,
+            [
+                ["1", "Stereolab", "Track\rTitle"],
+                ["1", "Juana Molina", "Other Track"],
+            ],
+        )
+        db_path = tmp_path / "library.db"
+
+        tsv_to_sqlite(str(library_tsv), str(db_path), str(cta_tsv))
+
+        conn = sqlite3.connect(str(db_path))
+        rows = conn.execute(
+            "SELECT artist_name, track_title FROM compilation_track_artist ORDER BY rowid"
+        ).fetchall()
+        conn.close()
+
+        # Both rows land intact -- the CR-bearing final column is not
+        # truncated, and the row following the bare CR is not mistaken for a
+        # continuation of the first.
+        assert rows == [("Stereolab", "Track\rTitle"), ("Juana Molina", "Other Track")]
+
+    def test_cta_cr_mid_row_no_longer_splits_row(self, tmp_path: Path) -> None:
+        r"""A bare CR in a non-final column (artist_name) no longer
+        terminates the line.
+
+        Pre-fix this was the loud, already-handled case: both fragments fail
+        the field-count check and the row is dropped with a WARNING. Post-fix
+        the row is accepted whole, with the CR preserved inside the field
+        (WXYC/discogs-etl#373) -- an intended behavior change, not a
+        regression.
+        """
+        library_tsv = self._library_tsv(tmp_path)
+        cta_tsv = self._cta_tsv(tmp_path, [["1", "Stereo\rlab", "Some Track"]])
+        db_path = tmp_path / "library.db"
+
+        tsv_to_sqlite(str(library_tsv), str(db_path), str(cta_tsv))
+
+        conn = sqlite3.connect(str(db_path))
+        row = conn.execute(
+            "SELECT library_release_id, artist_name FROM compilation_track_artist"
+        ).fetchone()
+        conn.close()
+
+        assert row == (1, "Stereo\rlab")
+
+    def test_cta_multiple_rows_still_parse_after_newline_fix(self, tmp_path: Path) -> None:
+        r"""A normal, CR-free multi-row CTA TSV parses unchanged under
+        ``newline="\n"`` -- regression guard for WXYC/discogs-etl#373."""
+        library_tsv = self._library_tsv(tmp_path)
+        cta_tsv = self._cta_tsv(
+            tmp_path,
+            [
+                ["1", "Stereolab", "Some Track"],
+                ["1", "Juana Molina", "Other Track"],
+            ],
+        )
+        db_path = tmp_path / "library.db"
+
+        tsv_to_sqlite(str(library_tsv), str(db_path), str(cta_tsv))
+
+        conn = sqlite3.connect(str(db_path))
+        rows = conn.execute(
+            "SELECT artist_name, track_title FROM compilation_track_artist ORDER BY rowid"
+        ).fetchall()
+        conn.close()
+
+        assert rows == [("Stereolab", "Some Track"), ("Juana Molina", "Other Track")]


### PR DESCRIPTION
Closes #373.

## The defect

`mysql`'s `safe_put_field` escapes exactly four bytes in `--batch` output — NUL, TAB, newline, and backslash — and **never carriage return**. Both TSV parsers in `lib/library_db.py` (`parse_library_tsv`, `parse_compilation_track_tsv`) opened their input in Python's default universal-newline mode, so a bare CR arriving in source data was read as a *line terminator* rather than as data.

That produces two outcomes, and only one of them is loud:

- **CR mid-row** — the line splits, both fragments fail the field-count check, and both are dropped with a WARNING on stderr. Already handled, and visible.
- **CR in the final column** — the first fragment still carries the full expected field count, so it is **accepted**, with the last value **silently truncated at the CR**. The orphaned tail is then dropped as a malformed row. That dropped tail does emit a WARNING, but it identifies neither the truncated row nor the fact of truncation — so the corrupted value lands in the served catalog with no diagnostic attached to it. A title or artist name is quietly missing its tail, and nothing in the run says so.

Both parsers feed the nightly `library.db` that library-metadata-lookup serves searches from (`scripts/sync-library.sh` → `scripts/tsv_to_sqlite.py`), and the parity harness (`scripts/catalog_parity_diff.py`) imports the same two functions — so this single fix covers both consumers, and no other TSV reader in the repo needs the same treatment.

## Why `newline=""` would not have fixed it

The obvious-looking spelling is a no-op here. `newline=""` suppresses newline *translation* but leaves universal-newline *splitting* enabled, so a bare CR still terminates a line. Only `newline="\n"` disables the splitting. Verified directly against `a\tb\tlast\rTRUNCATED\nx\ty\tz\n`:

| `open()` mode | lines produced | final-column value |
|---|---|---|
| default | 3 | `last` — **truncated** |
| `newline=""` | 3 | `last\r` — **still truncated** |
| `newline="\n"` | 2 | `last\rTRUNCATED` — **intact** |

Anyone implementing the `newline=""` form at face value ships a non-fix whose guard test never goes green. The docstring now records this explicitly so the next reader doesn't "simplify" it back.

`line.rstrip("\n")` is deliberately **not** broadened to `rstrip("\r\n")` — that would strip the very trailing CR this change exists to preserve.

The flip side, now documented: `newline="\n"` requires an **LF-terminated** file, which is what the Linux `mysql -B -N` producer emits. Fed a CRLF-terminated TSV, both parsers would leave a trailing CR on each row's final column rather than absorbing it. That is unreachable from this repo's producers, and it isn't fixable in the parser regardless — a CRLF terminator and a data CR at the end of the last field are the same two bytes, and resolving that ambiguity in favour of data is the whole point of the change.

## Real but latent — no data-shape risk

Measured against tubafrenzy MySQL (`wxycmusic`, server 5.1.56) on 2026-08-14, byte-exact: **CR, LF, and NUL are all zero in every source column behind both parsers** — the seven in `LIBRARY_SELECT_SQL` (`LIBRARY_RELEASE.TITLE` / `ALTERNATE_ARTIST_NAME` / `ALBUM_ARTIST` / `CALL_NUMBERS`, `LIBRARY_CODE.PRESENTATION_NAME` / `CALL_LETTERS` / `CALL_NUMBERS`) plus `COMPILATION_TRACK_ARTIST.ARTIST_NAME` and `TRACK_TITLE`.

So the class is real and reachable but **currently affects zero rows**: no row's ingestion outcome changes today, for either parser — only the guarantee going forward. That is what makes this safe to land unconditionally.

The measurement had to be byte-exact for a reason worth recording. The probe form is `LOCATE(CHAR(13), BINARY col)`, **not** `INSTR(col, CHAR(13))` — these columns collate case-insensitively, so `INSTR`/`LIKE` compare collation *weights* rather than bytes and spuriously match rows containing non-ASCII or double-encoded content. The naive probe reported 4,051 `ARTIST_NAME` and 10 `TITLE` rows for `CHAR(0)`; every sampled hit contained no `00` byte at all (it was detecting mojibake). The old docstring prescribed exactly that broken probe, and this PR corrects it.

## Behavior change

The **mid-row** case changes intentionally: previously two fragments were dropped with a WARNING, now the row is accepted whole with the CR preserved inside the field. This is the correct outcome — the CR is data — and it is covered by a test for each parser.

## No production SELECT changed

`LIBRARY_SELECT_SQL` and `COMPILATION_TRACK_SELECT_SQL` are untouched; `scripts/sync-library.sh` is not in the diff at all (the diff is two files). `test_select_statements_match_sync_library_sh`, which pins both against the shell script, stays green. The production TSV is byte-for-byte what it was.

## Tests

Red-then-green, mirroring the existing `test_tab_in_field_value` / `test_newline_in_field_value` sibling shape rather than inventing a new one:

- CR in the **final** column round-trips intact, for both parsers — the core red test. Pre-fix it fails with `'Cross'` vs `'Cross\rRef'` and `'Track'` vs `'Track\rTitle'`, i.e. exactly the silent truncation.
- CR **mid-row** no longer splits the row, for both parsers, and the value retains the CR.
- A Windows-entered line break round-trips as a real CRLF *inside* the field. This is the likeliest real origin of a CR in this data, and on the wire it is a two-part shape — `mysql` escapes the LF to two characters but leaves the CR bare — so it pins the interaction between the `newline="\n"` fix and `_unescape_mysql_field`. Covered once rather than twice, since the unescape half lives in the shared `_parse_nullable_field`.
- Normal CR-free multi-row files still parse unchanged, for both parsers (regression guard).

All five CR-sensitive cases confirmed red before the two-line parser change and green after. Pure-logic, no infrastructure, no `pg` marker — they run in the default suite.

## Verification

```
ruff check .                 # All checks passed
ruff format --check .        # 187 files already formatted
pytest                       # 1621 passed, 10 skipped, 1 xfailed
```

## Related

- Parent: #370 (parity harness "clean" definition)
- Found in review of: #371 (the producer-side unescape fix)
- Sibling: #375 (the `TITLE`/`PRESENTATION_NAME` NULL question, measured in the same 2026-08-14 pass)
