### PR TITLE
Grant ec2:DescribeImages to the deploy role so the ephemeral-rebuild stack can be updated

### DIFF
--- a/infra/bootstrap/README.md
+++ b/infra/bootstrap/README.md
@@ -53,13 +53,17 @@ The GitHub OIDC provider itself is **not** declared here. It is account-global, 
 
 ## Verifying the policy
 
-A bootstrap IAM template has no behaviour a unit test can assert before it is deployed, so its test is executed operationally:
+Two layers, because neither catches what the other does.
+
+**Statically**, `tests/unit/test_deploy_role_policy.py` pins the actions this deploy path is known to require, so a tightening that drops one fails at merge rather than at the next changeset. It asserts specific experimentally-established requirements, not minimality — that judgment stays with a human reading the template.
+
+**Operationally**, against the real deployed role:
 
 ```bash
 ./infra/bootstrap/simulate-deploy-role.sh
 ```
 
-22 expectations, exit non-zero if any fails. Run it after every deploy of this stack and after any policy edit. It covers the deploy actions, the `sync-library.yml` metrics grant, four negative controls (so a policy that got too permissive fails too, not just one that got too narrow), and two expected simulator artifacts.
+25 expectations, exit non-zero if any fails. Run it after every deploy of this stack and after any policy edit. It covers the deploy actions, the `sync-library.yml` metrics grant, four negative controls (so a policy that got too permissive fails too, not just one that got too narrow), and two expected simulator artifacts.
 
 **Do not simulate without `--resource-arns`.** Every statement here is resource-scoped, so a bare `simulate-principal-policy --action-names ...` evaluates against `*`, matches nothing, and returns `implicitDeny` for all of them — which reads as a completely broken role. It is the wrong question, not a finding.
 

--- a/infra/bootstrap/deploy-role.yaml
+++ b/infra/bootstrap/deploy-role.yaml
@@ -166,8 +166,27 @@ Resources:
                   ]
                 Resource: !Sub arn:aws:ec2:${AWS::Region}:${AWS::AccountId}:launch-template/*
               - Sid: Ec2Describe # ec2:Describe* has no resource-level scoping
+                # DescribeImages is required by the AmiId parameter, not by any
+                # resource in the template. AmiId is typed
+                # AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>, so after
+                # resolving the SSM parameter (see AmiSsmParameter above)
+                # CloudFormation validates that the resolved value is a real AMI
+                # — an ec2:DescribeImages call made with the *deploying
+                # principal's* credentials. That validation runs on every
+                # changeset, so without this the stack cannot be updated at all,
+                # even by a changeset that only adds an unrelated CloudWatch
+                # alarm. That is exactly how #396 surfaced: #358's alarm was the
+                # first real changeset since the org-account migration, and it
+                # failed with "AccessDenied … ec2:DescribeImages" and rolled
+                # back. Every deploy in between reported success only because
+                # --no-fail-on-empty-changeset makes a no-op exit 0.
                 Effect: Allow
-                Action: [ec2:DescribeLaunchTemplates, ec2:DescribeLaunchTemplateVersions]
+                Action:
+                  [
+                    ec2:DescribeLaunchTemplates,
+                    ec2:DescribeLaunchTemplateVersions,
+                    ec2:DescribeImages,
+                  ]
                 Resource: '*'
               - Sid: Lambda
                 Effect: Allow

--- a/infra/bootstrap/simulate-deploy-role.sh
+++ b/infra/bootstrap/simulate-deploy-role.sh
@@ -83,6 +83,17 @@ check allowed s3:PutObject \
     "arn:aws:s3:::wxyc-discogs-rebuild-logs-${ACCOUNT}/i-0123456789abcdef0/rebuild.log"
 check allowed ec2:CreateLaunchTemplate \
     "arn:aws:ec2:${REGION}:${ACCOUNT}:launch-template/lt-0123456789abcdef0"
+# ec2:Describe* takes '*' deliberately -- it has no resource-level scoping, so
+# unlike every other check here the bare resource is the correct question, not
+# the wrong one. These are reads CloudFormation makes while building a
+# changeset, and their absence is invisible until a changeset is actually
+# applied: this suite passed all 22 of its prior expectations while
+# ec2:DescribeImages was missing and the stack could not be updated at all
+# (#396). AmiId is typed AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>, so
+# resolving it is an ssm:GetParameters call (checked above) *and* an
+# ec2:DescribeImages validation, and only the first was covered.
+check allowed ec2:DescribeImages '*'
+check allowed ec2:DescribeLaunchTemplates '*'
 check allowed iam:CreateRole \
     "arn:aws:iam::${ACCOUNT}:role/wxyc-discogs-rebuild-InstanceRole-ABC123"
 check allowed iam:CreateInstanceProfile \

--- a/tests/cfn_yaml.py
+++ b/tests/cfn_yaml.py
@@ -1,0 +1,46 @@
+"""A YAML loader that understands CloudFormation's short-form intrinsic tags.
+
+``yaml.safe_load`` raises ``ConstructorError`` on ``!Ref`` / ``!Sub`` /
+``!GetAtt`` / ``!If`` / ``!Not`` / ``!Equals``, which every template in
+``infra/`` uses. Intrinsics are preserved as their long-form dicts
+(``!Ref X`` -> ``{"Ref": "X"}``) so assertions can distinguish a literal from
+an unresolved reference -- a distinction that is load-bearing in
+``test_ephemeral_rebuild_template.py``, where ``State: !Ref ScheduleState`` and
+``Enabled: !Ref ScheduleEnabled`` are semantically different despite looking
+alike.
+
+Shared rather than duplicated: this is the second template under test, and a
+per-file copy is how a repo ends up with several subtly different loaders.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import yaml
+
+
+class CfnLoader(yaml.SafeLoader):
+    """SafeLoader extended with CloudFormation's ``!`` tag family."""
+
+
+def _construct_cfn_tag(loader: yaml.Loader, tag_suffix: str, node: yaml.Node) -> Any:
+    key = "Ref" if tag_suffix == "Ref" else f"Fn::{tag_suffix}"
+    if isinstance(node, yaml.ScalarNode):
+        value: Any = loader.construct_scalar(node)
+        if key == "Fn::GetAtt":
+            value = value.split(".")
+    elif isinstance(node, yaml.SequenceNode):
+        value = loader.construct_sequence(node, deep=True)
+    else:
+        value = loader.construct_mapping(node, deep=True)
+    return {key: value}
+
+
+CfnLoader.add_multi_constructor("!", _construct_cfn_tag)
+
+
+def load_cfn(path: Any) -> dict[str, Any]:
+    """Parse a CloudFormation template, intrinsics preserved as dicts."""
+    with open(path, encoding="utf-8") as fh:
+        return yaml.load(fh, Loader=CfnLoader)  # noqa: S506 -- CfnLoader subclasses SafeLoader

--- a/tests/unit/test_deploy_role_policy.py
+++ b/tests/unit/test_deploy_role_policy.py
@@ -1,0 +1,139 @@
+"""Pins on the GitHub Actions deploy role's inline policy.
+
+``infra/bootstrap/deploy-role.yaml`` is applied by hand with admin credentials
+and is never deployed by CI -- it is what *lets* CI deploy. That makes it the
+one template in this repo with no deploy-time feedback loop: a policy that is
+too narrow does not fail at merge, it fails silently the next time somebody
+tries to change a different stack, possibly months later.
+
+That is not hypothetical. #396: the role was missing ``ec2:DescribeImages``,
+so ``sam deploy`` of the ephemeral-rebuild stack could not apply *any*
+changeset. Nobody noticed because the deploy workflow runs with
+``--no-fail-on-empty-changeset``, so every no-op deploy in between exited 0 and
+reported success. The gap only surfaced when #358's ``ReleaseCountAlarm``
+became the first real changeset since the org-account migration, and it failed
+with ``AccessDenied ... ec2:DescribeImages`` and rolled back.
+
+These tests are therefore a regression pin on the *actions the deploy path is
+known to need*, so that a future tightening of this policy fails here rather
+than at the next changeset. ``infra/bootstrap/README.md`` already warns that
+statements in this role are "easy to overlook when tightening the policy".
+
+They deliberately do not assert the policy is minimal -- that judgment belongs
+to a human reading the template. They assert only that specific, experimentally
+established requirements have not been dropped.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from tests.cfn_yaml import load_cfn
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEPLOY_ROLE_PATH = REPO_ROOT / "infra" / "bootstrap" / "deploy-role.yaml"
+EPHEMERAL_TEMPLATE_PATH = REPO_ROOT / "infra" / "ephemeral-rebuild" / "template.yaml"
+
+
+@pytest.fixture(scope="module")
+def deploy_role() -> dict[str, Any]:
+    return load_cfn(DEPLOY_ROLE_PATH)
+
+
+@pytest.fixture(scope="module")
+def statements(deploy_role: dict[str, Any]) -> list[dict[str, Any]]:
+    """Every statement across every inline policy on the role."""
+    roles = [
+        resource
+        for resource in deploy_role["Resources"].values()
+        if resource.get("Type") == "AWS::IAM::Role"
+    ]
+    assert roles, "deploy-role.yaml declares no AWS::IAM::Role"
+    collected: list[dict[str, Any]] = []
+    for role in roles:
+        for policy in role["Properties"].get("Policies", []):
+            collected.extend(policy["PolicyDocument"]["Statement"])
+    assert collected, "the deploy role has no inline policy statements"
+    return collected
+
+
+def _allowed_actions(statements: list[dict[str, Any]]) -> set[str]:
+    actions: set[str] = set()
+    for statement in statements:
+        if statement.get("Effect") != "Allow":
+            continue
+        declared = statement.get("Action", [])
+        if isinstance(declared, str):
+            declared = [declared]
+        actions.update(declared)
+    return actions
+
+
+@pytest.mark.parametrize(
+    ("action", "why"),
+    [
+        (
+            "ec2:DescribeImages",
+            "AmiId is typed AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>, so "
+            "CloudFormation validates the resolved value against EC2 on every "
+            "changeset. Without this the stack cannot be updated at all (#396).",
+        ),
+        (
+            "ssm:GetParameter",
+            "Resolving the AmiId SSM parameter happens with the deploying "
+            "principal's credentials, not the stack's roles.",
+        ),
+        (
+            "cloudformation:CreateChangeSet",
+            "sam deploy creates a changeset before applying it.",
+        ),
+    ],
+)
+def test_required_deploy_action_is_granted(
+    statements: list[dict[str, Any]], action: str, why: str
+) -> None:
+    assert action in _allowed_actions(statements), f"{action} missing from the deploy role: {why}"
+
+
+def test_ami_parameter_still_requires_ec2_image_validation() -> None:
+    """The reason ec2:DescribeImages is needed, pinned at its source.
+
+    If AmiId ever stops being an AWS::EC2::Image::Id-typed SSM parameter, the
+    DescribeImages grant may become unnecessary and this pin should be
+    revisited rather than carried forever.
+    """
+    template = load_cfn(EPHEMERAL_TEMPLATE_PATH)
+    ami_param = template["Parameters"]["AmiId"]
+    assert ami_param["Type"] == "AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>", (
+        "AmiId's parameter type changed; re-derive whether the deploy role still "
+        "needs ec2:DescribeImages (see #396) before editing the pin above."
+    )
+
+
+def test_describe_actions_are_unscoped_deliberately(statements: list[dict[str, Any]]) -> None:
+    """ec2:Describe* has no resource-level scoping, so Resource must be '*'.
+
+    Pinned because writing a narrower ARN here looks like good hygiene and
+    silently denies every call.
+    """
+    describe_statements = [
+        statement
+        for statement in statements
+        if any(
+            action.startswith("ec2:Describe")
+            for action in (
+                statement["Action"]
+                if isinstance(statement.get("Action"), list)
+                else [statement.get("Action", "")]
+            )
+        )
+    ]
+    assert describe_statements, "no statement grants any ec2:Describe* action"
+    for statement in describe_statements:
+        assert statement["Resource"] == "*", (
+            "ec2:Describe* does not support resource-level permissions; a narrower "
+            "Resource silently denies the call"
+        )

--- a/tests/unit/test_ephemeral_rebuild_template.py
+++ b/tests/unit/test_ephemeral_rebuild_template.py
@@ -33,6 +33,8 @@ import pytest
 import yaml
 from samtranslator.translator.transform import transform
 
+from tests.cfn_yaml import CfnLoader
+
 REPO_ROOT = Path(__file__).resolve().parents[2]
 TEMPLATE_PATH = REPO_ROOT / "infra" / "ephemeral-rebuild" / "template.yaml"
 
@@ -51,35 +53,15 @@ _TRANSFORM_REGION = "us-east-1"
 _PLACEHOLDER_CODE_URI = "s3://placeholder-bucket/placeholder.zip"
 
 
-class _CfnLoader(yaml.SafeLoader):
-    """SafeLoader that understands CloudFormation's short-form intrinsic tags.
-
-    ``yaml.safe_load`` raises ConstructorError on ``!Ref`` / ``!Sub`` / ``!GetAtt``
-    / ``!If`` / ``!Not`` / ``!Equals``, all of which this template uses.
-    """
-
-
-def _construct_cfn_tag(loader: yaml.Loader, tag_suffix: str, node: yaml.Node) -> Any:
-    key = "Ref" if tag_suffix == "Ref" else f"Fn::{tag_suffix}"
-    if isinstance(node, yaml.ScalarNode):
-        value: Any = loader.construct_scalar(node)
-        if key == "Fn::GetAtt":
-            value = value.split(".")
-    elif isinstance(node, yaml.SequenceNode):
-        value = loader.construct_sequence(node, deep=True)
-    else:
-        value = loader.construct_mapping(node, deep=True)
-    return {key: value}
-
-
-_CfnLoader.add_multi_constructor("!", _construct_cfn_tag)
+# CloudFormation's short-form intrinsic tags are handled by the shared loader
+# in tests/cfn_yaml.py -- see #396 for why it is shared rather than copied.
 
 
 @pytest.fixture(scope="module")
 def source_template() -> dict[str, Any]:
     """The template as written, intrinsics preserved as ``{"Ref": ...}`` dicts."""
     with TEMPLATE_PATH.open(encoding="utf-8") as fh:
-        return yaml.load(fh, Loader=_CfnLoader)  # noqa: S506 — _CfnLoader subclasses SafeLoader
+        return yaml.load(fh, Loader=CfnLoader)  # noqa: S506 — CfnLoader subclasses SafeLoader
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
Closes #396.

## The problem

`sam deploy` of the `wxyc-discogs-rebuild` stack could not apply **any** changeset. `#358`'s `ReleaseCountAlarm` was the first real changeset since the org-account migration, and it failed immediately:

```
UPDATE_ROLLBACK_IN_PROGRESS   wxyc-discogs-rebuild   AccessDenied. User doesn't have
                                                     permission to call ec2:DescribeImages
UPDATE_ROLLBACK_COMPLETE
```

Rollback was clean, so nothing was left half-applied — but the alarm was not created, and `infra/ephemeral-rebuild/template.yaml` on `main` has been describing a stack that does not match reality ever since.

## Why the role needs an EC2 permission to add a CloudWatch alarm

`AmiId` is declared `AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>`. CloudFormation resolves the SSM parameter (already granted, `AmiSsmParameter`) and then **validates the resolved value is a real AMI**, which is an `ec2:DescribeImages` call made with the *deploying principal's* credentials. That validation runs on every changeset regardless of what the changeset contains, so a missing grant blocks unrelated changes.

## Why nobody noticed

Two independent things hid it:

1. The deploy workflow runs `--no-fail-on-empty-changeset`, so a deploy with no template change exits 0 with `No changes to deploy`. Most of that workflow's green history is this, not successful deploys.
2. `simulate-deploy-role.sh` passed all of its prior expectations throughout — it covered the *mutating* `ec2:*` actions but no `ec2:Describe*` read at all, and those reads are exactly what changeset construction needs.

## What this changes

- **`deploy-role.yaml`** — adds `ec2:DescribeImages` to the existing unscoped `Ec2Describe` statement, with the reasoning inline so the next person tightening this policy knows why it is there.
- **`simulate-deploy-role.sh`** — adds `ec2:DescribeImages` and `ec2:DescribeLaunchTemplates` checks (23 → 25 expectations). These pass `'*'` as the resource deliberately: `ec2:Describe*` has no resource-level scoping, so unlike every other check here the bare resource is the correct question, not the wrong one the README warns against.
- **`tests/unit/test_deploy_role_policy.py`** — a static pin, so a future tightening fails at merge instead of at the next changeset. It asserts known requirements, not minimality. Verified non-vacuous: removing the grant fails the pin with the correct message.
- **`tests/cfn_yaml.py`** — the CloudFormation YAML loader, extracted from `test_ephemeral_rebuild_template.py` rather than copied. This is the second template under test; a per-file copy is how a repo accumulates several subtly different loaders.
- **`README.md`** — the "no behaviour a unit test can assert" claim is no longer true, and the stated expectation count was already off by one (22 stated, 23 actual).

## Deploying this

**This PR does not apply the fix.** `infra/bootstrap` is the chicken-and-egg layer — CI cannot deploy it, because it is what lets CI deploy. After merge, an operator with admin credentials must run the command in `infra/bootstrap/README.md`:

```bash
aws cloudformation deploy --profile wxyc-api --region us-east-1 \
  --template-file infra/bootstrap/deploy-role.yaml \
  --stack-name discogs-etl-deploy-role \
  --capabilities CAPABILITY_NAMED_IAM
```

Then re-run `deploy-ephemeral-rebuild.yml` on `main` and confirm the log says a changeset was **applied** rather than `No changes to deploy`, and that `ReleaseCountAlarm` exists in the deployed stack.

Until that happens, every push to `main` re-triggers the deploy and fails, so that check stays red.

## Not addressed here

Making the workflow distinguish "applied a changeset" from "nothing to deploy" is the remaining acceptance criterion on #396. It is a real gap — a no-op deploy and a successful one are currently indistinguishable in the workflow's output — but it is a separate change to `deploy-ephemeral-rebuild.yml` and does not belong in an IAM fix.

## Related

- WXYC/discogs-etl#396 — this issue
- WXYC/discogs-etl#358 — the alarm whose merge exposed it
- WXYC/discogs-etl#352 — the incident the alarm exists for