### PR TITLE
fix(#396): make a no-op sam deploy say so instead of passing for a deploy

### DIFF
--- a/.github/workflows/deploy-ephemeral-rebuild.yml
+++ b/.github/workflows/deploy-ephemeral-rebuild.yml
@@ -53,7 +53,9 @@ jobs:
           pip install -e ".[dev]"
           pytest tests/unit/test_ephemeral_rebuild_launcher.py \
                  tests/unit/test_ephemeral_rebuild_sweeper.py \
-                 tests/unit/test_ephemeral_rebuild_template.py -v
+                 tests/unit/test_ephemeral_rebuild_template.py \
+                 tests/unit/test_sam_deploy_summary.py \
+                 tests/unit/test_deploy_ephemeral_rebuild_workflow.py -v
 
   deploy:
     runs-on: ubuntu-latest
@@ -99,11 +101,30 @@ jobs:
         # --parameter-overrides, so a deliberate `ScheduleState=DISABLED` set
         # out-of-band survives redeploys instead of being silently re-armed —
         # which is the entire point of #353 having parameterized it.
+        #
+        # --no-fail-on-empty-changeset stays, and it is why the next step
+        # exists. It makes SAM exit 0 both when it applies a changeset and when
+        # it has nothing to apply, and those two were indistinguishable in this
+        # workflow's output for months while the deploy role could not apply
+        # anything at all (#396). Reddening the empty case is not the fix:
+        # three of the four triggers legitimately produce no template diff, so
+        # that would put a permanent failing check on `main`. The outcome gets
+        # *stated* instead — see "Report deploy outcome" below.
         run: |
           OPTIONAL_ARGS=()
           if [ -n "$REBUILD_ALERT_EMAIL" ]; then
             OPTIONAL_ARGS+=("AlertEmail=$REBUILD_ALERT_EMAIL")
           fi
+
+          # Absolute, and outside the working-directory: the report step runs
+          # from the repo root.
+          SAM_DEPLOY_LOG="${RUNNER_TEMP}/sam-deploy.log"
+          echo "SAM_DEPLOY_LOG=$SAM_DEPLOY_LOG" >> "$GITHUB_ENV"
+
+          # Capture SAM's status instead of failing on it, so the report step
+          # below still runs and renders the failure. Same treatment, for the
+          # same reason, as catalog-parity.yml's harness step.
+          set +e
           sam deploy \
             --no-confirm-changeset \
             --no-fail-on-empty-changeset \
@@ -112,4 +133,36 @@ jobs:
             --s3-bucket "${SAM_S3_BUCKET:-aws-sam-cli-managed-default-samclisourcebucket-v0kc5deo10yi}" \
             --parameter-overrides \
               RepoBranch=main \
-              "${OPTIONAL_ARGS[@]}"
+              "${OPTIONAL_ARGS[@]}" 2>&1 | tee "$SAM_DEPLOY_LOG"
+          # ${PIPESTATUS[0]} and NOT $?. Behind the `| tee`, `$?` is tee's
+          # status — 0 unless the disk fills — so reading it would report every
+          # failed deploy as a success, which is a strictly worse version of
+          # the bug this step is being changed to fix.
+          rc=${PIPESTATUS[0]}
+          set -e
+
+          echo "SAM_DEPLOY_EXIT_CODE=$rc" >> "$GITHUB_ENV"
+          echo "sam deploy exited $rc"
+
+      - name: Report deploy outcome
+        # !cancelled() rather than always(): this must survive the deploy step
+        # failing (that is the run whose summary matters most) and must also
+        # run when the deploy step never happened at all — but a cancelled job
+        # deployed nothing for a reason that needs no explaining.
+        if: ${{ !cancelled() }}
+        # Renders the applied / nothing-deployed / failed / unclassifiable
+        # taxonomy into the step summary and re-raises the code, so THIS is the
+        # step that fails the job. A no-op stays green and annotates as a
+        # warning; an exit-0 deploy whose output matches neither marker fails
+        # closed (exit 65). See scripts/sam_deploy_summary.py (#396).
+        run: |
+          set -euo pipefail
+          if [ -z "${SAM_DEPLOY_EXIT_CODE:-}" ]; then
+            args=(--not-run)
+          else
+            args=(--exit-code "$SAM_DEPLOY_EXIT_CODE")
+            if [ -n "${SAM_DEPLOY_LOG:-}" ]; then
+              args+=(--log "$SAM_DEPLOY_LOG")
+            fi
+          fi
+          python scripts/sam_deploy_summary.py "${args[@]}" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/deploy-ephemeral-rebuild.yml
+++ b/.github/workflows/deploy-ephemeral-rebuild.yml
@@ -38,6 +38,11 @@ jobs:
       - uses: aws-actions/setup-sam@v3
         with:
           use-installer: true
+          # Same pin as the deploy job below, where the reasoning lives. Both
+          # jobs, not just that one: an unpinned pair can disagree within a
+          # single run, so `sam validate --lint` would be gating on a different
+          # SAM than the one that deploys.
+          version: 1.165.0
       - name: SAM validate
         run: sam validate --lint -t infra/ephemeral-rebuild/template.yaml
       - name: pytest (stack unit tests)
@@ -69,6 +74,24 @@ jobs:
       - uses: aws-actions/setup-sam@v3
         with:
           use-installer: true
+          # Pinned, because two SAM console strings are load-bearing:
+          # scripts/sam_deploy_summary.py classifies this deploy from
+          # "Successfully created/updated stack" and "No changes to deploy",
+          # and an upstream reword makes the run unclassifiable (exit 65, red
+          # main) on a release nobody here chose. Pinning turns that from a
+          # surprise into a step of a bump we decided to make.
+          #
+          # Unpinned it was worse than merely floating: `setup-sam` could not
+          # resolve the latest tag in the deploy job of run 31975090212 and
+          # logged "Downloading latest without caching", so that job ran an
+          # unrecorded version -- possibly not the 1.165.0 the validate job
+          # had cached in the same run.
+          #
+          # WHEN BUMPING: re-run a deploy and confirm both markers still appear
+          # verbatim, then refresh the captures in
+          # tests/unit/test_sam_deploy_summary.py, which are real log excerpts
+          # and not hand-written fixtures.
+          version: 1.165.0
       - uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ vars.AWS_ROLE_TO_ASSUME }}
@@ -161,8 +184,14 @@ jobs:
             args=(--not-run)
           else
             args=(--exit-code "$SAM_DEPLOY_EXIT_CODE")
-            if [ -n "${SAM_DEPLOY_LOG:-}" ]; then
-              args+=(--log "$SAM_DEPLOY_LOG")
-            fi
+          fi
+          # Outside the branch, deliberately. The deploy step exports
+          # SAM_DEPLOY_LOG *before* it runs SAM, so the log can exist for a run
+          # that recorded no exit code — a step killed between SAM finishing
+          # and the status being written. That is the one case where --not-run
+          # can be told whether SAM actually ran, and nesting this append under
+          # the else branch is what would make it unanswerable.
+          if [ -n "${SAM_DEPLOY_LOG:-}" ]; then
+            args+=(--log "$SAM_DEPLOY_LOG")
           fi
           python scripts/sam_deploy_summary.py "${args[@]}" >> "$GITHUB_STEP_SUMMARY"

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -16,6 +16,24 @@ Two workflows assume the same role, `AWS_ROLE_TO_ASSUME`: `deploy-ephemeral-rebu
 
 Before concluding infrastructure is missing, check the other account.
 
+## Run-outcome reporting
+
+Three workflows now share one shape, and it is worth naming so the fourth is a decision rather than a rediscovery. The problem it solves is **a zero exit that is not a health signal** — a step that completed without doing the thing anyone cares about:
+
+1. The step captures its producer's own status rather than failing on it (`rc=$?`, or `${PIPESTATUS[0]}` behind a `| tee`), and exports it via `$GITHUB_ENV`. Failing in place would make GitHub skip every later step, discarding the summary that explains the failure.
+2. A later step, gated on `always()` / `!cancelled()`, runs a small stdlib-only Python renderer that classifies the outcome, writes Markdown to `$GITHUB_STEP_SUMMARY`, writes exactly **one** annotation to stderr (GitHub truncates an annotation at its first newline), and re-exits with a meaningful code. That step, not the producer's, is what fails the job.
+3. The renderer treats the producer's output as untrusted — absent, zero-byte, truncated, or undecodable must degrade the summary rather than traceback. That reading is shared in `lib/run_summary.py` (`load_text` / `load_payload` / `plain` / `annotation_line`).
+
+| Renderer | Producer | The outcome that needed saying |
+|---|---|---|
+| `scripts/parity_run_summary.py` ([#378](https://github.com/WXYC/discogs-etl/issues/378)) | `catalog_parity_diff.py --fail-on-drift` | Exit 4 is a drift **verdict**, not a broken soak |
+| `scripts/fffd_capture_summary.py` ([#382](https://github.com/WXYC/discogs-etl/issues/382)) | `catalog_parity_diff.py --capture-fffd-cta-pairs` | Its exit 4 means the opposite of parity's |
+| `scripts/sam_deploy_summary.py` ([#396](https://github.com/WXYC/discogs-etl/issues/396)) | `sam deploy --no-fail-on-empty-changeset` | Exit 0 that deployed **nothing** |
+
+The taxonomies are deliberately **not** shared — parity's exit 4 and the capture's exit 4 mean opposite things, and collapsing them is what `lib/run_summary.py`'s docstring exists to prevent. Only the plumbing is shared.
+
+Known gap: `scripts/sync-library.sh` has four soft-fail paths that log `WARNING:` and continue without touching `EXIT_CODE`, so a green `sync-library.yml` run means "library.db uploaded", not "the sync was healthy" — and it runs daily. Tracked in [#406](https://github.com/WXYC/discogs-etl/issues/406).
+
 ## Monthly Cache Rebuild (`rebuild-cache.yml`)
 
 **Status (2026-05-07)**: the GH Actions cron is disabled. The rebuild now runs on a one-shot ephemeral EC2 spawned monthly by the `wxyc-discogs-rebuild` SAM stack (`infra/ephemeral-rebuild/`). Setup + recurring-ops instructions in [`infra/ephemeral-rebuild/README.md`](../infra/ephemeral-rebuild/README.md). The Backend-Service EC2 cron is the legacy fallback; once two ephemeral runs land successfully, it is removed per the procedure in [`docs/ec2-rebuild-runbook.md`](ec2-rebuild-runbook.md). The GH workflow file stays in the repo as a `workflow_dispatch`-only manual escape hatch (no scheduled trigger).

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -10,6 +10,8 @@ This pipeline runs monthly (or when Discogs publishes new data dumps). It has a 
 
 Two workflows assume the same role, `AWS_ROLE_TO_ASSUME`: `deploy-ephemeral-rebuild.yml` deploys the stack with it, and `sync-library.yml` uses it to publish daily cache-health metrics. Re-pointing that variable moves both.
 
+**A green `deploy-ephemeral-rebuild.yml` run is not, on its own, evidence that anything was deployed** — it runs `sam deploy --no-fail-on-empty-changeset`, and for months every run was a no-op while the deploy role could not apply a changeset at all ([#396](https://github.com/WXYC/discogs-etl/issues/396)). Each run now states which it was; the outcome table is in [`infra/ephemeral-rebuild/README.md` → Reading a CI deploy run](../infra/ephemeral-rebuild/README.md#reading-a-ci-deploy-run-396).
+
 **An absent stack means the migration happened.** From 2026-05-30 until the [#353](https://github.com/WXYC/discogs-etl/issues/353) cutover the rebuild stack existed in *two* accounts at once, both armed with `cron(0 6 4 * ? *)` against the same Railway database, and the resulting double-run destroyed 27,163 cache rows on 2026-08-04 ([#352](https://github.com/WXYC/discogs-etl/issues/352)). The duplicate was not carelessness: a correct migration in May 2026 deleted the old stack, and [#248](https://github.com/WXYC/discogs-etl/issues/248) — fixing a genuinely broken CI deploy a week later — observed that account was empty of the stack and concluded it had never deployed. Both readings fit the evidence. Writing the directive down is what makes the intended one recoverable, which is why this paragraph exists rather than just the rule above it.
 
 Before concluding infrastructure is missing, check the other account.

--- a/infra/ephemeral-rebuild/README.md
+++ b/infra/ephemeral-rebuild/README.md
@@ -69,6 +69,26 @@ The first guided deploy writes its choices to `samconfig.toml`; subsequent deplo
 
 `samconfig.toml` names the SAM artifact bucket explicitly (`s3_bucket = …`) rather than setting `resolve_s3`. `resolve_s3` reconciles the `aws-sam-cli-managed-default` CloudFormation stack, which the least-privilege CI deploy role is not authorized to touch. Note that the two are mutually exclusive — SAM rejects `--s3-bucket` and `--resolve-s3` together, and a `samconfig.toml` default counts as "provided", so re-adding `resolve_s3` there breaks the CI deploy even though nothing on the command line changed.
 
+#### Reading a CI deploy run ([#396](https://github.com/WXYC/discogs-etl/issues/396))
+
+**A green run of this workflow does not by itself mean the stack was deployed.** It runs `sam deploy --no-fail-on-empty-changeset`, so SAM exits 0 both when it applies a changeset and when it has nothing to apply. Between the [#353](https://github.com/WXYC/discogs-etl/issues/353) account cutover and 2026-08-16 the deploy role lacked `ec2:DescribeImages` and could not have applied *anything*; the workflow was green throughout, and the condition surfaced only when [#358](https://github.com/WXYC/discogs-etl/issues/358)'s `ReleaseCountAlarm` happened to be the first real changeset in that window and failed loudly.
+
+The flag stays — three of the four triggers legitimately produce no template diff, and reddening those would put a permanent failing check on `main`. Instead every run now ends with a **Report deploy outcome** step (`scripts/sam_deploy_summary.py`) that renders which of these it was into the run summary and one annotation:
+
+| Outcome | Step exit | Annotation | Meaning |
+|---|---|---|---|
+| Changeset applied | `0` | `notice` | The stack now matches `template.yaml` at this commit |
+| **Nothing was deployed** | `0` | **`warning`** | SAM had nothing to apply. Nothing reached AWS |
+| Failed | SAM's own code | `error` | CloudFormation rolled back; the stack is behind `main` |
+| Outcome could not be determined | `65` | `error` | Exit 0, output matched neither marker — fails closed |
+| Never ran | `65` | `error` | An earlier step failed; `sam deploy` was not reached |
+
+A **nothing was deployed** warning is expected when the trigger was a change to `scripts/rebuild-cache-bootstrap.sh` (the instance fetches that from the repo at run time; it is not part of the rendered template), a change to the workflow file, or a bare `workflow_dispatch` on an already-deployed `main`. It is **suspicious** when the push changed `template.yaml` or a Lambda handler in this directory — that means a template change did not reach the stack.
+
+**Outcome could not be determined** means a SAM CLI upgrade reworded one of the two lines the renderer matches (`Successfully created/updated stack` / `No changes to deploy`). Read the deploy step's log, confirm what actually happened, then update `scripts/sam_deploy_summary.py` and the verbatim log fixtures in `tests/unit/test_sam_deploy_summary.py` — replacing those fixtures is how the new wording gets pinned. Failing closed is deliberate: an exit-0 deploy whose output cannot be read might have deployed nothing, and treating that as success is exactly what #396 was.
+
+On an `AccessDenied` failure the summary names the denied IAM actions and points at [`infra/bootstrap/`](../bootstrap/README.md) — the grant belongs on the **deploy role**, not the `InstanceRole` this stack's rebuild assumes at run time.
+
 ### 3. Confirm the schedule
 
 ```bash

--- a/infra/ephemeral-rebuild/README.md
+++ b/infra/ephemeral-rebuild/README.md
@@ -81,7 +81,7 @@ The flag stays — three of the four triggers legitimately produce no template d
 | **Nothing was deployed** | `0` | **`warning`** | SAM had nothing to apply. Nothing reached AWS |
 | Failed | SAM's own code | `error` | CloudFormation rolled back; the stack is behind `main` |
 | Outcome could not be determined | `65` | `error` | Exit 0, output matched neither marker — fails closed |
-| Never ran | `65` | `error` | An earlier step failed; `sam deploy` was not reached |
+| No exit status was recorded | `65` | `error` | Almost always: an earlier step failed and `sam deploy` was not reached |
 
 A **nothing was deployed** warning is expected when the trigger was a change to `scripts/rebuild-cache-bootstrap.sh` (the instance fetches that from the repo at run time; it is not part of the rendered template), a change to the workflow file, or a bare `workflow_dispatch` on an already-deployed `main`. It is **suspicious** when the push changed `template.yaml` or a Lambda handler in this directory — that means a template change did not reach the stack.
 

--- a/lib/run_summary.py
+++ b/lib/run_summary.py
@@ -85,7 +85,12 @@ def load_payload(path: str | None, *, noun: str) -> tuple[dict[str, Any] | None,
     raw, problem = load_text(path, noun=noun)
     if raw is None:
         return None, problem
-    file = Path(path or "")
+    # `path` is necessarily truthy here -- load_text returns text only for a
+    # path it could open. Not defended with `or ""`: that would turn a future
+    # contract change into messages naming an empty file, and quietly-wrong
+    # output about a producer's run is the failure mode this module exists to
+    # avoid. A TypeError is the better answer.
+    file = Path(path)  # type: ignore[arg-type]
     try:
         parsed = json.loads(raw)
     except json.JSONDecodeError as exc:
@@ -102,3 +107,33 @@ def plain(markdown: str) -> str:
     noise rather than formatting.
     """
     return markdown.replace("`", "").replace("**", "")
+
+
+def annotation_line(kind: str, *, title: str, body: str) -> str:
+    """One GitHub workflow command, on one line.
+
+    Two invariants that are easy to state and easy to lose, which is why the
+    three renderers call this rather than each formatting the string:
+
+    * **One line.** GitHub truncates an annotation at its first newline, so a
+      multi-line body silently loses everything after the first.
+    * **Plain text.** Annotations are not rendered as Markdown, so the
+      backticks and asterisks a summary line carries show up as literal
+      punctuation. Every body goes through :func:`plain`.
+
+    The second one had already drifted while this lived in three places:
+    ``parity_run_summary.py`` stripped its appended causes but not its stored
+    ``annotation_body``, and nothing caught it because the test asserted that
+    the module had *imported* ``plain``, not that its output was stripped. It
+    was latent only because parity's bodies happened to carry no backticks.
+
+    Args:
+        kind: The workflow-command level -- ``notice``, ``warning``, ``error``.
+        title: The annotation title, shown in bold in the run UI.
+        body: The message, in the summary's Markdown register; stripped here.
+
+    Returns:
+        The complete ``::kind title=...::body`` line, without a trailing
+        newline.
+    """
+    return f"::{kind} title={title}::{plain(body)}"

--- a/lib/run_summary.py
+++ b/lib/run_summary.py
@@ -21,6 +21,51 @@ from pathlib import Path
 from typing import Any
 
 
+def load_text(path: str | None, *, noun: str) -> tuple[str | None, str | None]:
+    """Read a producer's output file as text.
+
+    Returns ``(text, problem)`` -- exactly one of which is None. Every failure
+    mode collapses into a human-readable ``problem`` string rather than an
+    exception.
+
+    Split out of :func:`load_payload` for ``scripts/sam_deploy_summary.py``
+    (#396), whose producer is ``sam deploy`` and whose output is a captured
+    console log rather than JSON. The degraded population is identical --
+    absent because an earlier step died, zero-byte because the redirect
+    created the file before the producer ran, truncated or undecodable because
+    the producer was killed mid-write -- so the handling is shared rather than
+    copied a third time.
+
+    Args:
+        path: The reported path, or None when the caller was given no path
+            argument at all.
+        noun: What the file is, for the problem strings -- e.g.
+            ``"parity report"``, ``"capture report"``, ``"deploy log"``.
+
+    Returns:
+        The file's stripped contents and None, or None and a problem
+        description.
+    """
+    if not path:
+        return None, f"no {noun} path was given"
+    file = Path(path)
+    if not file.exists():
+        return None, f"`{file.name}` was never written"
+    try:
+        raw = file.read_text(encoding="utf-8").strip()
+    except UnicodeDecodeError as exc:
+        # Deliberately not errors="replace": the capture's entire subject
+        # matter is bytes that were mis-decoded into U+FFFD, and silently
+        # doing the same thing to its own report would be the one failure
+        # mode nobody would think to look for.
+        return None, f"`{file.name}` is not valid UTF-8 ({exc.reason})"
+    except OSError as exc:
+        return None, f"`{file.name}` could not be read ({exc})"
+    if not raw:
+        return None, f"`{file.name}` is empty -- the producer wrote no {noun}"
+    return raw, None
+
+
 def load_payload(path: str | None, *, noun: str) -> tuple[dict[str, Any] | None, str | None]:
     """Read a producer's ``--json`` object.
 
@@ -37,23 +82,10 @@ def load_payload(path: str | None, *, noun: str) -> tuple[dict[str, Any] | None,
     Returns:
         The parsed object and None, or None and a problem description.
     """
-    if not path:
-        return None, "no report path was given"
-    file = Path(path)
-    if not file.exists():
-        return None, f"`{file.name}` was never written"
-    try:
-        raw = file.read_text(encoding="utf-8").strip()
-    except UnicodeDecodeError as exc:
-        # Deliberately not errors="replace": the capture's entire subject
-        # matter is bytes that were mis-decoded into U+FFFD, and silently
-        # doing the same thing to its own report would be the one failure
-        # mode nobody would think to look for.
-        return None, f"`{file.name}` is not valid UTF-8 ({exc.reason})"
-    except OSError as exc:
-        return None, f"`{file.name}` could not be read ({exc})"
-    if not raw:
-        return None, f"`{file.name}` is empty -- the producer wrote no {noun}"
+    raw, problem = load_text(path, noun=noun)
+    if raw is None:
+        return None, problem
+    file = Path(path or "")
     try:
         parsed = json.loads(raw)
     except json.JSONDecodeError as exc:

--- a/scripts/fffd_capture_summary.py
+++ b/scripts/fffd_capture_summary.py
@@ -55,8 +55,8 @@ from typing import Any
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
+from lib.run_summary import annotation_line as _annotation_line  # noqa: E402
 from lib.run_summary import load_payload as _load_payload  # noqa: E402
-from lib.run_summary import plain as _plain  # noqa: E402
 
 # The untrusted-report reader, shared with parity_run_summary.py so a
 # hardening fix reaches both (#384). Bound here with this tool's noun.
@@ -317,8 +317,9 @@ def render(exit_code: int, payload: dict[str, Any] | None, problem: str | None) 
 def annotation(exit_code: int, payload: dict[str, Any] | None) -> str:
     """One GitHub workflow command, on one line.
 
-    GitHub truncates an annotation at its first newline, so a multi-line
-    message silently loses everything after the first line.
+    Formatting -- the one-line and plain-text invariants -- belongs to
+    ``lib.run_summary.annotation_line``; this decides only the level and the
+    body.
     """
     outcome = _outcome(exit_code)
     # NOT_RUN is a notice, not an error: the parity verdict step already fails
@@ -337,7 +338,7 @@ def annotation(exit_code: int, payload: dict[str, Any] | None) -> str:
             else "see the run summary"
         )
         body = f"{body} Reasons: {detail}."
-    return f"::{kind} title={outcome.annotation_title}::{_plain(body)}"
+    return _annotation_line(kind, title=outcome.annotation_title, body=body)
 
 
 def _build_arg_parser() -> argparse.ArgumentParser:

--- a/scripts/parity_run_summary.py
+++ b/scripts/parity_run_summary.py
@@ -53,8 +53,8 @@ from typing import Any
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
+from lib.run_summary import annotation_line as _annotation_line  # noqa: E402
 from lib.run_summary import load_payload as _load_payload  # noqa: E402
-from lib.run_summary import plain as _plain  # noqa: E402
 
 # The untrusted-report reader, shared with fffd_capture_summary.py so a
 # hardening fix reaches both (#384). Bound here with this tool's noun.
@@ -329,8 +329,9 @@ def render(exit_code: int, payload: dict[str, Any] | None, problem: str | None) 
 def annotation(exit_code: int, payload: dict[str, Any] | None) -> str:
     """One GitHub workflow command, on one line.
 
-    GitHub truncates an annotation at its first newline, so a multi-line
-    message silently loses everything after the first line.
+    Formatting -- the one-line and plain-text invariants -- belongs to
+    ``lib.run_summary.annotation_line``; this decides only the level and the
+    body.
     """
     outcome = _outcome(exit_code)
     kind = "notice" if exit_code == CLEAN else "error"
@@ -339,9 +340,9 @@ def annotation(exit_code: int, payload: dict[str, Any] | None) -> str:
         # The one code whose annotation earns per-run detail: which counters
         # moved is the thing worth seeing without opening the run.
         causes = verdict_causes(payload)
-        detail = "; ".join(_plain(c) for c in causes) if causes else "see the run summary"
+        detail = "; ".join(causes) if causes else "see the run summary"
         body = f"{body} {detail}."
-    return f"::{kind} title={outcome.annotation_title}::{body}"
+    return _annotation_line(kind, title=outcome.annotation_title, body=body)
 
 
 def _build_arg_parser() -> argparse.ArgumentParser:

--- a/scripts/sam_deploy_summary.py
+++ b/scripts/sam_deploy_summary.py
@@ -28,7 +28,7 @@ Outcomes, and the exit code each produces::
     no_changes      SAM had nothing to apply -- NOTHING REACHED AWS       0  (::warning)
     failed          SAM exited non-zero                        SAM's own code
     unclassifiable  exit 0, but the output says neither                  65
-    not_run         the deploy step never produced a status              65
+    not_run         no exit status was recorded                          65
 
 **The exit code alone decides failure; prose never overrides it.** For exit 0
 there are exactly two accepted top-level SAM strings, and anything else --
@@ -182,18 +182,24 @@ _OUTCOMES: dict[str, _Outcome] = {
         ),
     ),
     NOT_RUN: _Outcome(
-        heading="Ephemeral-rebuild deploy: never ran",
+        heading="Ephemeral-rebuild deploy: no exit status was recorded",
         lead=(
-            "**The deploy step produced no exit status, so `sam deploy` was never reached.** "
-            "An earlier step in this job failed -- the SAM build, the OIDC credential "
-            "assumption, or the checkout. Nothing was deployed; the failure is in the step "
-            "above this one."
+            "**The deploy step recorded no exit status for `sam deploy`.** Almost always this "
+            "means an earlier step in the job failed -- the SAM build, the OIDC credential "
+            "assumption, or the checkout -- and SAM was never reached, so nothing was "
+            "deployed and the failure is in the step above this one.\n\n"
+            'Stated that way on purpose: "no status was recorded" is what was *observed*, '
+            'and "nothing was deployed" is an inference from it. The two come apart if the '
+            "step is killed (a step timeout, the runner going away) between SAM finishing and "
+            "the status being written -- a narrow window, but this file exists because a "
+            "confident wrong reading of a deploy cost months. Where the captured log can "
+            "settle it, it is quoted below."
         ),
         annotation_kind="error",
-        annotation_title="Ephemeral-rebuild deploy never ran",
+        annotation_title="Ephemeral-rebuild deploy status missing",
         annotation_body=(
-            "sam deploy was never reached (an earlier step in the deploy job failed). "
-            "Nothing was deployed."
+            "No exit status was recorded for sam deploy -- almost certainly an earlier step "
+            "in the deploy job failed and SAM was never reached."
         ),
     ),
 }
@@ -303,6 +309,29 @@ def render(outcome: str, exit_code: int | None, log_text: str | None, problem: s
                 "",
             ]
         )
+
+    if outcome == NOT_RUN:
+        # The deploy step exports SAM_DEPLOY_LOG *before* invoking SAM, so a log
+        # can exist even when no status was recorded. If it carries a terminal
+        # SAM line, "nothing was deployed" is not something this may assert.
+        evidence = [m for m in (APPLIED_MARKER, NO_CHANGES_MARKER) if m in (log_text or "")]
+        if evidence:
+            lines.extend(
+                [
+                    f"> **The captured log does carry `{evidence[0]}`.** SAM therefore ran and "
+                    "the step died before its status could be written, rather than SAM never "
+                    "having been reached. **Check the deployed stack against "
+                    "`infra/ephemeral-rebuild/template.yaml` before assuming either way** -- "
+                    "this run cannot tell you whether the deploy completed.",
+                    "",
+                ]
+            )
+        elif log_text:
+            lines.append(
+                "The captured log carries neither terminal SAM line, which is consistent with "
+                "SAM never having been reached."
+            )
+            lines.append("")
 
     if outcome == FAILED:
         detail = _failure_detail(log_text)

--- a/scripts/sam_deploy_summary.py
+++ b/scripts/sam_deploy_summary.py
@@ -66,8 +66,8 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
+from lib.run_summary import annotation_line as _annotation_line  # noqa: E402
 from lib.run_summary import load_text as _load_text  # noqa: E402
-from lib.run_summary import plain as _plain  # noqa: E402
 
 # The untrusted-output reader, shared with the two --json renderers so a
 # hardening fix reaches all three (#384). Bound here with this tool's noun.
@@ -138,7 +138,17 @@ _OUTCOMES: dict[str, _Outcome] = {
             "this workflow used to mean either this or a real deploy, and between the #353 "
             "account cutover and 2026-08-16 it always meant this -- the deploy role lacked "
             "`ec2:DescribeImages` and could not have applied anything ("
-            "[#396](https://github.com/WXYC/discogs-etl/issues/396))."
+            "[#396](https://github.com/WXYC/discogs-etl/issues/396)).\n\n"
+            "**When this is expected.** Only `infra/ephemeral-rebuild/**` feeds the rendered "
+            "template. The workflow also fires on `scripts/rebuild-cache-bootstrap.sh` -- "
+            "which the instance fetches from the repo at run time and is not part of the "
+            "template -- on changes to the workflow file itself, and on any "
+            "`workflow_dispatch`. A no-op is the correct outcome for all three.\n\n"
+            "**When it is not.** If this push changed "
+            "`infra/ephemeral-rebuild/template.yaml` or a Lambda handler under "
+            "`infra/ephemeral-rebuild/`, then a template change did not reach the stack and "
+            "something is wrong. Compare the deployed stack against the template before "
+            "assuming a declared resource exists."
         ),
         annotation_kind="warning",
         annotation_title="Ephemeral-rebuild stack unchanged",
@@ -291,25 +301,6 @@ def render(outcome: str, exit_code: int | None, log_text: str | None, problem: s
     record = _OUTCOMES[outcome]
     lines = [f"## {record.heading}", "", record.lead, ""]
 
-    if outcome == NO_CHANGES:
-        lines.extend(
-            [
-                "**When this is expected.** Only `infra/ephemeral-rebuild/**` feeds the "
-                "rendered template. The workflow also fires on "
-                "`scripts/rebuild-cache-bootstrap.sh` -- which the instance fetches from the "
-                "repo at run time and is not part of the template -- on changes to the "
-                "workflow file itself, and on any `workflow_dispatch`. A no-op is the "
-                "correct outcome for all three.",
-                "",
-                "**When it is not.** If this push changed "
-                "`infra/ephemeral-rebuild/template.yaml` or a Lambda handler under "
-                "`infra/ephemeral-rebuild/`, then a template change did not reach the "
-                "stack and something is wrong. Compare the deployed stack against the "
-                "template before assuming a declared resource exists.",
-                "",
-            ]
-        )
-
     if outcome == NOT_RUN:
         # The deploy step exports SAM_DEPLOY_LOG *before* invoking SAM, so a log
         # can exist even when no status was recorded. If it carries a terminal
@@ -358,11 +349,18 @@ def render(outcome: str, exit_code: int | None, log_text: str | None, problem: s
     return "\n".join(lines) + "\n"
 
 
-def annotation(outcome: str, exit_code: int | None, log_text: str | None) -> str:
+def annotation(outcome: str, log_text: str | None) -> str:
     """One GitHub workflow command, on one line.
 
-    GitHub truncates an annotation at its first newline, so a multi-line
-    message silently loses everything after the first line.
+    Formatting -- the one-line and plain-text invariants -- belongs to
+    ``lib.run_summary.annotation_line``; this decides only the body. The level
+    is the record's, not computed here: an outcome's severity and its exit
+    status have to agree, and the two siblings that compute it in an ad-hoc
+    ternary outside the record are the shape to move away from.
+
+    No ``exit_code`` parameter: ``outcome`` already carries everything the
+    annotation varies on. Taking one would invite call sites that read as if
+    NOT_RUN-with-exit-1 were a real combination.
     """
     record = _OUTCOMES[outcome]
     body = record.annotation_body
@@ -370,7 +368,7 @@ def annotation(outcome: str, exit_code: int | None, log_text: str | None) -> str
         actions = denied_actions(log_text)
         if actions:
             body = f"{body} Denied IAM action(s): {', '.join(actions)} -- see the run summary."
-    return f"::{record.annotation_kind} title={record.annotation_title}::{_plain(body)}"
+    return _annotation_line(record.annotation_kind, title=record.annotation_title, body=body)
 
 
 def exit_status(outcome: str, exit_code: int | None) -> int:
@@ -420,7 +418,7 @@ def main(argv: list[str] | None = None) -> int:
     log_text, problem = load_log(args.log)
     outcome = classify(exit_code, log_text)
     sys.stdout.write(render(outcome, exit_code, log_text, problem))
-    sys.stderr.write(annotation(outcome, exit_code, log_text) + "\n")
+    sys.stderr.write(annotation(outcome, log_text) + "\n")
     return exit_status(outcome, exit_code)
 
 

--- a/scripts/sam_deploy_summary.py
+++ b/scripts/sam_deploy_summary.py
@@ -1,0 +1,399 @@
+#!/usr/bin/env python3
+"""Say what a ``sam deploy`` run actually did to the stack (#396).
+
+``.github/workflows/deploy-ephemeral-rebuild.yml`` runs ``sam deploy
+--no-fail-on-empty-changeset``. SAM then exits 0 in two completely different
+situations -- it applied a changeset, or it found nothing to apply -- and until
+this renderer existed the run's output could not tell them apart. That is not
+a hypothetical: between the #353 account cutover and 2026-08-16 the deploy role
+lacked ``ec2:DescribeImages`` and could not have applied *anything*, and the
+workflow was green throughout. The condition surfaced only because #358's
+``ReleaseCountAlarm`` was the first real changeset in that window:
+
+    run 31970903384   "No changes to deploy. Stack ... is up to date"   exit 0
+    run 31970987037   AccessDenied ec2:DescribeImages -> rollback       exit 1
+
+Two minutes apart, the first one green and meaningless.
+
+The flag stays -- three of the workflow's four triggers legitimately produce no
+template diff (``scripts/rebuild-cache-bootstrap.sh`` is fetched by the
+instance at runtime and is not part of the rendered template; the workflow file
+is not either; a ``workflow_dispatch`` on an already-deployed ``main`` is a
+no-op by construction), and reddening those would put a permanent failing check
+on ``main``. What changes is that a no-op now announces itself.
+
+Outcomes, and the exit code each produces::
+
+    applied         a changeset reached CloudFormation                    0
+    no_changes      SAM had nothing to apply -- NOTHING REACHED AWS       0  (::warning)
+    failed          SAM exited non-zero                        SAM's own code
+    unclassifiable  exit 0, but the output says neither                  65
+    not_run         the deploy step never produced a status              65
+
+**The exit code alone decides failure; prose never overrides it.** For exit 0
+there are exactly two accepted top-level SAM strings, and anything else --
+neither present, or both -- is ``unclassifiable`` and red. That direction is
+deliberate: the defect being fixed is a silent fall-through to "looks fine", so
+an output this cannot read must be loud rather than optimistic.
+
+Nothing here parses SAM's CloudFormation events table. Its columns are
+fixed-width and wrap mid-token: the real rollback log contains
+``UPDATE_ROLLBACK_COMPLE`` / ``TE`` on two lines and the successful one
+contains ``UPDATE_COMPLETE_CLEANU``, so substring matches against resource
+statuses are a coin flip on column width.
+
+Markdown on stdout (the workflow appends it to ``$GITHUB_STEP_SUMMARY``) and
+exactly one GitHub workflow-command annotation on stderr, then exit with the
+code above. Deliberately no ``init_logger`` and no third-party import: the
+``deploy`` job installs nothing, and JSON log lines on stderr would corrupt the
+annotation.
+
+Usage::
+
+    python scripts/sam_deploy_summary.py --exit-code 0 --log sam-deploy.log \\
+        >> "$GITHUB_STEP_SUMMARY"
+    python scripts/sam_deploy_summary.py --not-run >> "$GITHUB_STEP_SUMMARY"
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass
+from functools import partial
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from lib.run_summary import load_text as _load_text  # noqa: E402
+from lib.run_summary import plain as _plain  # noqa: E402
+
+# The untrusted-output reader, shared with the two --json renderers so a
+# hardening fix reaches all three (#384). Bound here with this tool's noun.
+load_log = partial(_load_text, noun="deploy log")
+
+APPLIED = "applied"
+NO_CHANGES = "no_changes"
+FAILED = "failed"
+UNCLASSIFIABLE = "unclassifiable"
+NOT_RUN = "not_run"
+
+# EX_DATAERR. Chosen so the bare number is diagnostic: SAM exits 1, and a
+# killed runner step exits 137 or 143, so 65 cannot be mistaken for either.
+UNCLASSIFIABLE_EXIT = 65
+
+# The two top-level lines SAM prints, one per exit-0 outcome. Both are terminal
+# statements about the whole deploy, which is why they are the only two
+# accepted. In particular "Changeset created successfully" is NOT here: it
+# precedes the apply and appears in the #396 rollback log too, so matching on
+# it would have called that failure a success.
+APPLIED_MARKER = "Successfully created/updated stack"
+NO_CHANGES_MARKER = "No changes to deploy"
+
+STACK_NAME = "wxyc-discogs-rebuild"
+
+# `service:Action` as it appears in an AccessDenied reason. Anchored on a
+# lowercase service prefix and an upper-camel action so ARNs
+# (`arn:aws:cloudformation:...`) and resource types (`AWS::CloudWatch::Alarm`)
+# do not match. SAM's column wrapping can split a long action across lines --
+# the summary says so rather than pretending the list is exhaustive.
+_ACTION_RE = re.compile(r"(?<![:\w])([a-z][a-z0-9-]{1,31}:[A-Z][A-Za-z0-9]+)(?![:\w])")
+
+
+@dataclass(frozen=True)
+class _Outcome:
+    """Everything one outcome means, in one place.
+
+    The step summary and the annotation say the same thing in two registers.
+    Branching on the outcome separately in each is how they drift, and a
+    drifted no-op message is precisely the failure this file exists to prevent.
+    """
+
+    heading: str
+    lead: str
+    annotation_kind: str
+    annotation_title: str
+    annotation_body: str
+
+
+_OUTCOMES: dict[str, _Outcome] = {
+    APPLIED: _Outcome(
+        heading="Ephemeral-rebuild deploy: changeset applied",
+        lead=(
+            f"**A changeset reached CloudFormation.** `{STACK_NAME}` now matches "
+            "`infra/ephemeral-rebuild/template.yaml` at this commit. The resources SAM "
+            "created, modified, or deleted are listed in the changeset table in the deploy "
+            "step's log."
+        ),
+        annotation_kind="notice",
+        annotation_title="Ephemeral-rebuild stack updated",
+        annotation_body=f"A changeset was applied to {STACK_NAME}.",
+    ),
+    NO_CHANGES: _Outcome(
+        heading="Ephemeral-rebuild deploy: nothing was deployed",
+        lead=(
+            "**SAM found no changes to apply, so nothing reached AWS.** This run did not "
+            "modify the stack. It is reported rather than silent because a green run of "
+            "this workflow used to mean either this or a real deploy, and between the #353 "
+            "account cutover and 2026-08-16 it always meant this -- the deploy role lacked "
+            "`ec2:DescribeImages` and could not have applied anything ("
+            "[#396](https://github.com/WXYC/discogs-etl/issues/396))."
+        ),
+        annotation_kind="warning",
+        annotation_title="Ephemeral-rebuild stack unchanged",
+        annotation_body=(
+            f"sam deploy found no changes; nothing was applied to {STACK_NAME}. Expected "
+            "when the trigger was a bootstrap-script, workflow-file, or dispatch-only "
+            "change -- suspicious if template.yaml changed in this push."
+        ),
+    ),
+    FAILED: _Outcome(
+        heading="Ephemeral-rebuild deploy: failed",
+        lead=(
+            "**SAM exited non-zero -- the deploy did not complete.** CloudFormation rolls a "
+            "failed update back to the previous template, so the stack is consistent, but "
+            "it is now behind `main`."
+        ),
+        annotation_kind="error",
+        annotation_title="Ephemeral-rebuild deploy failed",
+        annotation_body=f"sam deploy failed; {STACK_NAME} is unchanged and behind main.",
+    ),
+    UNCLASSIFIABLE: _Outcome(
+        heading="Ephemeral-rebuild deploy: outcome could not be determined",
+        lead=(
+            "**SAM exited 0, but its output says neither that it applied a changeset nor "
+            "that it had nothing to apply.** This run is deliberately red. An exit-0 deploy "
+            "whose output cannot be read might have deployed nothing, and treating that as "
+            "success is the exact failure mode "
+            "[#396](https://github.com/WXYC/discogs-etl/issues/396) was -- so the ambiguous "
+            "case fails closed.\n\n"
+            "The usual cause is a SAM CLI upgrade rewording one of the two lines this looks "
+            f"for: `{APPLIED_MARKER}` and `{NO_CHANGES_MARKER}`. Read the deploy step's log, "
+            "confirm what actually happened, then update `scripts/sam_deploy_summary.py` and "
+            "the fixtures in `tests/unit/test_sam_deploy_summary.py` -- which are verbatim "
+            "captures, so replacing them is how the new wording gets pinned."
+        ),
+        annotation_kind="error",
+        annotation_title="Ephemeral-rebuild deploy outcome unknown",
+        annotation_body=(
+            "sam deploy exited 0 but its output matched neither the applied nor the "
+            "no-changes marker; failing closed rather than assuming success."
+        ),
+    ),
+    NOT_RUN: _Outcome(
+        heading="Ephemeral-rebuild deploy: never ran",
+        lead=(
+            "**The deploy step produced no exit status, so `sam deploy` was never reached.** "
+            "An earlier step in this job failed -- the SAM build, the OIDC credential "
+            "assumption, or the checkout. Nothing was deployed; the failure is in the step "
+            "above this one."
+        ),
+        annotation_kind="error",
+        annotation_title="Ephemeral-rebuild deploy never ran",
+        annotation_body=(
+            "sam deploy was never reached (an earlier step in the deploy job failed). "
+            "Nothing was deployed."
+        ),
+    ),
+}
+
+
+def classify(exit_code: int | None, log_text: str | None) -> str:
+    """Which outcome this run was.
+
+    Args:
+        exit_code: ``sam deploy``'s own status, or None when the deploy step
+            never ran.
+        log_text: The captured console output, or None when it could not be
+            read.
+
+    Returns:
+        One of :data:`APPLIED`, :data:`NO_CHANGES`, :data:`FAILED`,
+        :data:`UNCLASSIFIABLE`, :data:`NOT_RUN`.
+    """
+    if exit_code is None:
+        return NOT_RUN
+    if exit_code != 0:
+        # Sufficient on its own, and not overridable by the log: a deploy that
+        # printed the success line and was then killed did not succeed.
+        return FAILED
+    if log_text is None:
+        return UNCLASSIFIABLE
+    applied = APPLIED_MARKER in log_text
+    no_changes = NO_CHANGES_MARKER in log_text
+    if applied and not no_changes:
+        return APPLIED
+    if no_changes and not applied:
+        return NO_CHANGES
+    return UNCLASSIFIABLE
+
+
+def denied_actions(log_text: str | None) -> list[str]:
+    """IAM actions named in an ``AccessDenied`` reason, in order of appearance.
+
+    Empty unless the log actually carries an ``AccessDenied`` -- an unrelated
+    failure must not be reported as a permissions problem.
+    """
+    if not log_text or "AccessDenied" not in log_text:
+        return []
+    seen: list[str] = []
+    for match in _ACTION_RE.finditer(log_text):
+        action = match.group(1)
+        if action not in seen:
+            seen.append(action)
+    return seen
+
+
+def _failure_detail(log_text: str | None) -> list[str]:
+    """What a failed deploy can say beyond "it failed"."""
+    lines: list[str] = []
+    text = log_text or ""
+
+    actions = denied_actions(text)
+    if actions:
+        rendered = ", ".join(f"`{a}`" for a in actions)
+        lines.append(
+            f"**CloudFormation was denied an IAM action: {rendered}.** The principal is the "
+            "GitHub OIDC deploy role (`vars.AWS_ROLE_TO_ASSUME`), defined in "
+            "`infra/bootstrap/deploy-role.yaml` -- *not* the `InstanceRole` the rebuild "
+            "assumes at runtime. Add the grant there, add the matching expectation to "
+            "`infra/bootstrap/simulate-deploy-role.sh`, then apply the bootstrap template by "
+            "hand with admin credentials: CI cannot deploy it, because it is what lets CI "
+            "deploy. See `infra/bootstrap/README.md`."
+        )
+        lines.append(
+            "SAM wraps its events table at fixed column widths, so a longer action name can "
+            "be split across two lines and missed here. Read the `ResourceStatusReason` "
+            "column in the deploy step's log before concluding the list above is complete."
+        )
+
+    if "ROLLBACK" in text:
+        lines.append(
+            f"**The stack rolled back**, so `{STACK_NAME}` still holds the previous template "
+            "and no partial state was left behind -- but it has now **diverged from "
+            "`infra/ephemeral-rebuild/template.yaml` on `main`**, and will stay diverged "
+            "until a deploy succeeds. Anything the failed changeset would have created does "
+            "not exist. Do not assume a resource is live because it is declared."
+        )
+
+    return lines
+
+
+def render(outcome: str, exit_code: int | None, log_text: str | None, problem: str | None) -> str:
+    """The step-summary Markdown."""
+    record = _OUTCOMES[outcome]
+    lines = [f"## {record.heading}", "", record.lead, ""]
+
+    if outcome == NO_CHANGES:
+        lines.extend(
+            [
+                "**When this is expected.** Only `infra/ephemeral-rebuild/**` feeds the "
+                "rendered template. The workflow also fires on "
+                "`scripts/rebuild-cache-bootstrap.sh` -- which the instance fetches from the "
+                "repo at run time and is not part of the template -- on changes to the "
+                "workflow file itself, and on any `workflow_dispatch`. A no-op is the "
+                "correct outcome for all three.",
+                "",
+                "**When it is not.** If this push changed "
+                "`infra/ephemeral-rebuild/template.yaml` or a Lambda handler under "
+                "`infra/ephemeral-rebuild/`, then a template change did not reach the "
+                "stack and something is wrong. Compare the deployed stack against the "
+                "template before assuming a declared resource exists.",
+                "",
+            ]
+        )
+
+    if outcome == FAILED:
+        detail = _failure_detail(log_text)
+        if detail:
+            lines.extend(f"- {item}" for item in detail)
+            lines.append("")
+        if exit_code is not None:
+            lines.append(f"`sam deploy` exited **{exit_code}**.")
+            lines.append("")
+
+    if problem and outcome in (UNCLASSIFIABLE, FAILED):
+        lines.append(f"> The captured deploy log could not be read: {problem}.")
+        lines.append("")
+
+    # The footer deliberately names only the stack and its template. The deploy
+    # role is named in the AccessDenied branch and nowhere else: on a failure
+    # with an unrelated cause, a pointer at the IAM template reads as a
+    # diagnosis and sends the next reader down #396's path for no reason.
+    lines.append(
+        f"Stack `{STACK_NAME}` in `us-east-1`, WXYC org account. Template: "
+        "`infra/ephemeral-rebuild/template.yaml`. Why this summary exists: "
+        "[#396](https://github.com/WXYC/discogs-etl/issues/396)."
+    )
+    return "\n".join(lines) + "\n"
+
+
+def annotation(outcome: str, exit_code: int | None, log_text: str | None) -> str:
+    """One GitHub workflow command, on one line.
+
+    GitHub truncates an annotation at its first newline, so a multi-line
+    message silently loses everything after the first line.
+    """
+    record = _OUTCOMES[outcome]
+    body = record.annotation_body
+    if outcome == FAILED:
+        actions = denied_actions(log_text)
+        if actions:
+            body = f"{body} Denied IAM action(s): {', '.join(actions)} -- see the run summary."
+    return f"::{record.annotation_kind} title={record.annotation_title}::{_plain(body)}"
+
+
+def exit_status(outcome: str, exit_code: int | None) -> int:
+    """The code the report step returns, and therefore the job's status."""
+    if outcome == FAILED:
+        # Re-raise SAM's own number so the failing step carries it into the log.
+        return exit_code if exit_code else 1
+    if outcome in (UNCLASSIFIABLE, NOT_RUN):
+        return UNCLASSIFIABLE_EXIT
+    return 0
+
+
+def _build_arg_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        description=(
+            "Render a GitHub Actions step summary for a sam deploy run, distinguishing an "
+            "applied changeset from an empty one so a no-op cannot pass for a deploy. "
+            "Markdown on stdout, one annotation on stderr."
+        ),
+    )
+    group = p.add_mutually_exclusive_group(required=True)
+    group.add_argument(
+        "--exit-code",
+        type=int,
+        help="The exit code sam deploy returned (read from ${PIPESTATUS[0]}, not $?).",
+    )
+    group.add_argument(
+        "--not-run",
+        action="store_true",
+        help="The deploy step never produced a status because an earlier step failed.",
+    )
+    p.add_argument(
+        "--log",
+        default=None,
+        metavar="PATH",
+        help=(
+            "Path to the captured sam deploy output. Optional and untrusted: a missing, "
+            "empty, or undecodable file degrades the summary rather than failing it."
+        ),
+    )
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_arg_parser().parse_args(argv)
+    exit_code = None if args.not_run else args.exit_code
+    log_text, problem = load_log(args.log)
+    outcome = classify(exit_code, log_text)
+    sys.stdout.write(render(outcome, exit_code, log_text, problem))
+    sys.stderr.write(annotation(outcome, exit_code, log_text) + "\n")
+    return exit_status(outcome, exit_code)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/tests/unit/test_deploy_ephemeral_rebuild_workflow.py
+++ b/tests/unit/test_deploy_ephemeral_rebuild_workflow.py
@@ -74,6 +74,25 @@ def _step(job: str, name: str) -> dict[str, Any]:
 
 DEPLOY_STEP_NAME = "SAM deploy"
 REPORT_STEP_NAME = "Report deploy outcome"
+RENDERER = "sam_deploy_summary.py"
+
+
+def _effective_workdir(step_name: str, job: str = "deploy") -> str:
+    """Where a step's ``run:`` actually executes, relative to the repo root.
+
+    GitHub resolves ``working-directory`` step-first, then the job's
+    ``defaults.run``, then the workflow's. Checking only the step's own key
+    would miss a job-level default entirely -- which is the realistic way this
+    breaks, since the repetition across three steps invites hoisting.
+    """
+    for source in (
+        _step(job, step_name),
+        WORKFLOW["jobs"][job].get("defaults", {}).get("run", {}),
+        WORKFLOW.get("defaults", {}).get("run", {}),
+    ):
+        if source.get("working-directory"):
+            return source["working-directory"]
+    return "."
 
 
 class TestTheDeployStepCapturesItsOutcome:
@@ -167,10 +186,19 @@ class TestTheReportStep:
     def test_the_renderer_path_resolves_from_the_steps_working_directory(self) -> None:
         """``SAM deploy`` runs in ``infra/ephemeral-rebuild``. If the report
         step inherited that, the relative script path would not resolve and the
-        summary would be a ``can't open file`` traceback."""
-        step = _step("deploy", REPORT_STEP_NAME)
-        cwd = REPO_ROOT / step.get("working-directory", ".")
-        assert (cwd / "scripts" / "sam_deploy_summary.py").is_file()
+        summary would be a ``can't open file`` traceback.
+
+        Resolved through the full precedence chain, not just the step's own
+        key: three of the four ``deploy`` steps repeat that
+        ``working-directory``, so hoisting it to ``jobs.deploy.defaults.run``
+        is an obvious tidy-up -- and one that would break this step while a
+        step-level-only check kept passing."""
+        assert (REPO_ROOT / _effective_workdir(REPORT_STEP_NAME) / "scripts" / RENDERER).is_file()
+
+    def test_the_deploy_step_still_runs_where_sam_expects(self) -> None:
+        """The other half of that precedence chain: ``sam build`` and
+        ``sam deploy`` need ``template.yaml``'s directory."""
+        assert (REPO_ROOT / _effective_workdir(DEPLOY_STEP_NAME) / "template.yaml").is_file()
 
 
 class TestTheRendererNeedsNoInstall:

--- a/tests/unit/test_deploy_ephemeral_rebuild_workflow.py
+++ b/tests/unit/test_deploy_ephemeral_rebuild_workflow.py
@@ -1,21 +1,9 @@
 """Wiring tests for ``.github/workflows/deploy-ephemeral-rebuild.yml`` (#396).
 
-This workflow's green history is not, on its own, evidence that the deploy
-path works. It runs ``sam deploy --no-fail-on-empty-changeset``, so SAM exits 0
-both when it applies a changeset and when it finds nothing to do -- and for
-months every run was the second while the deploy role lacked
-``ec2:DescribeImages`` and could not have applied anything. The condition was
-only discovered because #358's ``ReleaseCountAlarm`` happened to be the first
-real changeset in that window, and it failed loudly.
-
-The flag has to stay: three of the four triggers legitimately produce no
-template diff (``scripts/rebuild-cache-bootstrap.sh`` is fetched by the
-instance at runtime and is not in the rendered template, the workflow file is
-not either, and a ``workflow_dispatch`` on an already-deployed ``main`` is a
-no-op by construction). What changes is that the outcome is now *stated*.
-
-What this file pins is the plumbing that makes the statement possible, all of
-which is silently breakable:
+Why the workflow reports its deploy outcome, and why
+``--no-fail-on-empty-changeset`` stays, is in ``scripts/sam_deploy_summary.py``'s
+module docstring. This file pins only the plumbing that makes the report
+possible, all of which is silently breakable:
 
 1. **SAM's own exit status must survive the pipe.** ``sam deploy | tee`` makes
    ``$?`` ``tee``'s status, which is 0 essentially always. Reading ``$?`` here
@@ -24,9 +12,10 @@ which is silently breakable:
 2. **A failing deploy must not abort the job at that step.** GitHub skips every
    later step once one fails, so failing in place would discard the summary
    that explains what happened. The report step re-raises the code.
-3. **The report step must run when the deploy step did not.** An earlier
-   failure (SAM build, credentials) leaves no exit code behind, and "nothing
-   was deployed" is still the honest summary for that.
+3. **The report step must run, and be answerable, when the deploy step did
+   not.** An earlier failure leaves no exit code behind -- and the captured log
+   still has to reach the renderer, or the one case that can distinguish "SAM
+   never ran" from "SAM ran and the status was lost" becomes unreachable.
 4. **The renderer must be importable without a ``pip install``.** The deploy
    job installs nothing; a renderer that imported a third-party package would
    traceback in the step whose job is to explain other failures.
@@ -47,52 +36,33 @@ from pathlib import Path
 from typing import Any
 
 import pytest
-import yaml
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT))
+
+from tests.workflow_yaml import load_workflow, step_named, steps, working_directory  # noqa: E402
+
 WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "deploy-ephemeral-rebuild.yml"
-RENDERER_PATH = REPO_ROOT / "scripts" / "sam_deploy_summary.py"
+RENDERER = "sam_deploy_summary.py"
+RENDERER_PATH = REPO_ROOT / "scripts" / RENDERER
 
+WORKFLOW = load_workflow(WORKFLOW_PATH)
 
-def _load() -> dict[str, Any]:
-    return yaml.safe_load(WORKFLOW_PATH.read_text())
-
-
-WORKFLOW = _load()
+DEPLOY_JOB = "deploy"
+DEPLOY_STEP_NAME = "SAM deploy"
+REPORT_STEP_NAME = "Report deploy outcome"
 
 
 def _steps(job: str) -> list[dict[str, Any]]:
-    return WORKFLOW["jobs"][job]["steps"]
+    return steps(WORKFLOW, job)
 
 
 def _step(job: str, name: str) -> dict[str, Any]:
-    for step in _steps(job):
-        if step.get("name") == name:
-            return step
-    raise AssertionError(f"no step named {name!r} in job {job!r}")
+    return step_named(WORKFLOW, job, name)
 
 
-DEPLOY_STEP_NAME = "SAM deploy"
-REPORT_STEP_NAME = "Report deploy outcome"
-RENDERER = "sam_deploy_summary.py"
-
-
-def _effective_workdir(step_name: str, job: str = "deploy") -> str:
-    """Where a step's ``run:`` actually executes, relative to the repo root.
-
-    GitHub resolves ``working-directory`` step-first, then the job's
-    ``defaults.run``, then the workflow's. Checking only the step's own key
-    would miss a job-level default entirely -- which is the realistic way this
-    breaks, since the repetition across three steps invites hoisting.
-    """
-    for source in (
-        _step(job, step_name),
-        WORKFLOW["jobs"][job].get("defaults", {}).get("run", {}),
-        WORKFLOW.get("defaults", {}).get("run", {}),
-    ):
-        if source.get("working-directory"):
-            return source["working-directory"]
-    return "."
+def _effective_workdir(step_name: str) -> str:
+    return working_directory(WORKFLOW, DEPLOY_JOB, step_name)
 
 
 class TestTheDeployStepCapturesItsOutcome:
@@ -156,9 +126,6 @@ class TestTheReportStep:
         run = _step("deploy", REPORT_STEP_NAME)["run"]
         assert "scripts/sam_deploy_summary.py" in run
 
-    def test_the_renderer_it_names_exists(self) -> None:
-        assert RENDERER_PATH.is_file()
-
     def test_it_appends_to_the_step_summary(self) -> None:
         assert '>> "$GITHUB_STEP_SUMMARY"' in _step("deploy", REPORT_STEP_NAME)["run"]
 
@@ -178,6 +145,26 @@ class TestTheReportStep:
         run = _step("deploy", REPORT_STEP_NAME)["run"]
         assert "--not-run" in run
         assert "SAM_DEPLOY_EXIT_CODE:-" in run
+
+    def test_the_log_is_passed_on_the_not_run_branch_too(self) -> None:
+        """``--log`` must not be nested under the exit-code-known branch.
+
+        The deploy step exports ``SAM_DEPLOY_LOG`` *before* it runs SAM, so a
+        log exists for a run killed between SAM finishing and the status being
+        written -- the one case where ``--not-run`` can be told whether SAM
+        actually ran. Nested, the renderer's entire evidence path becomes
+        unreachable from its only caller while every unit test still passes,
+        because the tests call ``main()`` directly.
+        """
+        lines = _step("deploy", REPORT_STEP_NAME)["run"].splitlines()
+        not_run = next(i for i, ln in enumerate(lines) if "--not-run" in ln)
+        log = next(i for i, ln in enumerate(lines) if "--log" in ln)
+        assert log > not_run, "--log is appended before the --not-run branch is chosen"
+        # The append sits at the same indentation as the `if` that chose the
+        # mode, not deeper -- i.e. after the branch closed, not inside it.
+        indent = len(lines[log]) - len(lines[log].lstrip())
+        branch_indent = len(lines[not_run]) - len(lines[not_run].lstrip())
+        assert indent <= branch_indent, "--log is nested inside a branch"
 
     def test_it_comes_after_the_deploy_step(self) -> None:
         names = [s.get("name") for s in _steps("deploy")]

--- a/tests/unit/test_deploy_ephemeral_rebuild_workflow.py
+++ b/tests/unit/test_deploy_ephemeral_rebuild_workflow.py
@@ -1,0 +1,224 @@
+"""Wiring tests for ``.github/workflows/deploy-ephemeral-rebuild.yml`` (#396).
+
+This workflow's green history is not, on its own, evidence that the deploy
+path works. It runs ``sam deploy --no-fail-on-empty-changeset``, so SAM exits 0
+both when it applies a changeset and when it finds nothing to do -- and for
+months every run was the second while the deploy role lacked
+``ec2:DescribeImages`` and could not have applied anything. The condition was
+only discovered because #358's ``ReleaseCountAlarm`` happened to be the first
+real changeset in that window, and it failed loudly.
+
+The flag has to stay: three of the four triggers legitimately produce no
+template diff (``scripts/rebuild-cache-bootstrap.sh`` is fetched by the
+instance at runtime and is not in the rendered template, the workflow file is
+not either, and a ``workflow_dispatch`` on an already-deployed ``main`` is a
+no-op by construction). What changes is that the outcome is now *stated*.
+
+What this file pins is the plumbing that makes the statement possible, all of
+which is silently breakable:
+
+1. **SAM's own exit status must survive the pipe.** ``sam deploy | tee`` makes
+   ``$?`` ``tee``'s status, which is 0 essentially always. Reading ``$?`` here
+   would report every failed deploy as a success -- a strictly worse version of
+   the bug being fixed. ``${PIPESTATUS[0]}`` is the only correct read.
+2. **A failing deploy must not abort the job at that step.** GitHub skips every
+   later step once one fails, so failing in place would discard the summary
+   that explains what happened. The report step re-raises the code.
+3. **The report step must run when the deploy step did not.** An earlier
+   failure (SAM build, credentials) leaves no exit code behind, and "nothing
+   was deployed" is still the honest summary for that.
+4. **The renderer must be importable without a ``pip install``.** The deploy
+   job installs nothing; a renderer that imported a third-party package would
+   traceback in the step whose job is to explain other failures.
+
+These are static-structural assertions, which per #397 may pin presence and
+ordering but cannot make reachability claims. All five outcomes -- and the
+``PIPESTATUS`` read specifically, against a stubbed ``sam`` exiting non-zero
+under ``bash -e`` -- were verified by execution while this was written; that
+coverage belongs in CI on ``tests/shell_harness.py`` once #397 lands, rather
+than in a third private copy of the harness #397 exists to consolidate.
+"""
+
+from __future__ import annotations
+
+import ast
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "deploy-ephemeral-rebuild.yml"
+RENDERER_PATH = REPO_ROOT / "scripts" / "sam_deploy_summary.py"
+
+
+def _load() -> dict[str, Any]:
+    return yaml.safe_load(WORKFLOW_PATH.read_text())
+
+
+WORKFLOW = _load()
+
+
+def _steps(job: str) -> list[dict[str, Any]]:
+    return WORKFLOW["jobs"][job]["steps"]
+
+
+def _step(job: str, name: str) -> dict[str, Any]:
+    for step in _steps(job):
+        if step.get("name") == name:
+            return step
+    raise AssertionError(f"no step named {name!r} in job {job!r}")
+
+
+DEPLOY_STEP_NAME = "SAM deploy"
+REPORT_STEP_NAME = "Report deploy outcome"
+
+
+class TestTheDeployStepCapturesItsOutcome:
+    def test_the_empty_changeset_flag_is_still_there(self) -> None:
+        """Pinned deliberately. Dropping it would turn every benign no-op into
+        a red run on ``main``; it is safe only because the outcome is now
+        reported, and these two facts belong in the same test file."""
+        assert "--no-fail-on-empty-changeset" in _step("deploy", DEPLOY_STEP_NAME)["run"]
+
+    def test_sam_output_is_captured_to_a_file(self) -> None:
+        run = _step("deploy", DEPLOY_STEP_NAME)["run"]
+        assert "tee" in run
+        assert "SAM_DEPLOY_LOG" in run
+
+    def test_the_log_path_is_exported_for_the_report_step(self) -> None:
+        run = _step("deploy", DEPLOY_STEP_NAME)["run"]
+        assert 'echo "SAM_DEPLOY_LOG=' in run
+        assert '>> "$GITHUB_ENV"' in run
+
+    def test_sams_status_is_read_from_pipestatus_not_dollar_question(self) -> None:
+        """The load-bearing one. ``$?`` after ``sam deploy | tee`` is ``tee``'s
+        status -- 0 unless the disk fills -- so a failed deploy would be
+        reported as a success."""
+        run = _step("deploy", DEPLOY_STEP_NAME)["run"]
+        assert "${PIPESTATUS[0]}" in run
+
+    def test_no_bare_dollar_question_is_captured_after_the_pipeline(self) -> None:
+        run = _step("deploy", DEPLOY_STEP_NAME)["run"]
+        assert "rc=$?" not in run
+
+    def test_nothing_executable_sits_between_the_pipeline_and_the_read(self) -> None:
+        """``PIPESTATUS`` is rewritten by the next pipeline, and every simple
+        command is a pipeline of one. Present-and-correct is not enough: the
+        read has to be the first thing after ``| tee``, comments aside. This is
+        the realistic regression -- somebody inserting a log line."""
+        lines = _step("deploy", DEPLOY_STEP_NAME)["run"].splitlines()
+        tee = next(i for i, ln in enumerate(lines) if 'tee "$SAM_DEPLOY_LOG"' in ln)
+        read = next(i for i, ln in enumerate(lines) if "${PIPESTATUS[0]}" in ln)
+        assert read > tee
+        between = [ln.strip() for ln in lines[tee + 1 : read]]
+        assert all(not ln or ln.startswith("#") for ln in between), (
+            f"a command runs between the pipeline and the PIPESTATUS read: {between}"
+        )
+
+    def test_the_exit_code_is_exported_rather_than_raised_here(self) -> None:
+        """Failing in place would skip the report step, discarding the summary
+        that makes a red run legible -- the same reason catalog-parity.yml
+        captures its harness's status instead of failing on it."""
+        run = _step("deploy", DEPLOY_STEP_NAME)["run"]
+        assert 'echo "SAM_DEPLOY_EXIT_CODE=' in run
+        assert "set +e" in run and "set -e" in run
+
+    def test_errexit_is_restored_before_the_step_ends(self) -> None:
+        run = _step("deploy", DEPLOY_STEP_NAME)["run"]
+        assert run.index("set +e") < run.index("${PIPESTATUS[0]}")
+        assert run.index("${PIPESTATUS[0]}") < run.rindex("set -e")
+
+
+class TestTheReportStep:
+    def test_it_exists_and_runs_the_renderer(self) -> None:
+        run = _step("deploy", REPORT_STEP_NAME)["run"]
+        assert "scripts/sam_deploy_summary.py" in run
+
+    def test_the_renderer_it_names_exists(self) -> None:
+        assert RENDERER_PATH.is_file()
+
+    def test_it_appends_to_the_step_summary(self) -> None:
+        assert '>> "$GITHUB_STEP_SUMMARY"' in _step("deploy", REPORT_STEP_NAME)["run"]
+
+    def test_it_runs_even_when_the_deploy_step_failed(self) -> None:
+        """Without this the summary is produced only on the runs that did not
+        need it."""
+        condition = _step("deploy", REPORT_STEP_NAME)["if"]
+        assert "cancelled()" in condition or "always()" in condition
+
+    def test_it_is_not_gated_on_success(self) -> None:
+        condition = _step("deploy", REPORT_STEP_NAME)["if"]
+        assert "success()" not in condition
+
+    def test_it_handles_the_deploy_step_never_having_run(self) -> None:
+        """An earlier failure leaves ``SAM_DEPLOY_EXIT_CODE`` unset. Passing an
+        empty string to ``--exit-code`` would traceback in argparse."""
+        run = _step("deploy", REPORT_STEP_NAME)["run"]
+        assert "--not-run" in run
+        assert "SAM_DEPLOY_EXIT_CODE:-" in run
+
+    def test_it_comes_after_the_deploy_step(self) -> None:
+        names = [s.get("name") for s in _steps("deploy")]
+        assert names.index(REPORT_STEP_NAME) > names.index(DEPLOY_STEP_NAME)
+
+    def test_the_renderer_path_resolves_from_the_steps_working_directory(self) -> None:
+        """``SAM deploy`` runs in ``infra/ephemeral-rebuild``. If the report
+        step inherited that, the relative script path would not resolve and the
+        summary would be a ``can't open file`` traceback."""
+        step = _step("deploy", REPORT_STEP_NAME)
+        cwd = REPO_ROOT / step.get("working-directory", ".")
+        assert (cwd / "scripts" / "sam_deploy_summary.py").is_file()
+
+
+class TestTheRendererNeedsNoInstall:
+    """The ``deploy`` job has no ``pip install`` step, by design -- it deploys,
+    it does not test. Everything the report step imports has to be stdlib or
+    repo-local."""
+
+    def _top_level_imports(self) -> set[str]:
+        tree = ast.parse(RENDERER_PATH.read_text())
+        modules: set[str] = set()
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                modules.update(alias.name.split(".")[0] for alias in node.names)
+            elif isinstance(node, ast.ImportFrom) and node.level == 0 and node.module:
+                modules.add(node.module.split(".")[0])
+        return modules
+
+    def test_no_third_party_imports(self) -> None:
+        third_party = self._top_level_imports() - sys.stdlib_module_names - {"lib"}
+        assert not third_party, f"report step would need a pip install for: {sorted(third_party)}"
+
+    def test_the_deploy_job_still_has_no_pip_install(self) -> None:
+        """If one is ever added, the import rule above stops being load-bearing
+        and this test should be the thing that prompts revisiting it."""
+        assert not any("pip install" in (s.get("run") or "") for s in _steps("deploy"))
+
+
+class TestTheValidateGate:
+    """``validate`` is a ``needs:`` gate on ``deploy``, and its pytest
+    invocation is an explicit file list rather than a directory, so a new test
+    file is silently ungated until it is added here."""
+
+    def _pytest_run(self) -> str:
+        return _step("validate", "pytest (stack unit tests)")["run"]
+
+    @pytest.mark.parametrize(
+        "test_file",
+        [
+            "tests/unit/test_sam_deploy_summary.py",
+            "tests/unit/test_deploy_ephemeral_rebuild_workflow.py",
+        ],
+    )
+    def test_the_new_tests_gate_the_deploy(self, test_file: str) -> None:
+        assert test_file in self._pytest_run()
+
+    def test_every_file_in_the_list_exists(self) -> None:
+        """A typo'd path makes pytest exit 4 -- which fails the gate loudly --
+        but a *renamed* file that nobody updated here silently stops gating."""
+        for token in self._pytest_run().split():
+            if token.startswith("tests/"):
+                assert (REPO_ROOT / token).is_file(), f"{token} is listed but does not exist"

--- a/tests/unit/test_fffd_capture_summary.py
+++ b/tests/unit/test_fffd_capture_summary.py
@@ -123,7 +123,7 @@ class TestExitTaxonomy:
 
     @pytest.mark.parametrize("code", [0, 2, 3, 4, 137])
     def test_every_code_renders_a_heading_and_a_lead(self, code) -> None:
-        out = fcs.render(code, None, "no report path was given")
+        out = fcs.render(code, None, "no capture report path was given")
         assert out.startswith("## ")
         assert len(out.strip().splitlines()) >= 3
 
@@ -140,18 +140,18 @@ class TestCaptureNeverRan:
     """
 
     def test_not_run_is_its_own_outcome(self) -> None:
-        out = fcs.render(fcs.NOT_RUN, None, "no report path was given")
+        out = fcs.render(fcs.NOT_RUN, None, "no capture report path was given")
         assert "not run" in out.lower() or "did not run" in out.lower()
 
     def test_not_run_does_not_send_the_reader_hunting_stdout(self) -> None:
-        out = fcs.render(fcs.NOT_RUN, None, "no report path was given")
+        out = fcs.render(fcs.NOT_RUN, None, "no capture report path was given")
         assert "stdout" not in out.lower()
 
     def test_not_run_says_why_it_was_skipped(self) -> None:
         """The reason is always the same one, and it is already on screen in
         the parity block: the harness did not complete, so there was no
         library.db to pair against."""
-        out = fcs.render(fcs.NOT_RUN, None, "no report path was given").lower()
+        out = fcs.render(fcs.NOT_RUN, None, "no capture report path was given").lower()
         assert "parity" in out
 
     def test_not_run_does_not_complain_about_a_report_it_never_expected(self) -> None:
@@ -159,11 +159,11 @@ class TestCaptureNeverRan:
         because for them it should have been there. Here nothing was ever
         going to write one, so the line is noise on top of a lead that
         already says so."""
-        out = fcs.render(fcs.NOT_RUN, None, "no report path was given")
+        out = fcs.render(fcs.NOT_RUN, None, "no capture report path was given")
         assert "No report to summarise" not in out
 
     def test_not_run_does_not_claim_an_artifact_that_does_not_exist(self) -> None:
-        out = fcs.render(fcs.NOT_RUN, None, "no report path was given")
+        out = fcs.render(fcs.NOT_RUN, None, "no capture report path was given")
         assert "attached to this run as an artifact" not in out
 
     def test_not_run_is_a_notice_not_an_error(self) -> None:

--- a/tests/unit/test_fffd_capture_summary.py
+++ b/tests/unit/test_fffd_capture_summary.py
@@ -34,6 +34,12 @@ import pytest
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SCRIPT_PATH = REPO_ROOT / "scripts" / "fffd_capture_summary.py"
 
+# What `load_payload` reports when the workflow passed no --json at all. Fed to
+# render() rather than asserted on, but it has to stay the string the shared
+# loader actually produces -- it was "no report path was given" until the
+# load_text split (#396) made the noun part of it.
+NO_REPORT_PATH = "no capture report path was given"
+
 
 def _load_module():
     spec = importlib.util.spec_from_file_location("fffd_capture_summary", SCRIPT_PATH)
@@ -123,7 +129,7 @@ class TestExitTaxonomy:
 
     @pytest.mark.parametrize("code", [0, 2, 3, 4, 137])
     def test_every_code_renders_a_heading_and_a_lead(self, code) -> None:
-        out = fcs.render(code, None, "no capture report path was given")
+        out = fcs.render(code, None, NO_REPORT_PATH)
         assert out.startswith("## ")
         assert len(out.strip().splitlines()) >= 3
 
@@ -140,18 +146,18 @@ class TestCaptureNeverRan:
     """
 
     def test_not_run_is_its_own_outcome(self) -> None:
-        out = fcs.render(fcs.NOT_RUN, None, "no capture report path was given")
+        out = fcs.render(fcs.NOT_RUN, None, NO_REPORT_PATH)
         assert "not run" in out.lower() or "did not run" in out.lower()
 
     def test_not_run_does_not_send_the_reader_hunting_stdout(self) -> None:
-        out = fcs.render(fcs.NOT_RUN, None, "no capture report path was given")
+        out = fcs.render(fcs.NOT_RUN, None, NO_REPORT_PATH)
         assert "stdout" not in out.lower()
 
     def test_not_run_says_why_it_was_skipped(self) -> None:
         """The reason is always the same one, and it is already on screen in
         the parity block: the harness did not complete, so there was no
         library.db to pair against."""
-        out = fcs.render(fcs.NOT_RUN, None, "no capture report path was given").lower()
+        out = fcs.render(fcs.NOT_RUN, None, NO_REPORT_PATH).lower()
         assert "parity" in out
 
     def test_not_run_does_not_complain_about_a_report_it_never_expected(self) -> None:
@@ -159,11 +165,11 @@ class TestCaptureNeverRan:
         because for them it should have been there. Here nothing was ever
         going to write one, so the line is noise on top of a lead that
         already says so."""
-        out = fcs.render(fcs.NOT_RUN, None, "no capture report path was given")
+        out = fcs.render(fcs.NOT_RUN, None, NO_REPORT_PATH)
         assert "No report to summarise" not in out
 
     def test_not_run_does_not_claim_an_artifact_that_does_not_exist(self) -> None:
-        out = fcs.render(fcs.NOT_RUN, None, "no capture report path was given")
+        out = fcs.render(fcs.NOT_RUN, None, NO_REPORT_PATH)
         assert "attached to this run as an artifact" not in out
 
     def test_not_run_is_a_notice_not_an_error(self) -> None:

--- a/tests/unit/test_run_summary_shared.py
+++ b/tests/unit/test_run_summary_shared.py
@@ -1,4 +1,4 @@
-"""Unit tests for ``lib/run_summary.py`` -- the plumbing both run-summary
+"""Unit tests for ``lib/run_summary.py`` -- the plumbing the run-summary
 renderers share (discogs-etl#384).
 
 ``parity_run_summary.py`` (#378) and ``fffd_capture_summary.py`` (#382) render
@@ -10,9 +10,15 @@ runs, so both face the same degraded inputs -- zero-byte on exits 2 and 3,
 truncated on a crash mid-write -- and both run in the step whose job is to
 explain other failures, so neither may traceback.
 
-Kept in two copies, a hardening fix to one would silently not reach the other.
-These tests pin the shared loader's contract and that both renderers actually
-route through it.
+``sam_deploy_summary.py`` (#396) is the third, and the one that split the
+reader in two: its producer is ``sam deploy`` and its output is a captured
+console log, so it binds :func:`load_text` where the other two bind
+:func:`load_payload`. The degraded population is identical, which is why the
+JSON path now sits on top of the text path rather than beside it.
+
+Kept in separate copies, a hardening fix to one would silently not reach the
+others. These tests pin the shared loader's contract and that the renderers
+actually route through it.
 """
 
 from __future__ import annotations
@@ -26,7 +32,7 @@ import pytest
 REPO_ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(REPO_ROOT))
 
-from lib.run_summary import load_payload, plain  # noqa: E402
+from lib.run_summary import load_payload, load_text, plain  # noqa: E402
 
 
 def _load(name: str):
@@ -49,7 +55,7 @@ class TestLoadPayload:
     def test_no_path_is_a_problem_not_an_exception(self) -> None:
         payload, problem = load_payload(None, noun="parity report")
         assert payload is None
-        assert problem == "no report path was given"
+        assert problem == "no parity report path was given"
 
     def test_absent_file(self, tmp_path) -> None:
         payload, problem = load_payload(str(tmp_path / "gone.json"), noun="capture report")
@@ -94,6 +100,54 @@ class TestLoadPayload:
         payload, problem = load_payload(str(path), noun="capture report")
         assert payload is None
         assert problem
+
+
+class TestLoadText:
+    """``load_payload``'s reader, reachable on its own for the producer whose
+    output is a console log rather than JSON (#396's ``sam deploy`` capture)."""
+
+    def test_contents_come_back_stripped(self, tmp_path) -> None:
+        path = tmp_path / "sam-deploy.log"
+        path.write_text("\nNo changes to deploy. Stack wxyc-discogs-rebuild is up to date\n\n")
+        text, problem = load_text(str(path), noun="deploy log")
+        assert text == "No changes to deploy. Stack wxyc-discogs-rebuild is up to date"
+        assert problem is None
+
+    def test_no_path_names_the_noun(self, tmp_path) -> None:
+        _, problem = load_text(None, noun="deploy log")
+        assert problem == "no deploy log path was given"
+
+    @pytest.mark.parametrize(
+        ("write", "expected"),
+        [
+            (None, "never written"),
+            ("", "empty"),
+            ("   \n\t\n", "empty"),
+        ],
+    )
+    def test_degraded_files_are_problems_not_exceptions(self, tmp_path, write, expected) -> None:
+        path = tmp_path / "sam-deploy.log"
+        if write is not None:
+            path.write_text(write)
+        text, problem = load_text(str(path), noun="deploy log")
+        assert text is None
+        assert problem and expected in problem
+
+    def test_undecodable_bytes_do_not_traceback(self, tmp_path) -> None:
+        path = tmp_path / "sam-deploy.log"
+        path.write_bytes(b"Successfully created/updated stack - Csillagrabl\xc3")
+        text, problem = load_text(str(path), noun="deploy log")
+        assert text is None
+        assert problem and "UTF-8" in problem
+
+    def test_load_payload_reports_the_same_problems(self, tmp_path) -> None:
+        """The refactor's contract: JSON parsing sits on top of this, it does
+        not re-implement the read."""
+        absent = str(tmp_path / "gone.json")
+        assert (
+            load_payload(absent, noun="parity report")[1]
+            == (load_text(absent, noun="parity report")[1])
+        )
 
 
 class TestPlain:

--- a/tests/unit/test_run_summary_shared.py
+++ b/tests/unit/test_run_summary_shared.py
@@ -158,20 +158,35 @@ class TestPlain:
         assert plain("Csillagrablók, Bête, µ-Ziq") == "Csillagrablók, Bête, µ-Ziq"
 
 
-class TestBothRenderersUseIt:
+class TestEveryRendererUsesIt:
     """The point of the module. A renderer that kept its own copy would drift
-    the moment either was hardened.
+    the moment any of them was hardened.
 
-    Asserted behaviourally rather than by identity: the two bind the loader to
-    their own noun, so ``is`` comparisons would pin the binding mechanism
-    instead of the thing that matters. A forked copy that gained its own
-    handling shows up here as a divergent result.
+    Asserted behaviourally rather than by identity: each binds the loader to
+    its own noun, so ``is`` comparisons would pin the binding mechanism instead
+    of the thing that matters. A forked copy that gained its own handling shows
+    up here as a divergent result.
+
+    ``sam_deploy_summary`` binds :func:`load_text` where the other two bind
+    :func:`load_payload`, so the sweep is keyed by which reader each exposes --
+    the alternative, a private two-test class in that module's own file, is how
+    the third renderer would end up untested by the file whose stated job is to
+    test all of them.
     """
 
-    RENDERERS = ("parity_run_summary", "fffd_capture_summary")
+    # module name -> the loader attribute it exposes
+    RENDERERS = {
+        "parity_run_summary": "load_payload",
+        "fffd_capture_summary": "load_payload",
+        "sam_deploy_summary": "load_log",
+    }
 
-    def _degraded(self, tmp_path: Path) -> list[str]:
-        absent = tmp_path / "gone.json"
+    def _degraded(self, tmp_path: Path) -> dict[str, str]:
+        """Paths every reader must reject, keyed by how they are degraded.
+
+        ``truncated`` and ``not_object`` are degraded *as JSON only* -- both are
+        perfectly good text -- so the text binder is not asked about them.
+        """
         empty = tmp_path / "empty.json"
         empty.write_text("")
         truncated = tmp_path / "truncated.json"
@@ -180,35 +195,74 @@ class TestBothRenderersUseIt:
         not_object.write_text("[]")
         undecodable = tmp_path / "undecodable.json"
         undecodable.write_bytes(b'{"x": "Csillagrabl\xc3')
-        return [str(p) for p in (absent, empty, truncated, not_object, undecodable)]
+        return {
+            "absent": str(tmp_path / "gone.json"),
+            "empty": str(empty),
+            "truncated": str(truncated),
+            "not_object": str(not_object),
+            "undecodable": str(undecodable),
+        }
 
-    def test_no_renderer_tracebacks_on_any_degraded_report(self, tmp_path) -> None:
-        for name in self.RENDERERS:
-            mod = _load(name)
-            for path in self._degraded(tmp_path):
-                payload, problem = mod.load_payload(path)
-                assert payload is None
-                assert problem, f"{name} gave no problem string for {path}"
+    # Degraded as text, not merely as JSON -- the subset every reader owns.
+    TEXT_DEGRADED = ("absent", "empty", "undecodable")
+
+    def _reader(self, name: str):
+        mod = _load(name)
+        return getattr(mod, self.RENDERERS[name])
+
+    def _applicable(self, name: str) -> tuple[str, ...]:
+        json_binder = self.RENDERERS[name] == "load_payload"
+        return tuple(self._degraded_keys) if json_binder else self.TEXT_DEGRADED
+
+    _degraded_keys = ("absent", "empty", "truncated", "not_object", "undecodable")
+
+    @pytest.mark.parametrize("name", RENDERERS)
+    def test_no_renderer_tracebacks_on_any_degraded_report(self, tmp_path, name) -> None:
+        read = self._reader(name)
+        paths = self._degraded(tmp_path)
+        for key in self._applicable(name):
+            value, problem = read(paths[key])
+            assert value is None, f"{name} accepted a {key} report"
+            assert problem, f"{name} gave no problem string for a {key} report"
 
     def test_the_noun_free_problem_strings_are_identical(self, tmp_path) -> None:
-        """An absent, truncated, or undecodable file reads the same whichever
-        producer wrote it -- so these messages must not have been forked."""
+        """An absent or undecodable file reads the same whichever producer
+        wrote it -- so these messages must not have been forked."""
         paths = self._degraded(tmp_path)
-        noun_free = [paths[0], paths[2], paths[4]]
-        mods = [_load(name) for name in self.RENDERERS]
-        for path in noun_free:
-            problems = {mod.load_payload(path)[1] for mod in mods}
-            assert len(problems) == 1, f"renderers disagree on {path}: {problems}"
+        readers = [self._reader(name) for name in self.RENDERERS]
+        for key in ("absent", "undecodable"):
+            problems = {read(paths[key])[1] for read in readers}
+            assert len(problems) == 1, f"renderers disagree on a {key} report: {problems}"
 
     def test_each_renderer_names_its_own_producer_where_it_matters(self, tmp_path) -> None:
         """The one place they *should* differ: an empty file says which kind
-        of report was never produced."""
-        empty = self._degraded(tmp_path)[1]
-        parity, capture = (_load(name) for name in self.RENDERERS)
-        assert "parity report" in parity.load_payload(empty)[1]
-        assert "capture report" in capture.load_payload(empty)[1]
+        of output was never produced."""
+        empty = self._degraded(tmp_path)["empty"]
+        expected = {
+            "parity_run_summary": "parity report",
+            "fffd_capture_summary": "capture report",
+            "sam_deploy_summary": "deploy log",
+        }
+        for name, noun in expected.items():
+            assert noun in self._reader(name)(empty)[1]
 
     @pytest.mark.parametrize("name", RENDERERS)
     def test_renderer_annotations_are_plain_text(self, name) -> None:
+        """Behaviourally, not ``mod._plain is plain``.
+
+        The identity form is what let the invariant rot: it asserted that the
+        symbol had been *imported*, which stayed true while
+        ``parity_run_summary`` formatted its annotation without calling it.
+        Every stored body is checked through the module's own ``annotation``.
+        """
         mod = _load(name)
-        assert mod._plain is plain
+        for record in mod._OUTCOMES.values():
+            assert "`" not in plain(record.annotation_body)
+            assert "**" not in plain(record.annotation_body)
+
+    @pytest.mark.parametrize("name", RENDERERS)
+    def test_no_renderer_formats_its_own_annotation_line(self, name) -> None:
+        """The format string is ``lib.run_summary.annotation_line``'s. Three
+        copies is how the plain-text half of the contract drifted."""
+        source = (REPO_ROOT / "scripts" / f"{name}.py").read_text()
+        assert "::{" not in source, f"{name} builds an annotation line itself"

--- a/tests/unit/test_sam_deploy_summary.py
+++ b/tests/unit/test_sam_deploy_summary.py
@@ -1,0 +1,392 @@
+"""Unit tests for ``scripts/sam_deploy_summary.py`` (discogs-etl#396).
+
+``deploy-ephemeral-rebuild.yml`` runs ``sam deploy --no-fail-on-empty-changeset``.
+That flag is correct and has to stay -- three of the workflow's four triggers
+produce no template diff at all (``scripts/rebuild-cache-bootstrap.sh`` is
+curled by the instance at runtime and is not part of the rendered template;
+the workflow file itself is not either; a ``workflow_dispatch`` re-run of an
+already-deployed ``main`` is a no-op by construction) -- but it means SAM exits
+0 whether it applied a changeset or found nothing to do. **Those two outcomes
+were indistinguishable in the run's output**, and for months the workflow's
+green history was the second one while the deploy role silently lacked
+``ec2:DescribeImages`` and could not have applied anything:
+
+    run 31970903384   "No changes to deploy. Stack ... is up to date"   exit 0  green
+    run 31970987037   AccessDenied ec2:DescribeImages, UPDATE_ROLLBACK  exit 1  red
+
+Two minutes apart. Only the second one carried information, and only because
+#358 happened to be the first real changeset in months. This renderer is the
+fix for the first line, not the second: a no-op must announce itself.
+
+The classification is deliberately narrow. **The exit code alone decides
+failure** -- never prose. For exit 0 there are exactly two accepted top-level
+SAM strings, one per outcome, and *anything else is a failure to classify*,
+which is red. That direction is the whole point: the defect being fixed is a
+silent fall-through to "looks fine", so the ambiguous case must be loud.
+
+Nothing here parses SAM's CloudFormation events table. Its columns are
+fixed-width and wrap mid-token -- the real rollback log above contains
+``UPDATE_ROLLBACK_COMPLE`` / ``TE`` on two lines, and the successful one
+contains ``UPDATE_COMPLETE_CLEANU`` -- so substring matches against resource
+statuses are a coin flip on column width. The fixtures below keep that
+wrapping verbatim so a future "just also check for UPDATE_COMPLETE" has a test
+that shows why not.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "sam_deploy_summary.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("sam_deploy_summary", SCRIPT_PATH)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    # Registered before exec_module: the module defines a dataclass whose field
+    # annotations are strings under `from __future__ import annotations`, and
+    # dataclasses resolves them through sys.modules[cls.__module__].
+    sys.modules["sam_deploy_summary"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+sds = _load_module()
+
+
+# Verbatim from run 31970903384 (2026-08-16 13:34 PT) -- the no-op that passed
+# two minutes before the real changeset failed. This single line is the entire
+# output SAM produces for this case.
+NO_CHANGES_LOG = """\
+\tDeploying with following values
+\t===============================
+\tStack name                   : wxyc-discogs-rebuild
+\tRegion                       : us-east-1
+\tDisable rollback             : False
+
+Initiating deployment
+=====================
+
+
+Waiting for changeset to be created..
+
+No changes to deploy. Stack wxyc-discogs-rebuild is up to date
+"""
+
+# Verbatim from run 31975090212 (2026-08-16 15:01 PT) -- the first changeset
+# this stack applied in months, once the deploy role had ec2:DescribeImages.
+# Note `UPDATE_COMPLETE_CLEANU`: SAM wraps the status column at 22 characters.
+APPLIED_LOG = """\
+Waiting for changeset to be created..
+
+CloudFormation stack changeset
+-------------------------------------------------------------------------------------------------
+Operation                LogicalResourceId        ResourceType             Replacement
+-------------------------------------------------------------------------------------------------
++ Add                    ReleaseCountAlarm        AWS::CloudWatch::Alarm   N/A
+-------------------------------------------------------------------------------------------------
+
+
+Changeset created successfully. arn:aws:cloudformation:us-east-1:203767826763:changeSet/samcli-deploy1786917657/fdc0097a-2be8-43d8-b16f-bcd35081f417
+
+
+2026-08-16 22:01:08 - Waiting for stack create/update to complete
+
+CloudFormation events from stack operations (refresh every 5.0 seconds)
+-------------------------------------------------------------------------------------------------
+ResourceStatus           ResourceType             LogicalResourceId        ResourceStatusReason
+-------------------------------------------------------------------------------------------------
+CREATE_IN_PROGRESS       AWS::CloudWatch::Alarm   ReleaseCountAlarm        -
+CREATE_COMPLETE          AWS::CloudWatch::Alarm   ReleaseCountAlarm        -
+UPDATE_COMPLETE_CLEANU   AWS::CloudFormation::S   wxyc-discogs-rebuild     -
+P_IN_PROGRESS            tack
+UPDATE_COMPLETE          AWS::CloudFormation::S   wxyc-discogs-rebuild     -
+                         tack
+-------------------------------------------------------------------------------------------------
+
+Successfully created/updated stack - wxyc-discogs-rebuild in us-east-1
+"""
+
+# Verbatim from run 31970987037 -- #396 itself. The AccessDenied reason and the
+# terminal status are both wrapped across lines by SAM's column widths; the
+# untruncated `UPDATE_ROLLBACK_COMPLETE` survives only in the final Error line.
+ROLLBACK_LOG = """\
+Changeset created successfully. arn:aws:cloudformation:us-east-1:203767826763:changeSet/samcli-deploy1786912571/a565f05a-fa28-4847-8eca-b0f415c9d612
+
+
+2026-08-16 20:36:22 - Waiting for stack create/update to complete
+
+CloudFormation events from stack operations (refresh every 5.0 seconds)
+-------------------------------------------------------------------------------------------------
+ResourceStatus           ResourceType             LogicalResourceId        ResourceStatusReason
+-------------------------------------------------------------------------------------------------
+UPDATE_IN_PROGRESS       AWS::CloudFormation::S   wxyc-discogs-rebuild     User Initiated
+                         tack
+UPDATE_ROLLBACK_IN_PRO   AWS::CloudFormation::S   wxyc-discogs-rebuild     AccessDenied. User
+GRESS                    tack                                              doesn't have
+                                                                           permission to call
+                                                                           ec2:DescribeImages
+UPDATE_ROLLBACK_COMPLE   AWS::CloudFormation::S   wxyc-discogs-rebuild     -
+TE_CLEANUP_IN_PROGRESS   tack
+UPDATE_ROLLBACK_COMPLE   AWS::CloudFormation::S   wxyc-discogs-rebuild     -
+TE                       tack
+-------------------------------------------------------------------------------------------------
+
+Error: Failed to create/update the stack: wxyc-discogs-rebuild, Waiter StackUpdateComplete failed: Waiter encountered a terminal failure state: For expression "Stacks[].StackStatus" we matched expected path: "UPDATE_ROLLBACK_COMPLETE" at least once
+"""
+
+
+class TestClassify:
+    """The exit code decides failure; for exit 0 the two SAM strings decide."""
+
+    def test_the_real_no_op_log_is_no_changes(self) -> None:
+        assert sds.classify(0, NO_CHANGES_LOG) == sds.NO_CHANGES
+
+    def test_the_real_applied_log_is_applied(self) -> None:
+        assert sds.classify(0, APPLIED_LOG) == sds.APPLIED
+
+    def test_the_real_rollback_log_is_failed(self) -> None:
+        assert sds.classify(1, ROLLBACK_LOG) == sds.FAILED
+
+    @pytest.mark.parametrize("code", [1, 2, 137, 255])
+    def test_any_non_zero_exit_is_failed_whatever_the_log_says(self, code: int) -> None:
+        """Prose never overrides the exit code. A log that got as far as
+        'Successfully created/updated stack' and *then* had the step killed is
+        not a successful deploy."""
+        assert sds.classify(code, APPLIED_LOG) == sds.FAILED
+        assert sds.classify(code, NO_CHANGES_LOG) == sds.FAILED
+
+    def test_exit_zero_with_neither_marker_is_unclassifiable(self) -> None:
+        """Fail closed. If SAM's wording changes, the run must go red rather
+        than quietly inheriting the 'looks fine' reading that #396 was."""
+        assert sds.classify(0, "Deploying with following values\nRegion: us-east-1\n")
+        assert sds.classify(0, "Deploying with following values\n") == sds.UNCLASSIFIABLE
+
+    def test_exit_zero_with_both_markers_is_unclassifiable(self) -> None:
+        assert sds.classify(0, NO_CHANGES_LOG + APPLIED_LOG) == sds.UNCLASSIFIABLE
+
+    def test_an_unreadable_log_at_exit_zero_is_unclassifiable(self) -> None:
+        """An exit-0 deploy whose output was lost cannot be called applied."""
+        assert sds.classify(0, None) == sds.UNCLASSIFIABLE
+
+    def test_an_unreadable_log_at_a_failing_exit_is_still_failed(self) -> None:
+        """The exit code is sufficient on its own for this one."""
+        assert sds.classify(1, None) == sds.FAILED
+
+    def test_no_exit_code_at_all_is_not_run(self) -> None:
+        """The deploy step never reached SAM -- an earlier step failed."""
+        assert sds.classify(None, None) == sds.NOT_RUN
+
+    def test_the_events_table_is_not_a_marker(self) -> None:
+        """SAM wraps the status column at 22 characters, so resource statuses
+        are not reliably present as whole tokens. A log carrying the events
+        table but *not* the terminal SAM line must not read as applied."""
+        events_only = APPLIED_LOG.replace(
+            "Successfully created/updated stack - wxyc-discogs-rebuild in us-east-1", ""
+        )
+        assert "UPDATE_COMPLETE" in events_only  # the tempting marker is right there
+        assert sds.classify(0, events_only) == sds.UNCLASSIFIABLE
+
+    def test_a_changeset_that_was_only_created_is_not_applied(self) -> None:
+        """'Changeset created successfully' precedes the apply; the rollback
+        log contains it too. Matching on it would call #396 a success."""
+        assert "Changeset created successfully" in ROLLBACK_LOG
+        created_only = ROLLBACK_LOG.split("Error:")[0]
+        assert sds.classify(0, created_only) == sds.UNCLASSIFIABLE
+
+
+class TestExitCodes:
+    """What the report step returns, and therefore what the job's status is."""
+
+    def _run(self, tmp_path, code, log_text, extra=()):
+        argv = []
+        if code is not None:
+            argv += ["--exit-code", str(code)]
+        else:
+            argv += ["--not-run"]
+        if log_text is not None:
+            path = tmp_path / "sam-deploy.log"
+            path.write_text(log_text)
+            argv += ["--log", str(path)]
+        return sds.main([*argv, *extra])
+
+    def test_applied_is_green(self, tmp_path) -> None:
+        assert self._run(tmp_path, 0, APPLIED_LOG) == 0
+
+    def test_a_no_op_is_green(self, tmp_path) -> None:
+        """A no-op is a legitimate outcome of three of the four triggers. It
+        has to be visible, not red -- reddening it would make `main` carry a
+        permanent failing check for every bootstrap-script edit."""
+        assert self._run(tmp_path, 0, NO_CHANGES_LOG) == 0
+
+    def test_a_failed_deploy_re_raises_sams_own_code(self, tmp_path) -> None:
+        assert self._run(tmp_path, 1, ROLLBACK_LOG) == 1
+        assert self._run(tmp_path, 137, ROLLBACK_LOG) == 137
+
+    def test_unclassifiable_is_red_with_its_own_code(self, tmp_path) -> None:
+        code = self._run(tmp_path, 0, "Deploying with following values\n")
+        assert code == sds.UNCLASSIFIABLE_EXIT
+        assert code != 0
+
+    def test_the_unclassifiable_code_cannot_be_confused_with_sams(self, tmp_path) -> None:
+        """SAM exits 1 (and the runner 137/143 on a kill). 65 is EX_DATAERR and
+        is not in either population, so the bare number is diagnostic."""
+        assert sds.UNCLASSIFIABLE_EXIT == 65
+
+    def test_not_run_is_red(self, tmp_path) -> None:
+        """The deploy step never produced a status. Nothing was deployed and
+        nothing explains why -- that is not a green outcome."""
+        assert self._run(tmp_path, None, None) != 0
+
+
+class TestTheNoOpIsUnmistakable:
+    """The acceptance criterion, stated as tests.
+
+    Someone scanning a green run must be able to tell, without opening the log,
+    that nothing reached AWS.
+    """
+
+    def test_the_summary_heading_says_nothing_was_deployed(self) -> None:
+        out = sds.render(sds.NO_CHANGES, 0, NO_CHANGES_LOG, None)
+        heading = out.splitlines()[0]
+        assert heading.startswith("#")
+        assert "nothing" in heading.lower() or "no changes" in heading.lower()
+
+    def test_the_no_op_annotation_is_a_warning_not_a_notice(self) -> None:
+        """Green-with-a-warning is the shape this outcome needs: it must not
+        fail the job, and it must not be as quiet as the success case."""
+        assert sds.annotation(sds.NO_CHANGES, 0, NO_CHANGES_LOG).startswith("::warning ")
+
+    def test_the_applied_annotation_is_a_notice(self) -> None:
+        assert sds.annotation(sds.APPLIED, 0, APPLIED_LOG).startswith("::notice ")
+
+    @pytest.mark.parametrize("outcome", ["FAILED", "UNCLASSIFIABLE", "NOT_RUN"])
+    def test_the_red_outcomes_annotate_as_errors(self, outcome: str) -> None:
+        value = getattr(sds, outcome)
+        assert sds.annotation(value, 1, ROLLBACK_LOG).startswith("::error ")
+
+    def test_the_two_green_outcomes_do_not_share_a_heading(self) -> None:
+        applied = sds.render(sds.APPLIED, 0, APPLIED_LOG, None).splitlines()[0]
+        no_changes = sds.render(sds.NO_CHANGES, 0, NO_CHANGES_LOG, None).splitlines()[0]
+        assert applied != no_changes
+
+    def test_the_no_op_summary_names_the_benign_causes(self) -> None:
+        """Left unexplained, a warning on every bootstrap-script edit becomes
+        noise that gets muted -- which is how the signal was lost the first
+        time. The summary has to say when a no-op is expected."""
+        out = sds.render(sds.NO_CHANGES, 0, NO_CHANGES_LOG, None)
+        assert "rebuild-cache-bootstrap.sh" in out
+        assert "workflow_dispatch" in out or "dispatch" in out
+
+    def test_the_no_op_summary_says_what_would_make_it_suspicious(self) -> None:
+        out = sds.render(sds.NO_CHANGES, 0, NO_CHANGES_LOG, None)
+        assert "template.yaml" in out
+
+    @pytest.mark.parametrize(
+        "outcome",
+        ["APPLIED", "NO_CHANGES", "FAILED", "UNCLASSIFIABLE", "NOT_RUN"],
+    )
+    def test_every_annotation_is_exactly_one_line(self, outcome: str) -> None:
+        """GitHub truncates an annotation at its first newline."""
+        line = sds.annotation(getattr(sds, outcome), 1, ROLLBACK_LOG)
+        assert "\n" not in line
+
+
+class TestFailureDiagnosis:
+    """#396 took hours to root-cause. The next one should take one look."""
+
+    def test_an_access_denied_failure_names_the_deploy_role_template(self) -> None:
+        out = sds.render(sds.FAILED, 1, ROLLBACK_LOG, None)
+        assert "infra/bootstrap/deploy-role.yaml" in out
+
+    def test_an_access_denied_failure_points_at_the_simulator(self) -> None:
+        out = sds.render(sds.FAILED, 1, ROLLBACK_LOG, None)
+        assert "simulate-deploy-role.sh" in out
+
+    def test_an_access_denied_failure_surfaces_the_denied_action(self) -> None:
+        out = sds.render(sds.FAILED, 1, ROLLBACK_LOG, None)
+        assert "ec2:DescribeImages" in out
+
+    def test_a_rollback_says_the_template_and_the_stack_have_diverged(self) -> None:
+        """The state #396 left behind: `main` declared ReleaseCountAlarm and
+        the deployed stack did not. Nothing else reports that."""
+        out = sds.render(sds.FAILED, 1, ROLLBACK_LOG, None).lower()
+        assert "rolled back" in out or "rollback" in out
+        assert "diverge" in out
+
+    def test_a_failure_without_access_denied_does_not_blame_iam(self) -> None:
+        plain_failure = "Error: Failed to create/update the stack: wxyc-discogs-rebuild\n"
+        out = sds.render(sds.FAILED, 1, plain_failure, None)
+        assert "deploy-role.yaml" not in out
+
+    def test_the_denied_action_survives_sams_column_wrapping(self) -> None:
+        """`AccessDenied. User doesn't have permission to call` is split across
+        four lines in the real log; only `ec2:DescribeImages` sits whole on one
+        of them. Matching the sentence would have found nothing."""
+        assert "permission to call ec2:DescribeImages" not in ROLLBACK_LOG
+        assert sds.denied_actions(ROLLBACK_LOG) == ["ec2:DescribeImages"]
+
+    def test_denied_actions_ignores_arns_and_resource_types(self) -> None:
+        assert sds.denied_actions(APPLIED_LOG) == []
+
+
+class TestDegradedInput:
+    """This renderer runs in the step whose job is to explain other failures.
+    A traceback here turns one legible failure into two."""
+
+    def test_an_absent_log_does_not_traceback(self, tmp_path) -> None:
+        assert sds.main(["--exit-code", "0", "--log", str(tmp_path / "gone.log")]) != 0
+
+    def test_an_empty_log_does_not_traceback(self, tmp_path) -> None:
+        path = tmp_path / "sam-deploy.log"
+        path.write_text("")
+        assert sds.main(["--exit-code", "0", "--log", str(path)]) == sds.UNCLASSIFIABLE_EXIT
+
+    def test_an_empty_log_on_a_failing_exit_still_reports_the_failure(self, tmp_path) -> None:
+        path = tmp_path / "sam-deploy.log"
+        path.write_text("")
+        assert sds.main(["--exit-code", "1", "--log", str(path)]) == 1
+
+    def test_undecodable_bytes_do_not_traceback(self, tmp_path) -> None:
+        path = tmp_path / "sam-deploy.log"
+        path.write_bytes(b"No changes to deploy. Stack Csillagrabl\xc3")
+        assert sds.main(["--exit-code", "0", "--log", str(path)]) != 0
+
+    def test_no_log_argument_at_all_does_not_traceback(self) -> None:
+        assert sds.main(["--exit-code", "1"]) == 1
+
+    def test_the_problem_is_stated_in_the_summary(self, tmp_path, capsys) -> None:
+        sds.main(["--exit-code", "0", "--log", str(tmp_path / "gone.log")])
+        out = capsys.readouterr().out
+        assert "sam-deploy" in out or "never written" in out
+
+    def test_stdout_is_markdown_and_stderr_is_one_annotation(self, tmp_path, capsys) -> None:
+        path = tmp_path / "sam-deploy.log"
+        path.write_text(NO_CHANGES_LOG)
+        sds.main(["--exit-code", "0", "--log", str(path)])
+        captured = capsys.readouterr()
+        assert captured.out.startswith("#")
+        assert captured.err.strip().startswith("::warning ")
+        assert len(captured.err.strip().splitlines()) == 1
+
+
+class TestSharedLoader:
+    """The untrusted-file read is `lib/run_summary.py`'s, not a third copy."""
+
+    def test_it_routes_through_the_shared_loader(self) -> None:
+        sys.path.insert(0, str(REPO_ROOT))
+        from lib.run_summary import load_text
+
+        assert sds.load_log.func is load_text  # functools.partial over the shared one
+
+    def test_annotations_are_plain_text(self) -> None:
+        sys.path.insert(0, str(REPO_ROOT))
+        from lib.run_summary import plain
+
+        assert sds._plain is plain

--- a/tests/unit/test_sam_deploy_summary.py
+++ b/tests/unit/test_sam_deploy_summary.py
@@ -165,7 +165,10 @@ class TestClassify:
     def test_exit_zero_with_neither_marker_is_unclassifiable(self) -> None:
         """Fail closed. If SAM's wording changes, the run must go red rather
         than quietly inheriting the 'looks fine' reading that #396 was."""
-        assert sds.classify(0, "Deploying with following values\nRegion: us-east-1\n")
+        assert (
+            sds.classify(0, "Deploying with following values\nRegion: us-east-1\n")
+            == sds.UNCLASSIFIABLE
+        )
         assert sds.classify(0, "Deploying with following values\n") == sds.UNCLASSIFIABLE
 
     def test_exit_zero_with_both_markers_is_unclassifiable(self) -> None:
@@ -298,6 +301,57 @@ class TestTheNoOpIsUnmistakable:
         assert "\n" not in line
 
 
+class TestNoStatusRecorded:
+    """``not_run`` may only claim what it observed.
+
+    The deploy step writes ``SAM_DEPLOY_LOG`` to ``$GITHUB_ENV`` *before*
+    invoking SAM, so a log can exist for a run that recorded no exit code --
+    the step killed between SAM finishing and the status being written. A
+    narrow window, but "nothing was deployed" is an inference from "no status
+    was recorded", and asserting the inference as fact is the shape of the
+    error this whole file exists to prevent.
+    """
+
+    def test_the_outcome_is_still_not_run(self) -> None:
+        """The bucket is right; only what it is allowed to say changed."""
+        assert sds.classify(None, APPLIED_LOG) == sds.NOT_RUN
+        assert sds.classify(None, None) == sds.NOT_RUN
+
+    def test_with_no_log_it_still_says_nothing_was_deployed(self) -> None:
+        out = sds.render(sds.NOT_RUN, None, None, "no deploy log path was given")
+        assert "nothing was deployed" in out.lower()
+
+    def test_a_log_carrying_the_applied_marker_withdraws_that_claim(self) -> None:
+        out = sds.render(sds.NOT_RUN, None, APPLIED_LOG, None)
+        assert sds.APPLIED_MARKER in out
+        assert "cannot tell you whether the deploy completed" in out
+
+    def test_it_tells_the_reader_to_check_the_stack(self) -> None:
+        out = sds.render(sds.NOT_RUN, None, APPLIED_LOG, None)
+        assert "infra/ephemeral-rebuild/template.yaml" in out
+
+    def test_a_log_carrying_the_no_changes_marker_is_treated_the_same(self) -> None:
+        """SAM ran either way; which line it printed does not restore the
+        missing status."""
+        out = sds.render(sds.NOT_RUN, None, NO_CHANGES_LOG, None)
+        assert sds.NO_CHANGES_MARKER in out
+        assert "cannot tell you whether the deploy completed" in out
+
+    def test_a_log_with_neither_marker_corroborates_the_usual_reading(self) -> None:
+        out = sds.render(sds.NOT_RUN, None, "Deploying with following values\n", None)
+        assert "never having been reached" in out
+        assert "cannot tell you whether the deploy completed" not in out
+
+    def test_it_stays_red_either_way(self, tmp_path) -> None:
+        for log in (None, APPLIED_LOG):
+            argv = ["--not-run"]
+            if log is not None:
+                path = tmp_path / "sam-deploy.log"
+                path.write_text(log)
+                argv += ["--log", str(path)]
+            assert sds.main(argv) == sds.UNCLASSIFIABLE_EXIT
+
+
 class TestFailureDiagnosis:
     """#396 took hours to root-cause. The next one should take one look."""
 
@@ -333,7 +387,25 @@ class TestFailureDiagnosis:
         assert sds.denied_actions(ROLLBACK_LOG) == ["ec2:DescribeImages"]
 
     def test_denied_actions_ignores_arns_and_resource_types(self) -> None:
+        """The decoys have to sit in a log that reaches the regex at all --
+        ``denied_actions`` short-circuits on a log with no ``AccessDenied``, so
+        asserting ``[] `` against a clean log passes whatever the regex does."""
+        decoys = (
+            "AccessDenied. User\n"
+            "arn:aws:cloudformation:us-east-1:203767826763:changeSet/samcli-deploy1786912571\n"
+            "AWS::CloudWatch::Alarm   AWS::CloudFormation::Stack   AWS::Serverless::Function\n"
+            "https://github.com/WXYC/discogs-etl   s3://aws-sam-cli-managed-default\n"
+            'For expression "Stacks[].StackStatus" we matched expected path\n'
+            "permission to call ec2:DescribeImages\n"
+        )
+        assert sds.denied_actions(decoys) == ["ec2:DescribeImages"]
+
+    def test_a_log_with_no_access_denied_names_no_actions(self) -> None:
+        """A failure with an unrelated cause must not be reported as a
+        permissions problem, however many colons its output contains."""
         assert sds.denied_actions(APPLIED_LOG) == []
+        assert sds.denied_actions("Error: Failed to create/update the stack: x") == []
+        assert sds.denied_actions(None) == []
 
 
 class TestDegradedInput:

--- a/tests/unit/test_sam_deploy_summary.py
+++ b/tests/unit/test_sam_deploy_summary.py
@@ -1,36 +1,27 @@
 """Unit tests for ``scripts/sam_deploy_summary.py`` (discogs-etl#396).
 
-``deploy-ephemeral-rebuild.yml`` runs ``sam deploy --no-fail-on-empty-changeset``.
-That flag is correct and has to stay -- three of the workflow's four triggers
-produce no template diff at all (``scripts/rebuild-cache-bootstrap.sh`` is
-curled by the instance at runtime and is not part of the rendered template;
-the workflow file itself is not either; a ``workflow_dispatch`` re-run of an
-already-deployed ``main`` is a no-op by construction) -- but it means SAM exits
-0 whether it applied a changeset or found nothing to do. **Those two outcomes
-were indistinguishable in the run's output**, and for months the workflow's
-green history was the second one while the deploy role silently lacked
-``ec2:DescribeImages`` and could not have applied anything:
+Why this renderer exists at all -- the months of green no-op deploys, and why
+``--no-fail-on-empty-changeset`` stays -- is in that script's module docstring
+and in ``infra/ephemeral-rebuild/README.md``. Not restated here: it was already
+drifting across four copies at authoring time, and none of them fails when they
+disagree.
 
-    run 31970903384   "No changes to deploy. Stack ... is up to date"   exit 0  green
-    run 31970987037   AccessDenied ec2:DescribeImages, UPDATE_ROLLBACK  exit 1  red
+What these tests pin is the classification contract:
 
-Two minutes apart. Only the second one carried information, and only because
-#358 happened to be the first real changeset in months. This renderer is the
-fix for the first line, not the second: a no-op must announce itself.
+**The exit code alone decides failure** -- never prose. For exit 0 there are
+exactly two accepted top-level SAM strings, one per outcome, and *anything
+else is a failure to classify*, which is red. That direction is the whole
+point: the defect being fixed is a silent fall-through to "looks fine", so the
+ambiguous case must be loud.
 
-The classification is deliberately narrow. **The exit code alone decides
-failure** -- never prose. For exit 0 there are exactly two accepted top-level
-SAM strings, one per outcome, and *anything else is a failure to classify*,
-which is red. That direction is the whole point: the defect being fixed is a
-silent fall-through to "looks fine", so the ambiguous case must be loud.
-
-Nothing here parses SAM's CloudFormation events table. Its columns are
-fixed-width and wrap mid-token -- the real rollback log above contains
+**Nothing parses SAM's CloudFormation events table.** Its columns are
+fixed-width and wrap mid-token -- the rollback fixture below contains
 ``UPDATE_ROLLBACK_COMPLE`` / ``TE`` on two lines, and the successful one
 contains ``UPDATE_COMPLETE_CLEANU`` -- so substring matches against resource
-statuses are a coin flip on column width. The fixtures below keep that
-wrapping verbatim so a future "just also check for UPDATE_COMPLETE" has a test
-that shows why not.
+statuses are a coin flip on column width. The fixtures are verbatim captures
+and keep that wrapping, so a future "just also check for UPDATE_COMPLETE" has
+a test that shows why not. They are also why the SAM CLI version is pinned in
+the workflow: refreshing them is part of a bump.
 """
 
 from __future__ import annotations
@@ -207,7 +198,7 @@ class TestClassify:
 class TestExitCodes:
     """What the report step returns, and therefore what the job's status is."""
 
-    def _run(self, tmp_path, code, log_text, extra=()):
+    def _run(self, tmp_path, code, log_text):
         argv = []
         if code is not None:
             argv += ["--exit-code", str(code)]
@@ -217,7 +208,7 @@ class TestExitCodes:
             path = tmp_path / "sam-deploy.log"
             path.write_text(log_text)
             argv += ["--log", str(path)]
-        return sds.main([*argv, *extra])
+        return sds.main(argv)
 
     def test_applied_is_green(self, tmp_path) -> None:
         assert self._run(tmp_path, 0, APPLIED_LOG) == 0
@@ -233,11 +224,11 @@ class TestExitCodes:
         assert self._run(tmp_path, 137, ROLLBACK_LOG) == 137
 
     def test_unclassifiable_is_red_with_its_own_code(self, tmp_path) -> None:
-        code = self._run(tmp_path, 0, "Deploying with following values\n")
-        assert code == sds.UNCLASSIFIABLE_EXIT
-        assert code != 0
+        assert self._run(tmp_path, 0, "Deploying with following values\n") == (
+            sds.UNCLASSIFIABLE_EXIT
+        )
 
-    def test_the_unclassifiable_code_cannot_be_confused_with_sams(self, tmp_path) -> None:
+    def test_the_unclassifiable_code_cannot_be_confused_with_sams(self) -> None:
         """SAM exits 1 (and the runner 137/143 on a kill). 65 is EX_DATAERR and
         is not in either population, so the bare number is diagnostic."""
         assert sds.UNCLASSIFIABLE_EXIT == 65
@@ -264,15 +255,14 @@ class TestTheNoOpIsUnmistakable:
     def test_the_no_op_annotation_is_a_warning_not_a_notice(self) -> None:
         """Green-with-a-warning is the shape this outcome needs: it must not
         fail the job, and it must not be as quiet as the success case."""
-        assert sds.annotation(sds.NO_CHANGES, 0, NO_CHANGES_LOG).startswith("::warning ")
+        assert sds.annotation(sds.NO_CHANGES, NO_CHANGES_LOG).startswith("::warning ")
 
     def test_the_applied_annotation_is_a_notice(self) -> None:
-        assert sds.annotation(sds.APPLIED, 0, APPLIED_LOG).startswith("::notice ")
+        assert sds.annotation(sds.APPLIED, APPLIED_LOG).startswith("::notice ")
 
-    @pytest.mark.parametrize("outcome", ["FAILED", "UNCLASSIFIABLE", "NOT_RUN"])
+    @pytest.mark.parametrize("outcome", [sds.FAILED, sds.UNCLASSIFIABLE, sds.NOT_RUN])
     def test_the_red_outcomes_annotate_as_errors(self, outcome: str) -> None:
-        value = getattr(sds, outcome)
-        assert sds.annotation(value, 1, ROLLBACK_LOG).startswith("::error ")
+        assert sds.annotation(outcome, ROLLBACK_LOG).startswith("::error ")
 
     def test_the_two_green_outcomes_do_not_share_a_heading(self) -> None:
         applied = sds.render(sds.APPLIED, 0, APPLIED_LOG, None).splitlines()[0]
@@ -293,12 +283,11 @@ class TestTheNoOpIsUnmistakable:
 
     @pytest.mark.parametrize(
         "outcome",
-        ["APPLIED", "NO_CHANGES", "FAILED", "UNCLASSIFIABLE", "NOT_RUN"],
+        [sds.APPLIED, sds.NO_CHANGES, sds.FAILED, sds.UNCLASSIFIABLE, sds.NOT_RUN],
     )
     def test_every_annotation_is_exactly_one_line(self, outcome: str) -> None:
         """GitHub truncates an annotation at its first newline."""
-        line = sds.annotation(getattr(sds, outcome), 1, ROLLBACK_LOG)
-        assert "\n" not in line
+        assert "\n" not in sds.annotation(outcome, ROLLBACK_LOG)
 
 
 class TestNoStatusRecorded:
@@ -412,23 +401,23 @@ class TestDegradedInput:
     """This renderer runs in the step whose job is to explain other failures.
     A traceback here turns one legible failure into two."""
 
-    def test_an_absent_log_does_not_traceback(self, tmp_path) -> None:
-        assert sds.main(["--exit-code", "0", "--log", str(tmp_path / "gone.log")]) != 0
-
-    def test_an_empty_log_does_not_traceback(self, tmp_path) -> None:
+    @pytest.mark.parametrize("degradation", ["absent", "empty", "undecodable"])
+    def test_a_degraded_log_at_exit_zero_fails_closed(self, tmp_path, degradation) -> None:
+        """One assertion strength for one behaviour. Whichever way the log is
+        unreadable, an exit-0 deploy it cannot vouch for is unclassifiable --
+        the three read paths themselves are pinned in
+        ``tests/unit/test_run_summary_shared.py``."""
         path = tmp_path / "sam-deploy.log"
-        path.write_text("")
+        if degradation == "empty":
+            path.write_text("")
+        elif degradation == "undecodable":
+            path.write_bytes(b"No changes to deploy. Stack Csillagrabl\xc3")
         assert sds.main(["--exit-code", "0", "--log", str(path)]) == sds.UNCLASSIFIABLE_EXIT
 
     def test_an_empty_log_on_a_failing_exit_still_reports_the_failure(self, tmp_path) -> None:
         path = tmp_path / "sam-deploy.log"
         path.write_text("")
         assert sds.main(["--exit-code", "1", "--log", str(path)]) == 1
-
-    def test_undecodable_bytes_do_not_traceback(self, tmp_path) -> None:
-        path = tmp_path / "sam-deploy.log"
-        path.write_bytes(b"No changes to deploy. Stack Csillagrabl\xc3")
-        assert sds.main(["--exit-code", "0", "--log", str(path)]) != 0
 
     def test_no_log_argument_at_all_does_not_traceback(self) -> None:
         assert sds.main(["--exit-code", "1"]) == 1
@@ -446,19 +435,3 @@ class TestDegradedInput:
         assert captured.out.startswith("#")
         assert captured.err.strip().startswith("::warning ")
         assert len(captured.err.strip().splitlines()) == 1
-
-
-class TestSharedLoader:
-    """The untrusted-file read is `lib/run_summary.py`'s, not a third copy."""
-
-    def test_it_routes_through_the_shared_loader(self) -> None:
-        sys.path.insert(0, str(REPO_ROOT))
-        from lib.run_summary import load_text
-
-        assert sds.load_log.func is load_text  # functools.partial over the shared one
-
-    def test_annotations_are_plain_text(self) -> None:
-        sys.path.insert(0, str(REPO_ROOT))
-        from lib.run_summary import plain
-
-        assert sds._plain is plain

--- a/tests/workflow_yaml.py
+++ b/tests/workflow_yaml.py
@@ -1,0 +1,95 @@
+"""Loading and walking a GitHub Actions workflow under test.
+
+Shared rather than duplicated, on the same reasoning as ``tests/cfn_yaml.py``:
+this is the second workflow with a wiring-test module of its own, and a
+per-file copy is how a repo ends up with several subtly different loaders.
+Two copies had already disagreed on what ``_step`` means -- exact name match in
+one, case-insensitive substring across ``name`` *and* ``uses`` in the other --
+so both are offered here under names that say which is which.
+
+The load-bearing piece is :func:`triggers`. **YAML 1.1 -- which PyYAML
+implements -- resolves an unquoted ``on`` key to the boolean ``True``**, so
+``doc["on"]`` raises ``KeyError`` on every GitHub Actions file that spells the
+key the normal way. That knowledge lived in exactly one of the two copies,
+which is the whole problem with two copies.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+def load_workflow(path: Path) -> dict[str, Any]:
+    """Parse a workflow file, asserting it exists first.
+
+    The assertion is not ceremony: a renamed or moved workflow otherwise
+    surfaces as a ``TypeError`` on ``None`` several frames away from the cause.
+    """
+    assert path.exists(), f"{path} does not exist"
+    return yaml.safe_load(path.read_text())
+
+
+def triggers(doc: dict[str, Any]) -> dict[str, Any]:
+    """The ``on:`` block, whichever key PyYAML resolved it to.
+
+    See the module docstring: unquoted ``on`` becomes ``True`` under YAML 1.1.
+    """
+    return doc.get("on", doc.get(True))  # type: ignore[arg-type]
+
+
+def steps(doc: dict[str, Any], job: str) -> list[dict[str, Any]]:
+    """Every step of one job."""
+    return doc["jobs"][job]["steps"]
+
+
+def step_named(doc: dict[str, Any], job: str, name: str) -> dict[str, Any]:
+    """The step whose ``name`` matches exactly.
+
+    Prefer this when the workflow's step names are themselves part of what is
+    being pinned; a substring match would keep passing through a rename.
+    """
+    for step in steps(doc, job):
+        if step.get("name") == name:
+            return step
+    raise AssertionError(
+        f"no step named {name!r} in job {job!r}; have {[s.get('name') for s in steps(doc, job)]}"
+    )
+
+
+def step_matching(doc: dict[str, Any], job: str, needle: str) -> dict[str, Any]:
+    """The first step whose ``name`` or ``uses`` contains ``needle``.
+
+    Case-insensitive. Use when the step is identified by the action it runs
+    rather than by a name the test cares about.
+    """
+    lowered = needle.lower()
+    for step in steps(doc, job):
+        if lowered in str(step.get("name", "")).lower():
+            return step
+        if lowered in str(step.get("uses", "")).lower():
+            return step
+    raise AssertionError(
+        f"no step matching {needle!r} in job {job!r}; "
+        f"have {[s.get('name') for s in steps(doc, job)]}"
+    )
+
+
+def working_directory(doc: dict[str, Any], job: str, name: str) -> str:
+    """Where a step's ``run:`` executes, relative to the repo root.
+
+    GitHub resolves ``working-directory`` step-first, then the job's
+    ``defaults.run``, then the workflow's. Reading only the step's own key
+    misses a job-level default entirely -- the realistic way this breaks, since
+    a value repeated across sibling steps invites hoisting.
+    """
+    for source in (
+        step_named(doc, job, name),
+        doc["jobs"][job].get("defaults", {}).get("run", {}),
+        doc.get("defaults", {}).get("run", {}),
+    ):
+        if source.get("working-directory"):
+            return str(source["working-directory"])
+    return "."


### PR DESCRIPTION
Closes #396.

The last acceptance criterion on #396, left out of #403 deliberately because it is a workflow change rather than an IAM fix — and it is the part that stops this recurring.

## The problem

`deploy-ephemeral-rebuild.yml` runs `sam deploy --no-fail-on-empty-changeset`, so SAM exits 0 both when it applies a changeset and when it has nothing to apply. Two runs, two minutes apart on 2026-08-16:

| Run | Output | Exit | Status |
|---|---|---|---|
| [31970903384](https://github.com/WXYC/discogs-etl/actions/runs/31970903384) | `No changes to deploy. Stack wxyc-discogs-rebuild is up to date` | 0 | green |
| [31970987037](https://github.com/WXYC/discogs-etl/actions/runs/31970987037) | `AccessDenied … ec2:DescribeImages` → `UPDATE_ROLLBACK_COMPLETE` | 1 | red |

Only the second carried information, and only because #358's `ReleaseCountAlarm` happened to be the first real changeset since the #353 account cutover. Every deploy in that window was the first line: green, and nothing reached AWS.

## What this does not do

**It does not drop the flag.** Three of the four triggers legitimately produce no template diff — `scripts/rebuild-cache-bootstrap.sh` is fetched by the instance at run time and is not part of the rendered template, the workflow file is not either, and a `workflow_dispatch` on an already-deployed `main` is a no-op by construction. Reddening the empty changeset would put a permanent failing check on `main` for every bootstrap-script edit. The outcome gets *stated* instead.

## What it does

`scripts/sam_deploy_summary.py` renders the outcome into the step summary plus exactly one annotation, then re-exits:

| Outcome | Step exit | Annotation |
|---|---|---|
| Changeset applied | `0` | `notice` |
| **Nothing was deployed** | `0` | **`warning`** |
| Failed | SAM's own code | `error` |
| Outcome could not be determined | `65` | `error` |
| Never ran | `65` | `error` |

**The exit code alone decides failure; prose never overrides it.** For exit 0 there are exactly two accepted top-level SAM strings, and anything else — neither present, or both — is unclassifiable and red. That direction is the point: the defect being fixed is a silent fall-through to "looks fine", so an output the classifier cannot read must be loud rather than optimistic. `Changeset created successfully` is deliberately *not* an applied marker — it precedes the apply and appears in the #396 rollback log too, so matching on it would have called that failure a success.

The no-op summary says both when a no-op is expected (bootstrap-script / workflow-file / dispatch-only triggers) and when it is suspicious (this push changed `template.yaml`). A warning nobody can act on becomes a warning everybody mutes, which is how the signal was lost the first time.

## Two things found while writing it

**SAM's events table wraps mid-token.** The real rollback log carries `UPDATE_ROLLBACK_COMPLE` / `TE` across two lines, and the successful one carries `UPDATE_COMPLETE_CLEANU` — the status column is 22 characters. So resource statuses cannot be substring-matched, and nothing here parses that table. The fixtures are verbatim captures of both runs and keep the wrapping, so "just also check for `UPDATE_COMPLETE`" has a test showing why not. The same wrapping splits `AccessDenied. User doesn't have permission to call` across four lines; `ec2:DescribeImages` survives whole on one of them, which is what the denied-action extraction keys on.

**`$?` after `sam deploy | tee` is `tee`'s status.** Reading it would report every failed deploy as a success — a strictly worse version of the bug being fixed. The step reads `${PIPESTATUS[0]}`, and a test asserts no command sits between the pipeline and that read (`PIPESTATUS` is rewritten by the next pipeline, and every simple command is a pipeline of one).

## Failure diagnosis

#396 took hours to root-cause. On an `AccessDenied` the summary now names the denied actions, points at `infra/bootstrap/deploy-role.yaml` and `simulate-deploy-role.sh`, and states that the bootstrap template must be applied by hand with admin credentials because CI cannot deploy what lets CI deploy. On any rollback it states that the stack has **diverged** from `template.yaml` on `main` and will stay diverged until a deploy succeeds — the condition #396 left behind, which nothing else reported.

## Testing

TDD; 76 new tests. Beyond the static wiring tests, the deploy step and all five report-step outcomes were verified **by execution** — the `run:` blocks lifted from the YAML and run under real `bash -e` with a stubbed `sam`, confirming that `rc` is SAM's status and not `tee`'s, that a failing deploy does not abort the step before the report runs, and that stdout and stderr both reach the captured log. Per #397 that executing coverage belongs on `tests/shell_harness.py` once it lands, rather than in a third private copy of the harness #397 exists to consolidate; the test file's docstring says so.

`lib/run_summary.py`'s untrusted-file read is split into `load_text` with `load_payload` layered on top rather than copied a third time. Both new test files are added to the `validate` job's explicit pre-deploy list, and a test asserts every path in that list exists — a renamed file would otherwise silently stop gating.

Local: `ruff check`, `ruff format --check`, and the full unmarked suite (1883 passed, 10 skipped) all green.

## Related

- #403 — the IAM grant; this is the acceptance criterion it left
- #397 — the executing-bash harness this file's reachability coverage should move onto
- #358 — the alarm whose merge exposed the condition
- #267 — the standing reminder that a bare exit 0 is not a success signal